### PR TITLE
Protocol: parse B524 value types

### DIFF
--- a/src/helianthus_vrc_explorer/protocol/parser.py
+++ b/src/helianthus_vrc_explorer/protocol/parser.py
@@ -1,5 +1,152 @@
 from __future__ import annotations
 
+import math
+import struct
+from datetime import date
+
 
 class ValueParseError(Exception):
     """Raised when response bytes cannot be parsed into a typed value."""
+
+
+def _expect_len(type_spec: str, data: bytes, expected_len: int) -> None:
+    if len(data) != expected_len:
+        raise ValueParseError(f"{type_spec} expects {expected_len} bytes, got {len(data)} bytes")
+
+
+def _decode_bcd(type_spec: str, field: str, value: int) -> int:
+    """Decode a single byte containing a BCD-encoded decimal number."""
+
+    high = (value >> 4) & 0xF
+    low = value & 0xF
+    if high > 9 or low > 9:
+        raise ValueParseError(f"{type_spec} invalid BCD for {field}: 0x{value:02X}")
+    return high * 10 + low
+
+
+def parse_exp(data: bytes) -> float | None:
+    """Parse an `EXP` value (float32le).
+
+    Notes:
+        - NaN values are returned as `None` so they can later be rendered as JSON `null`.
+    """
+
+    _expect_len("EXP", data, 4)
+    value = struct.unpack("<f", data)[0]
+    if math.isnan(value):
+        return None
+    return float(value)
+
+
+def parse_uin(data: bytes) -> int:
+    """Parse an `UIN` value (u16le)."""
+
+    _expect_len("UIN", data, 2)
+    return int.from_bytes(data, byteorder="little", signed=False)
+
+
+def parse_uch(data: bytes) -> int:
+    """Parse an `UCH` value (u8)."""
+
+    _expect_len("UCH", data, 1)
+    return data[0]
+
+
+def parse_str_cstring(data: bytes) -> str:
+    """Parse a `STR:*` value (cstring).
+
+    This uses latin1 decoding after stripping trailing NUL bytes.
+    """
+
+    return data.rstrip(b"\x00").decode("latin1")
+
+
+def parse_hda3_date(data: bytes) -> str:
+    """Parse an `HDA:3` value (u24le date encoded as DDMMYY, BCD per byte).
+
+    Returns:
+        ISO-ish date string: `YYYY-MM-DD`.
+
+    Notes:
+        The underlying schema only gives a 2-digit year. We interpret it as `2000 + YY`
+        to match modern VRC firmware dates (2000-2099).
+    """
+
+    _expect_len("HDA:3", data, 3)
+    day = _decode_bcd("HDA:3", "day", data[0])
+    month = _decode_bcd("HDA:3", "month", data[1])
+    year_2digit = _decode_bcd("HDA:3", "year", data[2])
+
+    year = 2000 + year_2digit
+    try:
+        return date(year, month, day).isoformat()
+    except ValueError as exc:
+        raise ValueParseError(
+            f"HDA:3 invalid date DDMMYY={day:02d}{month:02d}{year_2digit:02d}"
+        ) from exc
+
+
+def parse_hti_time(data: bytes) -> str:
+    """Parse an `HTI` value (u24le time encoded as HH:MM:SS, BCD per byte).
+
+    Returns:
+        ISO-ish time string: `HH:MM:SS`.
+    """
+
+    _expect_len("HTI", data, 3)
+    hour = _decode_bcd("HTI", "hour", data[0])
+    minute = _decode_bcd("HTI", "minute", data[1])
+    second = _decode_bcd("HTI", "second", data[2])
+
+    if hour > 23:
+        raise ValueParseError(f"HTI hour must be 0..23, got {hour}")
+    if minute > 59:
+        raise ValueParseError(f"HTI minute must be 0..59, got {minute}")
+    if second > 59:
+        raise ValueParseError(f"HTI second must be 0..59, got {second}")
+
+    return f"{hour:02d}:{minute:02d}:{second:02d}"
+
+
+def parse_typed_value(type_spec: str, data: bytes) -> object:
+    """Parse a typed value from a B524 response tail.
+
+    The type is taken from the ebusd CSV schema (`type` column). Only the minimal set
+    needed for B524 register reads is implemented:
+
+    - `EXP`: float32le (`NaN` -> `None`)
+    - `UIN`: u16le
+    - `UCH`: u8
+    - `STR:*`: cstring (latin1, trailing NULs stripped)
+    - `HDA:3`: u24le date encoded as DDMMYY (BCD per byte, `YYYY-MM-DD`)
+    - `HTI`: u24le time encoded as HH:MM:SS (BCD per byte, `HH:MM:SS`)
+
+    Args:
+        type_spec: Type spec string (e.g. `"EXP"`, `"STR:*"`).
+        data: Raw bytes for the value (after stripping the 4-byte echo header).
+
+    Returns:
+        Parsed Python value. `EXP` may return `None` if the decoded float is NaN.
+
+    Raises:
+        ValueParseError: On unknown type, wrong length, or malformed values.
+    """
+
+    normalized = type_spec.strip().upper()
+
+    if normalized.startswith("STR:"):
+        return parse_str_cstring(data)
+
+    match normalized:
+        case "EXP":
+            return parse_exp(data)
+        case "UIN":
+            return parse_uin(data)
+        case "UCH":
+            return parse_uch(data)
+        case "HDA:3":
+            return parse_hda3_date(data)
+        case "HTI":
+            return parse_hti_time(data)
+        case _:
+            raise ValueParseError(f"Unknown type spec: {type_spec!r}")

--- a/tests/test_b524_value_parser.py
+++ b/tests/test_b524_value_parser.py
@@ -1,0 +1,80 @@
+import pytest
+
+from helianthus_vrc_explorer.protocol.parser import ValueParseError, parse_typed_value
+
+
+def test_parse_exp_float32le() -> None:
+    assert parse_typed_value("EXP", bytes.fromhex("0000803f")) == 1.0
+
+
+def test_parse_exp_nan_is_none() -> None:
+    # Quiet NaN (0x7FC00000) encoded as float32 little-endian.
+    assert parse_typed_value("EXP", bytes.fromhex("0000c07f")) is None
+
+
+def test_parse_uin_u16le() -> None:
+    assert parse_typed_value("UIN", bytes.fromhex("3412")) == 0x1234
+
+
+def test_parse_uch_u8() -> None:
+    assert parse_typed_value("UCH", bytes.fromhex("7f")) == 0x7F
+
+
+def test_parse_str_cstring_strips_trailing_nuls_and_decodes_latin1() -> None:
+    assert parse_typed_value(" str:* ", b"hello\x00\x00") == "hello"
+
+
+def test_parse_str_cstring_empty_string() -> None:
+    assert parse_typed_value("STR:*", b"\x00\x00") == ""
+
+
+def test_parse_hda3_date_u24le_ddmmyy() -> None:
+    assert parse_typed_value("HDA:3", bytes.fromhex("060226")) == "2026-02-06"
+
+
+def test_parse_hti_time_u24le_hhmmss() -> None:
+    assert parse_typed_value("HTI", bytes.fromhex("235958")) == "23:59:58"
+
+
+@pytest.mark.parametrize(
+    ("type_spec", "data_hex"),
+    [
+        ("EXP", ""),
+        ("EXP", "000080"),
+        ("UIN", ""),
+        ("UIN", "00"),
+        ("UIN", "000000"),
+        ("UCH", ""),
+        ("UCH", "0000"),
+        ("HDA:3", ""),
+        ("HDA:3", "01020304"),
+        ("HTI", ""),
+        ("HTI", "0102"),
+        ("HTI", "01020304"),
+    ],
+)
+def test_parse_wrong_lengths_raise(type_spec: str, data_hex: str) -> None:
+    with pytest.raises(ValueParseError):
+        parse_typed_value(type_spec, bytes.fromhex(data_hex))
+
+
+@pytest.mark.parametrize(
+    ("type_spec", "data_hex"),
+    [
+        ("HDA:3", "320226"),  # day=32
+        ("HDA:3", "310226"),  # day=31 in Feb
+        ("HDA:3", "063b26"),  # invalid BCD month (0x3B)
+        ("HTI", "240000"),  # hour=24
+        ("HTI", "006000"),  # minute=60
+        ("HTI", "000060"),  # second=60
+        ("HTI", "23593a"),  # invalid BCD second (0x3A)
+    ],
+)
+def test_parse_malformed_values_raise(type_spec: str, data_hex: str) -> None:
+    with pytest.raises(ValueParseError):
+        parse_typed_value(type_spec, bytes.fromhex(data_hex))
+
+
+def test_parse_unknown_type_raises() -> None:
+    with pytest.raises(ValueParseError, match=r"Unknown type spec"):
+        parse_typed_value("FOO", b"")


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: Ready for review
Branch: issue-4-parse-b524-value-types
Last verified (lint/tests): 2026-02-07 01:56 EET (ruff check ., ruff format ., pytest)
How to reproduce: venv/bin/pytest
Next steps: Merge after review + CI green
Notes (no secrets, no private infra): No manual smoke test required for this issue.
```

## Summary
- Add minimal typed value parsing for B524 response tails (EXP/UIN/UCH/STR:*/HDA:3/HTI)
- Represent float32 NaN as `None` for JSON `null`
- Add unit tests for each supported type + malformed inputs

## Linked Issue
- Closes #4

## Checklist
- [x] `ruff check .`
- [x] `ruff format .`
- [x] `pytest`
- [x] Manual SSH integration test (if required by the issue): N/A
- [x] Audit: no private identifiers introduced (IPs other than 127.0.0.1, serial numbers, hostnames, internal repo names)

## Notes
- `HDA:3` dates interpret the 2-digit year as `2000 + YY` (2000-2099).
