### PR TITLE
UX: replanning hotkey during register scan

### DIFF
--- a/src/helianthus_vrc_explorer/ui/live.py
+++ b/src/helianthus_vrc_explorer/ui/live.py
@@ -107,6 +107,10 @@ class RichScanObserver(AbstractContextManager["RichScanObserver"], ScanObserver)
                 "Tip: set `--trace-file` to capture ebusd request/response exchanges.",
                 style="dim",
             ),
+            Text(
+                "Tip: type `p` + Enter during Register Scan to open the scan planner.",
+                style="dim",
+            ),
         )
         self._progress.console.print(header)
         return self


### PR DESCRIPTION
Closes #24.

What:
- During Phase D (register scan) in interactive TTY mode, the operator can type `p` + Enter to reopen the scan planner.
- The updated plan rebuilds the *remaining* work queue (already-scanned registers are not rewritten/re-read).
- Progress total is adjusted to `done + remaining` so the bar stays consistent after trimming/expanding scope.
- Planner defaults now preserve the current plan selection/overrides.

Tests:
- Unit tests for queue building / plan parsing.
- CI: ruff/mypy/pytest.
