### PR TITLE
Follow-up: immediate classic replanner fallback for Phase D

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -525,7 +525,7 @@ def scan_b524(
                                     if selected is None:
                                         raise KeyboardInterrupt
                                     plan = selected
-                        else:
+                        if planner_mode == "classic":
                             plan = prompt_scan_plan(
                                 console,
                                 planner_groups,

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -405,6 +405,74 @@ def test_scan_b524_replan_before_first_completed_task_does_not_divide_by_zero(
     assert artifact["meta"]["incomplete"] is False
 
 
+def test_scan_b524_replan_textual_failure_prompts_classic_immediately(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+    from contextlib import contextmanager
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    class _FakeHotkeys:
+        def __init__(self, *, enabled: bool) -> None:
+            self._enabled = enabled
+            self._seen = False
+
+        def __enter__(self) -> _FakeHotkeys:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def poll(self) -> bool:
+            if not self._enabled or self._seen:
+                return False
+            self._seen = True
+            return True
+
+        @contextmanager
+        def suspend(self):
+            yield None
+
+    transport = DummyTransport(_write_fixture_group_02(tmp_path))
+    textual_calls = {"count": 0}
+    classic_calls = {"count": 0}
+
+    def fake_run_textual_scan_plan(*_args, **kwargs):
+        textual_calls["count"] += 1
+        default_plan = kwargs.get("default_plan")
+        assert isinstance(default_plan, dict)
+        if textual_calls["count"] == 1:
+            return default_plan
+        raise RuntimeError("textual init failed")
+
+    def fake_prompt_scan_plan(*_args, **_kwargs):
+        classic_calls["count"] += 1
+        return {0x02: GroupScanPlan(group=0x02, rr_max=0x0000, instances=(0x00,))}
+
+    monkeypatch.setattr(scan_mod, "_PlannerHotkeyReader", _FakeHotkeys)
+    monkeypatch.setattr(
+        "helianthus_vrc_explorer.ui.planner_textual.run_textual_scan_plan",
+        fake_run_textual_scan_plan,
+    )
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="auto",
+    )
+
+    registers = artifact["groups"]["0x02"]["instances"]["0x00"]["registers"]
+    assert set(registers) == {"0x0000"}
+    assert textual_calls["count"] == 2
+    assert classic_calls["count"] == 1
+
+
 def test_scan_b524_marks_incomplete_on_keyboard_interrupt(tmp_path: Path) -> None:
     inner = DummyTransport(_write_fixture_group_02(tmp_path))
     transport = InterruptingTransport(inner, interrupt_after=10)


### PR DESCRIPTION
## Summary
This follow-up PR is intentionally minimal and contains only a cherry-pick of `a60ce3ea5a93c58e5b9826e0e6ed82b117596d76` onto `main`.

Codex review context (from PR #65):
- `discussion_r2795235745` (GG=0x00 RR range): preserved with `GROUP_CONFIG[0x00]["rr_max"] == 0x01FF`.
- `discussion_r2795369119` (Phase D fallback): fixed by immediately invoking classic prompt replanner after textual failure in auto mode.

## Changes
- `src/helianthus_vrc_explorer/scanner/scan.py`
  - In Phase D hotkey replanning, fallback now executes `prompt_scan_plan(...)` immediately when textual replanner fails and mode switches to classic.
- `tests/test_scanner_scan.py`
  - Adds regression test `test_scan_b524_replan_textual_failure_prompts_classic_immediately`.

Closes #66.

## Validation
- `PYTHONPATH=src .venv/bin/pytest -q tests/test_scanner_director.py tests/test_scanner_scan.py`
  - `14 passed`

## Agent State
Status: Follow-up fix branch created from `main` and pushed.
Branch: `issue/66-codex-replan-fallback`
Last verified (lint/tests): `PYTHONPATH=src .venv/bin/pytest -q tests/test_scanner_director.py tests/test_scanner_scan.py` (14 passed)
How to reproduce: Run an interactive scan with planner hotkey enabled; in Phase D press `p` and force textual replanner failure in `auto` mode. Classic replanner now opens immediately and applies the request.
Next steps: Await CI and review.
Notes (no secrets, no private infra): Branch contains only the cherry-picked fix commit.

@codex review
