### PR TITLE
Transport: DummyTransport for --dry-run (fixture replay)

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,61 @@
+# Fixtures
+
+This directory contains **scan artifact fixtures** used for deterministic, offline tests and for
+`scan --dry-run` output.
+
+## Format (Minimal, Stable)
+
+A fixture is a JSON object with:
+
+- `meta`: arbitrary metadata about the scan (timestamps, device info, etc.).
+- `groups`: mapping of group id -> group data.
+
+### `groups`
+
+`groups` is an object keyed by **hex strings**:
+
+- group key: `0xGG` (u8)
+- instance key: `0xII` (u8)
+- register key: `0xRRRR` (u16)
+
+Each group entry contains:
+
+- `descriptor_type` (number): Value returned by the B524 directory probe (`opcode=0x00`), encoded
+  as float32 little-endian on the wire.
+- `instances` (object, optional): Mapping of instance id -> instance data.
+
+Each instance entry contains:
+
+- `registers` (object, optional): Mapping of register id -> register data.
+
+Each register entry contains:
+
+- `raw_hex` (string): Hex-encoded **value bytes only** for a register read response (no 4-byte echo
+  header).
+
+### Example
+
+```json
+{
+  "meta": {},
+  "groups": {
+    "0x02": {
+      "descriptor_type": 1.0,
+      "instances": {
+        "0x00": {
+          "registers": {
+            "0x000f": { "raw_hex": "3412" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## DummyTransport Behavior
+
+- Directory probe (`00 <GG> 00`): returns `float32le(descriptor_type)` for known groups, otherwise
+  `0.0`.
+- Register read (`02/06 00 <GG> <II> <RR_LO> <RR_HI>`): returns `echo(4 bytes) + value_bytes`
+  where `value_bytes = bytes.fromhex(raw_hex)`. If missing, `TransportTimeout` is raised.

--- a/fixtures/vrc720_full_scan.json
+++ b/fixtures/vrc720_full_scan.json
@@ -18,5 +18,18 @@
     "schema_sources": [],
     "incomplete": false
   },
-  "groups": {}
+  "groups": {
+    "0x02": {
+      "descriptor_type": 1.0,
+      "instances": {
+        "0x00": {
+          "registers": {
+            "0x000f": {
+              "raw_hex": "3412"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import typer
 
 from . import __version__
@@ -22,6 +25,48 @@ def main(
 
 
 @app.command()
-def scan() -> None:
+def scan(
+    dry_run: bool = typer.Option(  # noqa: B008
+        False,
+        "--dry-run",
+        help="Replay a scan fixture and write it as the output artifact (no device I/O).",
+    ),
+    fixture: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--fixture",
+        help=(
+            "Path to a scan artifact fixture JSON "
+            "(defaults to fixtures/vrc720_full_scan.json in repo)."
+        ),
+    ),
+    output_dir: Path = typer.Option(  # noqa: B008
+        Path("."),
+        "--output-dir",
+        help="Directory to write the scan JSON artifact to.",
+    ),
+) -> None:
     """Scan a VRC regulator using B524 (GetExtendedRegisters)."""
-    typer.echo("scan: not implemented yet")
+    if not dry_run:
+        typer.echo("scan: not implemented yet (use --dry-run)")
+        return
+
+    fixture_path = fixture or (
+        Path(__file__).resolve().parents[2] / "fixtures" / "vrc720_full_scan.json"
+    )
+    if not fixture_path.exists():
+        typer.echo(f"Fixture not found: {fixture_path}", err=True)
+        raise typer.Exit(2)
+
+    try:
+        artifact = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Invalid JSON fixture: {fixture_path} ({exc})", err=True)
+        raise typer.Exit(2) from exc
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "scan.json"
+    output_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    typer.echo(str(output_path))

--- a/src/helianthus_vrc_explorer/transport/dummy.py
+++ b/src/helianthus_vrc_explorer/transport/dummy.py
@@ -1,19 +1,158 @@
 from __future__ import annotations
 
+import json
+import struct
 from pathlib import Path
+from typing import Any
 
-from .base import TransportInterface
+from .base import TransportError, TransportInterface, TransportTimeout
 
 
 class DummyTransport(TransportInterface):
     """Fixture-backed transport used for --dry-run.
 
-    This is intentionally a stub in bootstrap. Follow-up issues will define
-    the fixture format and behavior.
+    The dummy transport replays *responses* from a scan artifact fixture (JSON).
+    It supports the minimal subset needed for offline scanner tests:
+
+    - Directory probe (opcode 0x00): returns a float32le descriptor type for known groups
+    - Register read (opcode 0x02 / 0x06, optype 0x00): returns `echo(4 bytes) + value_bytes`
     """
 
     def __init__(self, fixture_path: Path) -> None:
         self._fixture_path = fixture_path
+        self._group_descriptor: dict[int, float] = {}
+        self._register_values: dict[tuple[int, int, int], bytes] = {}
+        self._load_fixture()
 
     def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
-        raise NotImplementedError("DummyTransport is not implemented yet")
+        if not payload:
+            raise TransportError("Empty payload")
+
+        opcode = payload[0]
+
+        if opcode == 0x00:
+            return self._handle_directory_probe(payload)
+
+        if opcode in {0x02, 0x06}:
+            return self._handle_register_read(payload)
+
+        raise TransportError(f"Unsupported opcode 0x{opcode:02X} for DummyTransport")
+
+    def _handle_directory_probe(self, payload: bytes) -> bytes:
+        if len(payload) != 3:
+            raise TransportError(f"Directory probe expects 3 bytes, got {len(payload)}")
+        if payload[2] != 0x00:
+            raise TransportError(f"Directory probe expects final byte 0x00, got 0x{payload[2]:02X}")
+
+        group = payload[1]
+        descriptor = self._group_descriptor.get(group, 0.0)
+        return struct.pack("<f", float(descriptor))
+
+    def _handle_register_read(self, payload: bytes) -> bytes:
+        if len(payload) < 2:
+            raise TransportError(f"Register payload too short: {len(payload)} bytes")
+
+        optype = payload[1]
+        if optype != 0x00:
+            raise TransportError(
+                f"DummyTransport only supports register reads (optype=0x00), got 0x{optype:02X}"
+            )
+
+        if len(payload) != 6:
+            raise TransportError(f"Register read expects 6 bytes, got {len(payload)}")
+
+        group = payload[2]
+        instance = payload[3]
+        register = int.from_bytes(payload[4:6], byteorder="little", signed=False)
+
+        value = self._register_values.get((group, instance, register))
+        if value is None:
+            raise TransportTimeout(
+                "Fixture missing register raw_hex for "
+                f"GG=0x{group:02X}, II=0x{instance:02X}, RR=0x{register:04X}"
+            )
+
+        echo_header = payload[:4]
+        return echo_header + value
+
+    @staticmethod
+    def _parse_hex_key_u8(key: str, field: str) -> int:
+        try:
+            value = int(key, 16)
+        except ValueError as exc:
+            raise ValueError(f"Invalid {field} key (expected hex): {key!r}") from exc
+        if not (0x00 <= value <= 0xFF):
+            raise ValueError(f"{field} key out of range 0..255: {key!r}")
+        return value
+
+    @staticmethod
+    def _parse_hex_key_u16(key: str, field: str) -> int:
+        try:
+            value = int(key, 16)
+        except ValueError as exc:
+            raise ValueError(f"Invalid {field} key (expected hex): {key!r}") from exc
+        if not (0x0000 <= value <= 0xFFFF):
+            raise ValueError(f"{field} key out of range 0..65535: {key!r}")
+        return value
+
+    def _load_fixture(self) -> None:
+        raw = self._fixture_path.read_text(encoding="utf-8")
+        data: Any = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("Fixture root must be a JSON object")
+
+        groups = data.get("groups")
+        if not isinstance(groups, dict):
+            raise ValueError('Fixture must contain top-level key "groups" as an object')
+
+        for group_key, group_value in groups.items():
+            if not isinstance(group_key, str):
+                raise ValueError(f"Group keys must be strings, got {type(group_key).__name__}")
+            group = self._parse_hex_key_u8(group_key, "group")
+            if not isinstance(group_value, dict):
+                raise ValueError(f"Group {group_key!r} must be a JSON object")
+
+            descriptor = group_value.get("descriptor_type")
+            if not isinstance(descriptor, (int, float)) or isinstance(descriptor, bool):
+                raise ValueError(f"Group {group_key!r} must contain numeric descriptor_type")
+            self._group_descriptor[group] = float(descriptor)
+
+            instances = group_value.get("instances", {})
+            if not isinstance(instances, dict):
+                raise ValueError(f'Group {group_key!r} field "instances" must be an object')
+
+            for instance_key, instance_value in instances.items():
+                if not isinstance(instance_key, str):
+                    raise ValueError(
+                        f"Instance keys must be strings, got {type(instance_key).__name__}"
+                    )
+                instance = self._parse_hex_key_u8(instance_key, "instance")
+                if not isinstance(instance_value, dict):
+                    raise ValueError(f"Instance {instance_key!r} must be a JSON object")
+
+                registers = instance_value.get("registers", {})
+                if not isinstance(registers, dict):
+                    raise ValueError(
+                        f'Instance {instance_key!r} field "registers" must be an object'
+                    )
+
+                for register_key, register_value in registers.items():
+                    if not isinstance(register_key, str):
+                        raise ValueError(
+                            f"Register keys must be strings, got {type(register_key).__name__}"
+                        )
+                    register = self._parse_hex_key_u16(register_key, "register")
+                    if not isinstance(register_value, dict):
+                        raise ValueError(f"Register {register_key!r} must be a JSON object")
+
+                    raw_hex = register_value.get("raw_hex")
+                    if not isinstance(raw_hex, str):
+                        raise ValueError(f"Register {register_key!r} must contain raw_hex string")
+                    try:
+                        value_bytes = bytes.fromhex(raw_hex)
+                    except ValueError as exc:
+                        raise ValueError(
+                            f"Register {register_key!r} has invalid raw_hex: {raw_hex!r}"
+                        ) from exc
+
+                    self._register_values[(group, instance, register)] = value_bytes

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from helianthus_vrc_explorer import __version__
@@ -15,3 +18,41 @@ def test_scan_command_is_present() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["scan"])
     assert result.exit_code == 0
+
+
+def test_scan_dry_run_writes_scan_artifact(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["scan", "--dry-run", "--output-dir", str(tmp_path)])
+    assert result.exit_code == 0
+
+    output_path = tmp_path / "scan.json"
+    assert output_path.exists()
+
+    artifact = json.loads(output_path.read_text(encoding="utf-8"))
+    assert isinstance(artifact, dict)
+    assert "meta" in artifact
+    assert "groups" in artifact
+    assert isinstance(artifact["groups"], dict)
+
+    raw_hex_values: list[str] = []
+    for group in artifact["groups"].values():
+        if not isinstance(group, dict):
+            continue
+        instances = group.get("instances", {})
+        if not isinstance(instances, dict):
+            continue
+        for instance in instances.values():
+            if not isinstance(instance, dict):
+                continue
+            registers = instance.get("registers", {})
+            if not isinstance(registers, dict):
+                continue
+            for register in registers.values():
+                if not isinstance(register, dict):
+                    continue
+                raw_hex = register.get("raw_hex")
+                if isinstance(raw_hex, str):
+                    raw_hex_values.append(raw_hex)
+
+    assert raw_hex_values
+    bytes.fromhex(raw_hex_values[0])

--- a/tests/test_dummy_transport.py
+++ b/tests/test_dummy_transport.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from helianthus_vrc_explorer.protocol.b524 import (
+    build_directory_probe_payload,
+    build_register_read_payload,
+)
+from helianthus_vrc_explorer.transport.base import TransportTimeout
+from helianthus_vrc_explorer.transport.dummy import DummyTransport
+
+
+def _write_min_fixture(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {},
+        "groups": {
+            "0x02": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x000f": {"raw_hex": "3412"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+    return fixture_path
+
+
+def test_dummy_transport_directory_probe_known_group(tmp_path: Path) -> None:
+    transport = DummyTransport(_write_min_fixture(tmp_path))
+    response = transport.send(0x15, build_directory_probe_payload(0x02))
+    assert response == struct.pack("<f", 1.0)
+
+
+def test_dummy_transport_directory_probe_unknown_group_returns_zero(tmp_path: Path) -> None:
+    transport = DummyTransport(_write_min_fixture(tmp_path))
+    response = transport.send(0x15, build_directory_probe_payload(0x03))
+    assert response == struct.pack("<f", 0.0)
+
+
+def test_dummy_transport_register_read_returns_echo_plus_value(tmp_path: Path) -> None:
+    transport = DummyTransport(_write_min_fixture(tmp_path))
+    payload = build_register_read_payload(0x02, group=0x02, instance=0x00, register=0x000F)
+    response = transport.send(0x15, payload)
+    assert response == bytes.fromhex("020002003412")
+
+
+def test_dummy_transport_missing_register_raises_timeout(tmp_path: Path) -> None:
+    transport = DummyTransport(_write_min_fixture(tmp_path))
+    payload = build_register_read_payload(0x02, group=0x02, instance=0x00, register=0x0010)
+    with pytest.raises(TransportTimeout):
+        transport.send(0x15, payload)


### PR DESCRIPTION
- Implements DummyTransport fixture replay for directory probe + register reads
- Documents fixture JSON format under fixtures/README.md
- Adds minimal `scan --dry-run` path to write fixture artifact to `--output-dir`
- Adds unit tests for DummyTransport and CLI dry-run

Closes #6
