### PR TITLE
Scan: Add BASV device discovery via QueryExistence + Scan

### DIFF
--- a/src/helianthus_vrc_explorer/ebusd.py
+++ b/src/helianthus_vrc_explorer/ebusd.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+_ADDR_LINE_RE = re.compile(r"^address\s+([0-9a-fA-F]{2}):\s*(.*)$")
+
+
+def parse_ebusd_info_slave_addresses(lines: Sequence[str]) -> list[int]:
+    """Extract slave addresses from ebusd `info` output lines.
+
+    The ebusd command-port `info` output typically includes entries like:
+
+        address 08: slave, scanned Vaillant;BAI00;...
+
+    We treat anything containing "slave" as a device address and ignore "self".
+    """
+
+    addresses: list[int] = []
+    seen: set[int] = set()
+    for raw in lines:
+        if not isinstance(raw, str):
+            continue
+        m = _ADDR_LINE_RE.match(raw.strip())
+        if not m:
+            continue
+        try:
+            addr = int(m.group(1), 16)
+        except ValueError:
+            continue
+        rest = m.group(2).lower()
+        if "slave" not in rest:
+            continue
+        if "self" in rest:
+            continue
+        if addr in seen:
+            continue
+        seen.add(addr)
+        addresses.append(addr)
+
+    addresses.sort()
+    return addresses

--- a/src/helianthus_vrc_explorer/protocol/basv.py
+++ b/src/helianthus_vrc_explorer/protocol/basv.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class BasvError(Exception):
+    """Base class for BASV/broadcast protocol errors."""
+
+
+class ScanIdParseError(BasvError, ValueError):
+    """Raised when parsing a 0x0704 scan identification payload fails."""
+
+
+class VaillantScanIdParseError(BasvError, ValueError):
+    """Raised when parsing Vaillant scan-id chunks (B509 QQ=0x24..0x27) fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class ScanIdentification:
+    manufacturer: int
+    device_id: str
+    sw: str
+    hw: str
+
+
+@dataclass(frozen=True, slots=True)
+class VaillantScanId:
+    prefix: str
+    year: str
+    week: str
+    product: str
+    supplier: str
+    counter: str
+    suffix: str
+    raw: str
+
+    @property
+    def model_number(self) -> str:
+        return self.product
+
+    @property
+    def serial_number(self) -> str:
+        # Best-effort: the scan-id "serial" is everything except the product number.
+        return f"{self.prefix}{self.year}{self.week}{self.supplier}{self.counter}{self.suffix}"
+
+
+def parse_scan_identification(payload: bytes) -> ScanIdentification:
+    """Parse a 0x0704 identification response payload (no length prefix).
+
+    Expected layout (based on ebusd broadcast.csv for 0704):
+    - manufacturer: 1 byte
+    - device id: N bytes (ASCII)
+    - software version: 2 bytes
+    - hardware version: 2 bytes
+    """
+
+    if not isinstance(payload, (bytes, bytearray, memoryview)):
+        raise TypeError(f"payload must be bytes-like, got {type(payload).__name__}")
+    blob = bytes(payload)
+    if len(blob) < 5:
+        raise ScanIdParseError(f"Scan identification payload too short: {len(blob)} bytes")
+
+    manufacturer = blob[0]
+    sw_bytes = blob[-4:-2]
+    hw_bytes = blob[-2:]
+    device_id_bytes = blob[1:-4]
+    device_id = device_id_bytes.decode("ascii", errors="replace").rstrip("\x00").strip()
+
+    return ScanIdentification(
+        manufacturer=manufacturer,
+        device_id=device_id,
+        sw=sw_bytes.hex(),
+        hw=hw_bytes.hex(),
+    )
+
+
+def parse_vaillant_scan_id_chunks(chunks: list[bytes]) -> VaillantScanId:
+    """Parse Vaillant scan.id response chunks (B509 QQ=0x24..0x27).
+
+    ebusd's `scan.csv` defines the scan-id as 4 chunks (QQ=0x24..0x27) of 8 bytes each,
+    returned with a leading status byte. `EbusdTcpTransport` already strips the outer
+    length prefix from `hex` responses, so each chunk is expected to be:
+
+        <status:1> <ascii:8>
+    """
+
+    if len(chunks) != 4:
+        raise VaillantScanIdParseError(f"Expected 4 chunks (0x24..0x27), got {len(chunks)}")
+
+    parts: list[str] = []
+    for chunk in chunks:
+        if len(chunk) < 9:
+            raise VaillantScanIdParseError(
+                f"Scan-id chunk too short: expected >=9 bytes, got {len(chunk)}"
+            )
+        status = chunk[0]
+        if status != 0x00:
+            raise VaillantScanIdParseError(f"Scan-id chunk returned status 0x{status:02X}")
+        segment = chunk[1:9]
+        parts.append(segment.decode("ascii", errors="replace"))
+
+    raw = "".join(parts)
+    raw = raw.rstrip("\x00").strip()
+
+    if len(raw) < 28:
+        raise VaillantScanIdParseError(f"Scan-id string too short: {len(raw)} chars")
+
+    prefix = raw[0:2]
+    year = raw[2:4]
+    week = raw[4:6]
+    product = raw[6:16]
+    supplier = raw[16:20]
+    counter = raw[20:26]
+    suffix = raw[26:28]
+
+    return VaillantScanId(
+        prefix=prefix,
+        year=year,
+        week=week,
+        product=product,
+        supplier=supplier,
+        counter=counter,
+        suffix=suffix,
+        raw=raw,
+    )

--- a/tests/test_basv_protocol.py
+++ b/tests/test_basv_protocol.py
@@ -1,0 +1,34 @@
+from helianthus_vrc_explorer.ebusd import parse_ebusd_info_slave_addresses
+from helianthus_vrc_explorer.protocol.basv import (
+    parse_scan_identification,
+    parse_vaillant_scan_id_chunks,
+)
+
+
+def test_parse_scan_identification_parses_manufacturer_id_sw_hw() -> None:
+    payload = bytes.fromhex("b556525f393104154803")  # Vaillant VR_91 SW=0415 HW=4803
+    ident = parse_scan_identification(payload)
+    assert ident.manufacturer == 0xB5
+    assert ident.device_id == "VR_91"
+    assert ident.sw == "0415"
+    assert ident.hw == "4803"
+
+
+def test_parse_vaillant_scan_id_chunks_parses_model_and_serial() -> None:
+    raw = "21231600202609140953035469N6" + " " * 4
+    segments = [raw[i : i + 8] for i in range(0, 32, 8)]
+    chunks = [bytes([0x00]) + s.encode("ascii") for s in segments]
+
+    scan_id = parse_vaillant_scan_id_chunks(chunks)
+    assert scan_id.model_number == "0020260914"
+    assert scan_id.serial_number == "2123160953035469N6"
+
+
+def test_parse_ebusd_info_slave_addresses_filters_masters_and_self() -> None:
+    lines = [
+        "address 03: master",
+        "address 08: slave, scanned Vaillant;BAI00;0703;7401",
+        "address 31: master, self",
+        "address 36: slave, self",
+    ]
+    assert parse_ebusd_info_slave_addresses(lines) == [0x08]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,12 @@ def test_scan_command_is_present() -> None:
     assert result.exit_code == 0
 
 
+def test_discover_command_is_present() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["discover", "--help"])
+    assert result.exit_code == 0
+
+
 def test_scan_dry_run_writes_scan_artifact(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["scan", "--dry-run", "--output-dir", str(tmp_path)])


### PR DESCRIPTION
Closes #30.

What:
- Add `discover` CLI command that triggers QueryExistence broadcast (07FE) and performs per-address scan (0704) via the ebusd command port.
- For Vaillant devices, read scan.id chunks (B509 QQ=0x24..0x27) and print `model_number` + `serial_number`.
- If a Vaillant device is present at 0x15, run B524 group/instance discovery and print instances per group (no full register scan).

Implementation:
- Extend `EbusdTcpTransport` with `command_lines()` (multi-line responses) and `send_proto()` (arbitrary PBSB telegrams).
- Add BASV parsing helpers in `src/helianthus_vrc_explorer/protocol/basv.py` and ebusd info parsing in `src/helianthus_vrc_explorer/ebusd.py`.

Tests:
- Add unit tests for scan identification parsing, scan-id chunk parsing, and ebusd info address extraction.

Agent State:
Status: ready for review
Branch: issue-30-basv-discover
Last verified (lint/tests): 2026-02-08 (ruff check/format, mypy, pytest)
How to reproduce: `python -m helianthus_vrc_explorer discover --host 127.0.0.1 --port 8888`
Next steps: run on Home Assistant host (configured locally) and confirm expected device list + optional VRC@0x15 B524 summary.
Notes (no secrets, no private infra): read-only bus operations only; best-effort broadcast queryexistence.
