### PR TITLE
Scanner: Phase A group discovery + classification

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -1,5 +1,134 @@
 from __future__ import annotations
 
+import logging
+import math
+import struct
+from dataclasses import dataclass
+from typing import Final, TypedDict
 
-def discover_groups() -> None:
-    """Discover supported groups (stub)."""
+from ..protocol.b524 import build_directory_probe_payload
+from ..transport.base import TransportInterface
+
+logger = logging.getLogger(__name__)
+
+
+class GroupConfig(TypedDict):
+    desc: float
+    name: str
+    ii_max: int
+    rr_max: int
+
+
+# Known groups (hardcoded reference, validated against CSV).
+# Source of truth: `AGENTS.md` (keep in sync).
+GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
+    0x00: {"desc": 3.0, "name": "Discovery", "ii_max": 0x00, "rr_max": 0xFF},
+    0x01: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x8F},
+    0x02: {"desc": 1.0, "name": "Heating Circuits", "ii_max": 0x0A, "rr_max": 0x21},
+    0x03: {"desc": 1.0, "name": "Zones", "ii_max": 0x0A, "rr_max": 0x2F},
+    0x04: {"desc": 6.0, "name": "Solar Circuit", "ii_max": 0x0A, "rr_max": 0x40},
+    0x09: {"desc": 1.0, "name": "RoomState", "ii_max": 0x2F, "rr_max": 0x1F},
+    0x0A: {"desc": 1.0, "name": "RoomSensors", "ii_max": 0x2F, "rr_max": 0x4F},
+    0x0C: {"desc": 1.0, "name": "Unrecognized", "ii_max": 0x2F, "rr_max": 0x4F},
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveredGroup:
+    group: int
+    descriptor: float
+
+
+@dataclass(frozen=True, slots=True)
+class ClassifiedGroup:
+    group: int
+    descriptor: float
+    name: str
+    expected_descriptor: float | None
+    descriptor_mismatch: bool
+
+
+def _parse_directory_descriptor(resp: bytes, group: int) -> float:
+    if len(resp) < 4:
+        logger.warning(
+            "Short directory probe response for GG=0x%02X: expected >=4 bytes, got %d",
+            group,
+            len(resp),
+        )
+        return float("nan")
+    return struct.unpack("<f", resp[:4])[0]
+
+
+def discover_groups(transport: TransportInterface, dst: int) -> list[DiscoveredGroup]:
+    """Phase A: Probe GG=0x00..0xFF via directory probe (opcode 0x00).
+
+    Terminator logic: stop after 2 consecutive NaN descriptors.
+    Holes (descriptor==0.0) are skipped.
+    """
+
+    discovered: list[DiscoveredGroup] = []
+    nan_streak = 0
+
+    for gg in range(0x00, 0x100):
+        payload = build_directory_probe_payload(gg)
+        resp = transport.send(dst, payload)
+        descriptor = _parse_directory_descriptor(resp, gg)
+
+        if descriptor == 0.0:
+            # Hole: skip without resetting the NaN streak.
+            continue
+
+        if math.isnan(descriptor):
+            nan_streak += 1
+            if nan_streak >= 2:
+                logger.info("Directory terminator after GG=0x%02X (NaN streak=%d)", gg, nan_streak)
+                break
+            continue
+
+        nan_streak = 0
+        discovered.append(DiscoveredGroup(group=gg, descriptor=descriptor))
+
+    return discovered
+
+
+def classify_groups(discovered: list[DiscoveredGroup]) -> list[ClassifiedGroup]:
+    """Phase C (per issue wording): Map discovered groups using GROUP_CONFIG.
+
+    Emits a warning when a known group's descriptor doesn't match `GROUP_CONFIG`.
+    """
+
+    classified: list[ClassifiedGroup] = []
+    for group in discovered:
+        config = GROUP_CONFIG.get(group.group)
+        if config is None:
+            classified.append(
+                ClassifiedGroup(
+                    group=group.group,
+                    descriptor=group.descriptor,
+                    name="Unknown",
+                    expected_descriptor=None,
+                    descriptor_mismatch=False,
+                )
+            )
+            continue
+
+        expected = config["desc"]
+        mismatch = expected != group.descriptor
+        if mismatch:
+            logger.warning(
+                "Descriptor mismatch for GG=0x%02X: expected %s, got %s",
+                group.group,
+                expected,
+                group.descriptor,
+            )
+        classified.append(
+            ClassifiedGroup(
+                group=group.group,
+                descriptor=group.descriptor,
+                name=config["name"],
+                expected_descriptor=expected,
+                descriptor_mismatch=mismatch,
+            )
+        )
+
+    return classified

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from helianthus_vrc_explorer.scanner.director import (
+    DiscoveredGroup,
+    classify_groups,
+    discover_groups,
+)
+from helianthus_vrc_explorer.transport.base import TransportInterface
+from helianthus_vrc_explorer.transport.dummy import DummyTransport
+
+
+class RecordingTransport(TransportInterface):
+    def __init__(self, inner: TransportInterface) -> None:
+        self._inner = inner
+        self.probed_groups: list[int] = []
+
+    def send(self, dst: int, payload: bytes) -> bytes:
+        if payload and payload[0] == 0x00 and len(payload) >= 2:
+            self.probed_groups.append(payload[1])
+        return self._inner.send(dst, payload)
+
+
+def _write_directory_fixture(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x05"}},
+        "groups": {
+            "0x00": {"descriptor_type": 3.0, "instances": {}},
+            # Intentional hole at 0x01/0x02 (unknown groups => descriptor==0.0)
+            "0x03": {"descriptor_type": 1.0, "instances": {}},
+        },
+    }
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+    return fixture_path
+
+
+def test_discover_groups_stops_after_second_nan_and_skips_holes(tmp_path: Path) -> None:
+    transport = RecordingTransport(DummyTransport(_write_directory_fixture(tmp_path)))
+
+    discovered = discover_groups(transport, dst=0x15)
+
+    # Holes (descriptor==0.0) should not be recorded as discovered groups.
+    assert [group.group for group in discovered] == [0x00, 0x03]
+
+    # Terminator is triggered by the *second* NaN (GG=0x06), so probing stops there.
+    assert transport.probed_groups == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
+
+
+def test_classify_groups_warns_on_descriptor_mismatch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="helianthus_vrc_explorer.scanner.director")
+
+    classified = classify_groups([DiscoveredGroup(group=0x02, descriptor=3.0)])
+
+    assert classified[0].descriptor_mismatch is True
+    assert classified[0].expected_descriptor == 1.0
+    assert any("Descriptor mismatch for GG=0x02" in record.message for record in caplog.records)


### PR DESCRIPTION
Implements scanner Phase A (directory group discovery) and Phase C (classification) per AGENTS.md.

- Probe GG=0x00..0xFF using opcode 0x00 directory probe payload
- Stop after 2 consecutive NaN descriptors; skip holes (descriptor==0.0)
- Classify discovered groups via GROUP_CONFIG; warn on descriptor mismatches
- DummyTransport supports meta.dummy_transport.directory_terminator_group to simulate NaN terminator
- Adds pytest coverage for terminator + hole handling

Closes #7.