### PR TITLE
Issue #3: B524 payload builders

### DIFF
--- a/tests/test_b524_payload_builders.py
+++ b/tests/test_b524_payload_builders.py
@@ -1,0 +1,67 @@
+import pytest
+
+from helianthus_vrc_explorer.protocol.b524 import (
+    build_directory_probe_payload,
+    build_register_read_payload,
+)
+
+
+@pytest.mark.parametrize(
+    ("group", "expected_hex"),
+    [
+        (0x03, "000300"),
+        (0x0A, "000a00"),
+    ],
+)
+def test_build_directory_probe_payload(group: int, expected_hex: str) -> None:
+    assert build_directory_probe_payload(group) == bytes.fromhex(expected_hex)
+
+
+@pytest.mark.parametrize(
+    ("opcode", "group", "instance", "register", "expected_hex"),
+    [
+        (0x02, 0x03, 0x00, 0x0016, "020003001600"),
+        (0x02, 0x02, 0x00, 0x000F, "020002000f00"),
+        (0x06, 0x09, 0x01, 0x0007, "060009010700"),
+        (0x06, 0x0A, 0x01, 0x000F, "06000a010f00"),
+    ],
+)
+def test_build_register_read_payload_known_selectors(
+    opcode: int,
+    group: int,
+    instance: int,
+    register: int,
+    expected_hex: str,
+) -> None:
+    assert build_register_read_payload(opcode, group, instance, register) == bytes.fromhex(
+        expected_hex
+    )
+
+
+@pytest.mark.parametrize("group", [-1, 256])
+def test_build_directory_probe_payload_range_validation(group: int) -> None:
+    with pytest.raises(ValueError, match=r"group must be in range 0\.\.255"):
+        build_directory_probe_payload(group)
+
+
+@pytest.mark.parametrize(
+    ("group", "instance", "register"),
+    [
+        (-1, 0, 0),
+        (0, -1, 0),
+        (0, 0, -1),
+        (256, 0, 0),
+        (0, 256, 0),
+        (0, 0, 65536),
+    ],
+)
+def test_build_register_read_payload_range_validation(
+    group: int, instance: int, register: int
+) -> None:
+    with pytest.raises(ValueError):
+        build_register_read_payload(0x02, group, instance, register)
+
+
+def test_build_register_read_payload_opcode_validation() -> None:
+    with pytest.raises(ValueError, match=r"opcode must be 0x02 or 0x06"):
+        build_register_read_payload(0x03, 0x01, 0x00, 0x0000)


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: Ready for review.
Branch: issue-3-b524-payload-builders
Last verified (lint/tests): 2026-02-06 23:35 UTC: `venv/bin/ruff check .`, `venv/bin/ruff format .`, `venv/bin/pytest` (25 passed)
How to reproduce: `venv/bin/pytest`
Next steps: Address review feedback and keep CI green.
Notes (no secrets, no private infra): Smoke test required by issue: NO.
```

## Summary
- Implement B524 payload builders for directory probe (`opcode=0x00`) and register reads (`opcode=0x02`/`0x06`, `optype=0x00`)
- Add byte-level unit tests validating payload output for known selectors

## Linked Issue
- Closes #3

## Checklist
- [x] `ruff check .`
- [x] `ruff format .`
- [x] `pytest`
- [x] Manual SSH integration test (if required by the issue): NO
- [x] Audit: no private identifiers introduced (IPs other than 127.0.0.1, serial numbers, hostnames, internal repo names)

## Notes
- N/A
