### PR TITLE
Artifact: include TT + full reply hex + register names

### DIFF
--- a/src/helianthus_vrc_explorer/schema/ebusd_csv.py
+++ b/src/helianthus_vrc_explorer/schema/ebusd_csv.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import csv
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..protocol.b524 import B524RegisterSelector, parse_b524_id
+
+_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class EbusdRegisterSchemaEntry:
+    name: str
+    type_spec: str | None
+
+
+def _looks_like_type_spec(value: str) -> bool:
+    normalized = value.strip().upper()
+    if not normalized:
+        return False
+    if normalized in {"EXP", "UIN", "UCH", "HTI", "HDA:3", "I8", "I16", "U32", "I32", "BOOL"}:
+        return True
+    return normalized.startswith(("STR:", "HEX:"))
+
+
+def _extract_b524_id_hex(fields: list[str]) -> str | None:
+    for i, raw in enumerate(fields):
+        field = raw.strip()
+        if not field:
+            continue
+        lowered = field.lower()
+        if lowered.startswith("b524,"):
+            return field[5:].strip()
+        if lowered == "b524" and i + 1 < len(fields):
+            candidate = fields[i + 1].strip()
+            if candidate and _HEX_RE.fullmatch(candidate) and len(candidate) % 2 == 0:
+                return candidate
+    return None
+
+
+def _extract_value_type_spec(fields: list[str]) -> str | None:
+    for raw in reversed(fields):
+        if _looks_like_type_spec(raw):
+            return raw.strip().upper()
+    return None
+
+
+class EbusdCsvSchema:
+    """Lightweight loader for ebusd configuration CSV files (e.g. `15.720.csv`)."""
+
+    def __init__(
+        self,
+        *,
+        exact: dict[tuple[int, int, int, int], EbusdRegisterSchemaEntry],
+        wildcard_instance: dict[tuple[int, int, int], EbusdRegisterSchemaEntry],
+    ) -> None:
+        self._exact = exact
+        self._wildcard_instance = wildcard_instance
+
+    @classmethod
+    def from_path(cls, path: Path) -> EbusdCsvSchema:
+        exact: dict[tuple[int, int, int, int], EbusdRegisterSchemaEntry] = {}
+        wildcard_instance: dict[tuple[int, int, int], EbusdRegisterSchemaEntry] = {}
+
+        with path.open(newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if not row:
+                    continue
+                # Skip comment lines.
+                if row[0].lstrip().startswith("#"):
+                    continue
+
+                name = row[3].strip() if len(row) > 3 else ""
+                if not name:
+                    continue
+
+                id_hex = _extract_b524_id_hex(row)
+                if id_hex is None:
+                    continue
+
+                try:
+                    selector = parse_b524_id(f"b524,{id_hex}")
+                except Exception:
+                    continue
+
+                if not isinstance(selector, B524RegisterSelector):
+                    continue
+                if selector.optype != 0x00:
+                    continue
+
+                type_spec = _extract_value_type_spec(row)
+                entry = EbusdRegisterSchemaEntry(name=name, type_spec=type_spec)
+
+                if selector.instance == 0xFF:
+                    wildcard_key = (selector.opcode, selector.group, selector.register)
+                    wildcard_instance.setdefault(wildcard_key, entry)
+                else:
+                    exact_key = (
+                        selector.opcode,
+                        selector.group,
+                        selector.instance,
+                        selector.register,
+                    )
+                    exact.setdefault(exact_key, entry)
+
+        return cls(exact=exact, wildcard_instance=wildcard_instance)
+
+    def lookup(
+        self,
+        *,
+        opcode: int,
+        group: int,
+        instance: int,
+        register: int,
+    ) -> EbusdRegisterSchemaEntry | None:
+        entry = self._exact.get((opcode, group, instance, register))
+        if entry is not None:
+            return entry
+        return self._wildcard_instance.get((opcode, group, register))

--- a/src/helianthus_vrc_explorer/schema/myvaillant_map.py
+++ b/src/helianthus_vrc_explorer/schema/myvaillant_map.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class MyvaillantRegisterName:
+    leaf: str
+
+
+def _parse_hex_u8(value: str) -> int:
+    parsed = int(value, 0)
+    if not (0x00 <= parsed <= 0xFF):
+        raise ValueError(f"u8 out of range: {value!r}")
+    return parsed
+
+
+def _parse_hex_u16(value: str) -> int:
+    parsed = int(value, 0)
+    if not (0x0000 <= parsed <= 0xFFFF):
+        raise ValueError(f"u16 out of range: {value!r}")
+    return parsed
+
+
+class MyvaillantRegisterMap:
+    """Optional register-to-myVaillant leaf-name mapping.
+
+    File format (CSV with header):
+
+        group,instance,register,leaf
+        0x03,0x01,0x0016,name
+
+    `instance` may be `*` to match all instances in the group.
+    """
+
+    def __init__(
+        self,
+        *,
+        exact: dict[tuple[int, int, int], MyvaillantRegisterName],
+        wildcard_instance: dict[tuple[int, int], MyvaillantRegisterName],
+    ) -> None:
+        self._exact = exact
+        self._wildcard_instance = wildcard_instance
+
+    @classmethod
+    def from_path(cls, path: Path) -> MyvaillantRegisterMap:
+        exact: dict[tuple[int, int, int], MyvaillantRegisterName] = {}
+        wildcard_instance: dict[tuple[int, int], MyvaillantRegisterName] = {}
+
+        with path.open(newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if not row:
+                    continue
+                gg_raw = (row.get("group") or "").strip()
+                ii_raw = (row.get("instance") or "").strip()
+                rr_raw = (row.get("register") or "").strip()
+                leaf = (row.get("leaf") or "").strip()
+                if not (gg_raw and ii_raw and rr_raw and leaf):
+                    continue
+
+                gg = _parse_hex_u8(gg_raw)
+                rr = _parse_hex_u16(rr_raw)
+                entry = MyvaillantRegisterName(leaf=leaf)
+
+                if ii_raw == "*":
+                    wildcard_instance.setdefault((gg, rr), entry)
+                    continue
+
+                ii = _parse_hex_u8(ii_raw)
+                exact.setdefault((gg, ii, rr), entry)
+
+        return cls(exact=exact, wildcard_instance=wildcard_instance)
+
+    def lookup(self, *, group: int, instance: int, register: int) -> MyvaillantRegisterName | None:
+        entry = self._exact.get((group, instance, register))
+        if entry is not None:
+            return entry
+        return self._wildcard_instance.get((group, register))

--- a/src/helianthus_vrc_explorer/transport/dummy.py
+++ b/src/helianthus_vrc_explorer/transport/dummy.py
@@ -85,8 +85,9 @@ class DummyTransport(TransportInterface):
             )
 
         # Empirically, register replies include a 4-byte header:
-        #   <STATUS> <GG> <RR_LO> <RR_HI>
-        header = bytes((0x00, group)) + payload[4:6]
+        #   <TT> <GG> <RR_LO> <RR_HI>
+        # Use TT=0x01 (live) for fixtures unless they explicitly model no-data via timeouts.
+        header = bytes((0x01, group)) + payload[4:6]
         return header + value
 
     @staticmethod

--- a/tests/test_dummy_transport.py
+++ b/tests/test_dummy_transport.py
@@ -51,7 +51,7 @@ def test_dummy_transport_register_read_returns_header_plus_value(tmp_path: Path)
     transport = DummyTransport(_write_min_fixture(tmp_path))
     payload = build_register_read_payload(0x02, group=0x02, instance=0x00, register=0x000F)
     response = transport.send(0x15, payload)
-    assert response == bytes.fromhex("00020f003412")
+    assert response == bytes.fromhex("01020f003412")
 
 
 def test_dummy_transport_missing_register_raises_timeout(tmp_path: Path) -> None:

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -21,7 +21,7 @@ class _FlakyOnceTransport(TransportInterface):
         # Return a register response header + a u16le value (UIN) so parsing succeeds.
         group = payload[2]
         rr = payload[4:6]
-        header = bytes((0x00, group)) + rr
+        header = bytes((0x01, group)) + rr
         return header + b"\x01\x00"
 
 
@@ -128,10 +128,13 @@ def test_read_register_status_only_response_is_not_decode_error() -> None:
         register=0x0000,
     )
 
-    assert entry["raw_hex"] == "00"
+    assert entry["reply_hex"] == "00"
+    assert entry["tt"] == 0x00
+    assert entry["tt_kind"] == "no_data"
+    assert entry["raw_hex"] is None
     assert entry["type"] is None
     assert entry["value"] is None
-    assert entry["error"] == "status_only_response: 0x00"
+    assert entry["error"] is None
 
 
 def test_is_instance_present_group_0c_requires_valid_register_response() -> None:


### PR DESCRIPTION
Closes #42.

- Each register entry now includes `reply_hex` (full reply payload) + `tt` and `tt_kind` interpretation.
- `raw_hex` remains the value bytes only (as before), so the post-scan viewer type cycling keeps working.
- Optional annotation from an ebusd config CSV via `--ebusd-csv-path` (`ebusd_name` + preferred type hint).
- Optional myVaillant leaf-name annotation via `--myvaillant-map-path` (`myvaillant_name`).
