### PR TITLE
Browse UI P0: fullscreen Textual explorer

### DIFF
--- a/src/helianthus_vrc_explorer/ui/browse_models.py
+++ b/src/helianthus_vrc_explorer/ui/browse_models.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+BrowseTab = Literal["config", "config_limits", "state"]
+
+
+@dataclass(frozen=True, slots=True)
+class RegisterAddress:
+    group_key: str
+    instance_key: str
+    register_key: str
+    read_opcode: str | None
+
+    @property
+    def label(self) -> str:
+        suffix = f" {self.read_opcode}" if self.read_opcode else ""
+        return f"GG={self.group_key} II={self.instance_key} RR={self.register_key}{suffix}"
+
+
+@dataclass(frozen=True, slots=True)
+class RegisterRow:
+    row_id: str
+    category_key: str
+    category_label: str
+    group_key: str
+    group_name: str
+    instance_key: str
+    register_key: str
+    name: str
+    path: str
+    tab: BrowseTab
+    address: RegisterAddress
+    value_text: str
+    raw_hex: str
+    unit: str
+    access_flags: str
+    last_update_text: str
+    age_text: str
+    change_indicator: str
+    search_blob: str
+
+
+@dataclass(frozen=True, slots=True)
+class TreeNodeRef:
+    node_id: str
+    label: str
+    level: Literal["root", "category", "group", "instance", "register"]
+    category_key: str | None = None
+    group_key: str | None = None
+    instance_key: str | None = None
+    register_key: str | None = None

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from .browse_models import BrowseTab, RegisterAddress, RegisterRow, TreeNodeRef
+
+_CATEGORY_NAMES: dict[int, tuple[str, str]] = {
+    0x00: ("regulator", "Regulator"),
+    0x01: ("hot_water", "Hot Water"),
+    0x02: ("heating", "Heating"),
+    0x03: ("zones", "Zones"),
+    0x04: ("heating", "Heating"),
+    0x05: ("hot_water", "Hot Water"),
+    0x06: ("heating", "Heating"),
+    0x07: ("heating", "Heating"),
+    0x09: ("rooms", "Rooms"),
+    0x0A: ("rooms", "Rooms"),
+    0x0C: ("rooms", "Rooms"),
+}
+
+
+def _safe_int_hex(value: str) -> int:
+    try:
+        return int(value, 0)
+    except ValueError:
+        return 0
+
+
+def _fmt_value(value: object | None) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def _parse_timestamp(meta: dict[str, Any]) -> datetime | None:
+    ts = meta.get("scan_timestamp")
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _category_for_group(group_key: str, group_name: str) -> tuple[str, str]:
+    gg = _safe_int_hex(group_key)
+    mapped = _CATEGORY_NAMES.get(gg)
+    if mapped is not None:
+        return mapped
+    low_name = group_name.lower()
+    if "water" in low_name:
+        return ("hot_water", "Hot Water")
+    if "zone" in low_name or "room" in low_name:
+        return ("rooms", "Rooms")
+    if "heat" in low_name:
+        return ("heating", "Heating")
+    return ("other", "Other")
+
+
+def _tab_from_entry(entry: dict[str, Any]) -> BrowseTab:
+    tt_kind = entry.get("tt_kind")
+    if tt_kind == "parameter_config":
+        return "config"
+    if tt_kind == "parameter_limit":
+        return "config_limits"
+    return "state"
+
+
+def _access_for_tab(tab: BrowseTab) -> str:
+    if tab == "state":
+        return "R"
+    return "R/W?"
+
+
+def _address_label(
+    group_key: str, instance_key: str, register_key: str, read_opcode: str | None
+) -> str:
+    op_txt = f" {read_opcode}" if read_opcode else ""
+    return f"{group_key}/{instance_key}/{register_key}{op_txt}"
+
+
+@dataclass(slots=True)
+class BrowseStore:
+    device_label: str
+    rows: list[RegisterRow]
+    tree_nodes: list[TreeNodeRef]
+    _row_by_id: dict[str, RegisterRow]
+
+    @classmethod
+    def from_artifact(cls, artifact: dict[str, Any]) -> BrowseStore:
+        meta = artifact.get("meta")
+        if not isinstance(meta, dict):
+            meta = {}
+        dst = meta.get("destination_address")
+        dst_txt = dst if isinstance(dst, str) else "0x??"
+        device_label = f"Device {dst_txt}"
+
+        last_update_dt = _parse_timestamp(meta)
+        last_update_text = (
+            last_update_dt.strftime("%Y-%m-%d %H:%M:%SZ") if last_update_dt else "n/a"
+        )
+        age_text = "n/a"
+        if last_update_dt is not None:
+            age_s = max(0.0, (datetime.now(UTC) - last_update_dt).total_seconds())
+            age_text = f"{age_s:.1f}s"
+
+        rows: list[RegisterRow] = []
+        tree_nodes: list[TreeNodeRef] = [
+            TreeNodeRef(node_id="root", label=device_label, level="root")
+        ]
+        row_by_id: dict[str, RegisterRow] = {}
+        groups = artifact.get("groups")
+        if not isinstance(groups, dict):
+            return cls(
+                device_label=device_label,
+                rows=[],
+                tree_nodes=tree_nodes,
+                _row_by_id={},
+            )
+
+        category_seen: set[str] = set()
+        group_seen: set[str] = set()
+        instance_seen: set[tuple[str, str]] = set()
+
+        for group_key in sorted((k for k in groups if isinstance(k, str)), key=_safe_int_hex):
+            group_obj = groups.get(group_key)
+            if not isinstance(group_obj, dict):
+                continue
+            group_name = str(group_obj.get("name") or "Unknown")
+            category_key, category_label = _category_for_group(group_key, group_name)
+
+            if category_key not in category_seen:
+                tree_nodes.append(
+                    TreeNodeRef(
+                        node_id=f"cat:{category_key}",
+                        label=category_label,
+                        level="category",
+                        category_key=category_key,
+                    )
+                )
+                category_seen.add(category_key)
+
+            group_node_id = f"group:{group_key}"
+            if group_node_id not in group_seen:
+                tree_nodes.append(
+                    TreeNodeRef(
+                        node_id=group_node_id,
+                        label=f"{group_key} {group_name}",
+                        level="group",
+                        category_key=category_key,
+                        group_key=group_key,
+                    )
+                )
+                group_seen.add(group_node_id)
+
+            instances = group_obj.get("instances")
+            if not isinstance(instances, dict):
+                continue
+
+            for instance_key in sorted(
+                (k for k in instances if isinstance(k, str)), key=_safe_int_hex
+            ):
+                instance_obj = instances.get(instance_key)
+                if not isinstance(instance_obj, dict):
+                    continue
+                if (group_key, instance_key) not in instance_seen:
+                    tree_nodes.append(
+                        TreeNodeRef(
+                            node_id=f"inst:{group_key}:{instance_key}",
+                            label=f"{instance_key}",
+                            level="instance",
+                            category_key=category_key,
+                            group_key=group_key,
+                            instance_key=instance_key,
+                        )
+                    )
+                    instance_seen.add((group_key, instance_key))
+
+                registers = instance_obj.get("registers")
+                if not isinstance(registers, dict):
+                    continue
+                for register_key in sorted(
+                    (k for k in registers if isinstance(k, str)),
+                    key=_safe_int_hex,
+                ):
+                    entry = registers.get(register_key)
+                    if not isinstance(entry, dict):
+                        continue
+
+                    name = (
+                        str(entry.get("myvaillant_name") or "").strip()
+                        or str(entry.get("ebusd_name") or "").strip()
+                        or register_key
+                    )
+                    tab = _tab_from_entry(entry)
+                    address = RegisterAddress(
+                        group_key=group_key,
+                        instance_key=instance_key,
+                        register_key=register_key,
+                        read_opcode=entry.get("read_opcode")
+                        if isinstance(entry.get("read_opcode"), str)
+                        else None,
+                    )
+                    value_text = _fmt_value(entry.get("value"))
+                    raw_hex = str(entry.get("raw_hex") or "")
+                    path = f"{category_label}/{group_name}/{instance_key}/{name}"
+                    row_id = f"{group_key}:{instance_key}:{register_key}"
+                    row = RegisterRow(
+                        row_id=row_id,
+                        category_key=category_key,
+                        category_label=category_label,
+                        group_key=group_key,
+                        group_name=group_name,
+                        instance_key=instance_key,
+                        register_key=register_key,
+                        name=name,
+                        path=path,
+                        tab=tab,
+                        address=address,
+                        value_text=value_text,
+                        raw_hex=raw_hex,
+                        unit="n/a",
+                        access_flags=_access_for_tab(tab),
+                        last_update_text=last_update_text,
+                        age_text=age_text,
+                        change_indicator="-",
+                        search_blob=" ".join(
+                            [
+                                path.lower(),
+                                _address_label(
+                                    group_key,
+                                    instance_key,
+                                    register_key,
+                                    address.read_opcode,
+                                ).lower(),
+                                value_text.lower(),
+                                raw_hex.lower(),
+                                tab.lower(),
+                            ]
+                        ),
+                    )
+                    rows.append(row)
+                    row_by_id[row_id] = row
+                    tree_nodes.append(
+                        TreeNodeRef(
+                            node_id=f"reg:{group_key}:{instance_key}:{register_key}",
+                            label=f"{register_key} {name}",
+                            level="register",
+                            category_key=category_key,
+                            group_key=group_key,
+                            instance_key=instance_key,
+                            register_key=register_key,
+                        )
+                    )
+
+        rows.sort(
+            key=lambda r: (
+                _safe_int_hex(r.group_key),
+                _safe_int_hex(r.instance_key),
+                _safe_int_hex(r.register_key),
+            )
+        )
+        return cls(
+            device_label=device_label,
+            rows=rows,
+            tree_nodes=tree_nodes,
+            _row_by_id=row_by_id,
+        )
+
+    def row_by_id(self, row_id: str) -> RegisterRow | None:
+        return self._row_by_id.get(row_id)
+
+    def rows_for_selection(self, node: TreeNodeRef | None, *, tab: BrowseTab) -> list[RegisterRow]:
+        selected = [row for row in self.rows if row.tab == tab]
+        if node is None or node.level == "root":
+            return selected
+        if node.level == "category" and node.category_key is not None:
+            return [row for row in selected if row.category_key == node.category_key]
+        if node.level == "group" and node.group_key is not None:
+            return [row for row in selected if row.group_key == node.group_key]
+        if (
+            node.level == "instance"
+            and node.group_key is not None
+            and node.instance_key is not None
+        ):
+            return [
+                row
+                for row in selected
+                if row.group_key == node.group_key and row.instance_key == node.instance_key
+            ]
+        if (
+            node.level == "register"
+            and node.group_key is not None
+            and node.instance_key is not None
+            and node.register_key is not None
+        ):
+            return [
+                row
+                for row in selected
+                if row.group_key == node.group_key
+                and row.instance_key == node.instance_key
+                and row.register_key == node.register_key
+            ]
+        return selected

--- a/src/helianthus_vrc_explorer/ui/browse_textual.py
+++ b/src/helianthus_vrc_explorer/ui/browse_textual.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .browse_models import BrowseTab, RegisterRow, TreeNodeRef
+from .browse_store import BrowseStore
+
+
+@dataclass(slots=True)
+class _SearchState:
+    query: str = ""
+    matches: list[str | int] | None = None
+    index: int = -1
+    target: str = ""
+
+    def __post_init__(self) -> None:
+        if self.matches is None:
+            self.matches = []
+
+
+def _tab_id(tab: BrowseTab) -> str:
+    return {
+        "config": "tab-config",
+        "config_limits": "tab-config-limits",
+        "state": "tab-state",
+    }[tab]
+
+
+def _tab_from_id(tab_id: str) -> BrowseTab:
+    if tab_id == "tab-config":
+        return "config"
+    if tab_id == "tab-config-limits":
+        return "config_limits"
+    return "state"
+
+
+def run_browse_from_artifact(
+    artifact: dict[str, object],
+    *,
+    allow_write: bool,
+) -> None:
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.containers import Horizontal, Vertical
+    from textual.screen import ModalScreen
+    from textual.widgets import DataTable, Footer, Header, Input, Label, Static, Tab, Tabs, Tree
+
+    class _FocusableStatic(Static):
+        can_focus = True
+
+    class _InputDialog(ModalScreen[str | None]):
+        BINDINGS = [
+            Binding("escape", "cancel", "Cancel"),
+            Binding("enter", "submit", "Search"),
+        ]
+        CSS = """
+        _InputDialog {
+            align: center middle;
+        }
+        _InputDialog > Vertical {
+            width: 70;
+            padding: 1 2;
+            border: heavy $accent;
+            background: $surface;
+        }
+        """
+
+        def __init__(self, *, title: str, value: str) -> None:
+            super().__init__()
+            self._title = title
+            self._value = value
+
+        def compose(self) -> ComposeResult:
+            yield Vertical(Label(self._title), Input(value=self._value, id="value"))
+
+        def on_mount(self) -> None:
+            self.query_one(Input).focus()
+
+        def action_cancel(self) -> None:
+            self.dismiss(None)
+
+        def action_submit(self) -> None:
+            self.dismiss(self.query_one(Input).value.strip())
+
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            self.dismiss(event.value.strip())
+
+    class _HelpDialog(ModalScreen[None]):
+        BINDINGS = [Binding("escape", "close", "Close"), Binding("q", "close", "Close")]
+        CSS = """
+        _HelpDialog {
+            align: center middle;
+        }
+        _HelpDialog > Vertical {
+            width: 86;
+            padding: 1 2;
+            border: heavy $accent;
+            background: $surface;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            yield Vertical(
+                Label("Browse Help"),
+                Static(
+                    "Tab/Shift+Tab focus | 1/2/3 tabs | Arrow keys navigate\n"
+                    "/ search (focused widget) | n/N next/prev match\n"
+                    "? help | q quit\n"
+                    "W/P/R/E are reserved for watch/write flows (P1/P2)."
+                ),
+            )
+
+        def action_close(self) -> None:
+            self.dismiss(None)
+
+    class _BrowseApp(App[None]):
+        BINDINGS = [
+            Binding("tab", "focus_next_section", "Next Focus"),
+            Binding("shift+tab", "focus_prev_section", "Prev Focus"),
+            Binding("1", "tab_config", "Config"),
+            Binding("2", "tab_config_limits", "Config-Limits"),
+            Binding("3", "tab_state", "State"),
+            Binding("/", "search", "Search"),
+            Binding("n", "search_next", "Next Match"),
+            Binding("N", "search_prev", "Prev Match"),
+            Binding("question_mark", "help", "Help"),
+            Binding("e", "edit_selected", "Edit"),
+            Binding("q", "quit", "Quit"),
+            Binding("escape", "close_dialog", "Back"),
+        ]
+
+        CSS = """
+        Screen {
+            background: #2e3436;
+            color: #eeeeec;
+        }
+        #main {
+            height: 1fr;
+        }
+        #tree-pane {
+            width: 35%;
+            border: round #729fcf;
+        }
+        #right-pane {
+            width: 65%;
+            border: round #729fcf;
+        }
+        #watch-dock {
+            height: 5;
+            border: round #888a85;
+        }
+        #status {
+            height: 1;
+            padding: 0 1;
+            color: #fce94f;
+            background: #555753;
+        }
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._store = BrowseStore.from_artifact(artifact)
+            self._node_by_id = {node.node_id: node for node in self._store.tree_nodes}
+            self._tree_node_by_ref: dict[str, Any] = {}
+            self._focus_order = ["tree", "tabs", "table", "watch"]
+            self._focus_idx = 0
+            self._selected_node_id = "root"
+            self._active_tab: BrowseTab = "config"
+            self._table_rows: list[RegisterRow] = []
+            self._search = _SearchState()
+            self._write_enabled = allow_write
+
+        def compose(self) -> ComposeResult:
+            yield Header(show_clock=False)
+            with Horizontal(id="main"):
+                with Vertical(id="tree-pane"):
+                    yield Tree(self._store.device_label, id="browse-tree")
+                with Vertical(id="right-pane"):
+                    yield Tabs(
+                        Tab("Config", id="tab-config"),
+                        Tab("Config-Limits", id="tab-config-limits"),
+                        Tab("State", id="tab-state"),
+                        id="browse-tabs",
+                    )
+                    yield DataTable(id="browse-table")
+            yield _FocusableStatic("Watchlist: reserved for P1 (watch/pin)", id="watch-dock")
+            yield Static("", id="status")
+            yield Footer()
+
+        def on_mount(self) -> None:
+            table = self.query_one("#browse-table", DataTable)
+            table.cursor_type = "row"
+            table.add_columns(
+                "Path/Name",
+                "Address",
+                "Value",
+                "Raw",
+                "Unit",
+                "Access",
+                "Last Update",
+                "Age",
+                "Δ",
+            )
+            self._build_tree()
+            self._refresh_table()
+            self._set_status("Ready")
+            self._focus_tree()
+
+        def _set_status(self, text: str) -> None:
+            self.query_one("#status", Static).update(text)
+
+        def _build_tree(self) -> None:
+            tree = self.query_one("#browse-tree", Tree[str])
+            tree.clear()
+            root = tree.root
+            root.data = "root"
+            self._tree_node_by_ref = {"root": root}
+            categories: dict[str, Any] = {}
+            groups: dict[str, Any] = {}
+            instances: dict[tuple[str, str], Any] = {}
+            for node in self._store.tree_nodes:
+                if node.level == "root":
+                    continue
+                if node.level == "category" and node.category_key is not None:
+                    category_node = root.add(node.label, data=node.node_id)
+                    categories[node.category_key] = category_node
+                    self._tree_node_by_ref[node.node_id] = category_node
+                    continue
+                if node.level == "group" and node.category_key is not None:
+                    parent = categories.get(node.category_key)
+                    if parent is None:
+                        continue
+                    group_node = parent.add(node.label, data=node.node_id)
+                    groups[node.group_key or ""] = group_node
+                    self._tree_node_by_ref[node.node_id] = group_node
+                    continue
+                if (
+                    node.level == "instance"
+                    and node.group_key is not None
+                    and node.instance_key is not None
+                ):
+                    parent = groups.get(node.group_key)
+                    if parent is None:
+                        continue
+                    instance_node = parent.add(node.label, data=node.node_id)
+                    instances[(node.group_key, node.instance_key)] = instance_node
+                    self._tree_node_by_ref[node.node_id] = instance_node
+                    continue
+                if (
+                    node.level == "register"
+                    and node.group_key is not None
+                    and node.instance_key is not None
+                ):
+                    parent = instances.get((node.group_key, node.instance_key))
+                    if parent is None:
+                        continue
+                    register_node = parent.add(node.label, data=node.node_id)
+                    self._tree_node_by_ref[node.node_id] = register_node
+            root.expand()
+
+        def _current_node(self) -> TreeNodeRef | None:
+            return self._node_by_id.get(self._selected_node_id)
+
+        def _refresh_table(self) -> None:
+            table = self.query_one("#browse-table", DataTable)
+            selected = self._current_node()
+            self._table_rows = self._store.rows_for_selection(selected, tab=self._active_tab)
+            cursor = max(0, table.cursor_row)
+            table.clear(columns=False)
+            for row in self._table_rows:
+                table.add_row(
+                    row.path,
+                    row.address.label,
+                    row.value_text,
+                    row.raw_hex,
+                    row.unit,
+                    row.access_flags,
+                    row.last_update_text,
+                    row.age_text,
+                    row.change_indicator,
+                    key=row.row_id,
+                )
+            if self._table_rows:
+                table.move_cursor(row=min(cursor, len(self._table_rows) - 1))
+            status_text = (
+                f"Rows: {len(self._table_rows)} | Selection: {self._selected_node_id} | "
+                f"Tab: {self._active_tab}"
+            )
+            self._set_status(status_text)
+
+        def _focus_tree(self) -> None:
+            self.query_one("#browse-tree", Tree[str]).focus()
+            self._focus_idx = 0
+
+        def _focus_tabs(self) -> None:
+            self.query_one("#browse-tabs", Tabs).focus()
+            self._focus_idx = 1
+
+        def _focus_table(self) -> None:
+            self.query_one("#browse-table", DataTable).focus()
+            self._focus_idx = 2
+
+        def _focus_watch(self) -> None:
+            self.query_one("#watch-dock", Static).focus()
+            self._focus_idx = 3
+
+        def _focus_by_index(self) -> None:
+            match self._focus_order[self._focus_idx]:
+                case "tree":
+                    self._focus_tree()
+                case "tabs":
+                    self._focus_tabs()
+                case "table":
+                    self._focus_table()
+                case _:
+                    self._focus_watch()
+
+        def action_focus_next_section(self) -> None:
+            self._focus_idx = (self._focus_idx + 1) % len(self._focus_order)
+            self._focus_by_index()
+
+        def action_focus_prev_section(self) -> None:
+            self._focus_idx = (self._focus_idx - 1) % len(self._focus_order)
+            self._focus_by_index()
+
+        def action_tab_config(self) -> None:
+            self.query_one("#browse-tabs", Tabs).active = _tab_id("config")
+
+        def action_tab_config_limits(self) -> None:
+            self.query_one("#browse-tabs", Tabs).active = _tab_id("config_limits")
+
+        def action_tab_state(self) -> None:
+            self.query_one("#browse-tabs", Tabs).active = _tab_id("state")
+
+        def on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
+            if event.tabs.id != "browse-tabs":
+                return
+            self._active_tab = _tab_from_id(event.tab.id or "tab-state")
+            self._refresh_table()
+
+        def on_tree_node_selected(self, event: Tree.NodeSelected[str]) -> None:
+            data = event.node.data
+            if isinstance(data, str):
+                self._selected_node_id = data
+                self._refresh_table()
+
+        def action_search(self) -> None:
+            target = self._focus_order[self._focus_idx]
+            self._search.target = target
+            self.push_screen(
+                _InputDialog(title=f"Search in {target}", value=self._search.query),
+                self._on_search_entered,
+            )
+
+        def _on_search_entered(self, query: str | None) -> None:
+            if query is None:
+                return
+            q = query.strip().lower()
+            self._search.query = q
+            self._search.matches = []
+            self._search.index = -1
+            if not q:
+                self._set_status("Search cleared")
+                return
+
+            if self._search.target == "tree":
+                self._search.matches = [
+                    node.node_id for node in self._store.tree_nodes if q in node.label.lower()
+                ]
+            else:
+                self._search.matches = [
+                    idx for idx, row in enumerate(self._table_rows) if q in row.search_blob
+                ]
+            if not self._search.matches:
+                self._set_status(f"No matches for '{query}'")
+                return
+            self._search.index = 0
+            self._apply_search_current()
+
+        def _apply_search_current(self) -> None:
+            if not self._search.matches or self._search.index < 0:
+                return
+            current = self._search.matches[self._search.index]
+            if self._search.target == "tree":
+                tree = self.query_one("#browse-tree", Tree[str])
+                node = self._tree_node_by_ref.get(str(current))
+                if node is not None:
+                    parent = node.parent
+                    while parent is not None:
+                        parent.expand()
+                        parent = parent.parent
+                    tree.select_node(node)
+                    self._focus_tree()
+            else:
+                table = self.query_one("#browse-table", DataTable)
+                row = int(current)
+                if 0 <= row < len(self._table_rows):
+                    table.move_cursor(row=row)
+                    self._focus_table()
+            match_status = (
+                f"Match {self._search.index + 1}/{len(self._search.matches)} "
+                f"for '{self._search.query}'"
+            )
+            self._set_status(match_status)
+
+        def action_search_next(self) -> None:
+            if not self._search.matches:
+                return
+            self._search.index = (self._search.index + 1) % len(self._search.matches)
+            self._apply_search_current()
+
+        def action_search_prev(self) -> None:
+            if not self._search.matches:
+                return
+            self._search.index = (self._search.index - 1) % len(self._search.matches)
+            self._apply_search_current()
+
+        def action_help(self) -> None:
+            self.push_screen(_HelpDialog())
+
+        def action_edit_selected(self) -> None:
+            if not self._write_enabled:
+                self._set_status("Write disabled: run with --allow-write")
+                return
+            self._set_status("Write flow is planned for P2 (not implemented in P0).")
+
+        def action_close_dialog(self) -> None:
+            if len(self.screen_stack) > 1:
+                self.pop_screen()
+
+    _BrowseApp().run()

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from helianthus_vrc_explorer.ui.browse_store import BrowseStore
+
+
+def _sample_artifact() -> dict[str, object]:
+    return {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+        },
+        "groups": {
+            "0x00": {
+                "name": "Regulator Parameters",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {
+                                "value": 1.0,
+                                "raw_hex": "00",
+                                "tt_kind": "parameter_config",
+                                "read_opcode": "0x02",
+                                "ebusd_name": "regulator_param_1",
+                            },
+                            "0x0002": {
+                                "value": 2.0,
+                                "raw_hex": "0102",
+                                "tt_kind": "parameter_limit",
+                                "read_opcode": "0x06",
+                                "myvaillant_name": "limit_value",
+                            },
+                            "0x0003": {
+                                "value": 3.0,
+                                "raw_hex": "03",
+                                "tt_kind": "live_operational",
+                                "read_opcode": "0x02",
+                            },
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_browse_store_builds_rows_and_prefers_myvaillant_name() -> None:
+    store = BrowseStore.from_artifact(_sample_artifact())
+    assert store.device_label == "Device 0x15"
+    assert len(store.rows) == 3
+
+    by_register = {row.register_key: row for row in store.rows}
+    assert by_register["0x0001"].tab == "config"
+    assert by_register["0x0002"].tab == "config_limits"
+    assert by_register["0x0003"].tab == "state"
+    assert by_register["0x0001"].name == "regulator_param_1"
+    assert by_register["0x0002"].name == "limit_value"
+    assert by_register["0x0003"].name == "0x0003"
+
+
+def test_browse_store_filters_rows_for_tree_selection() -> None:
+    store = BrowseStore.from_artifact(_sample_artifact())
+    category_node = next(
+        node
+        for node in store.tree_nodes
+        if node.level == "category" and node.category_key == "regulator"
+    )
+    group_node = next(
+        node for node in store.tree_nodes if node.level == "group" and node.group_key == "0x00"
+    )
+    instance_node = next(
+        node
+        for node in store.tree_nodes
+        if node.level == "instance" and node.group_key == "0x00" and node.instance_key == "0x00"
+    )
+
+    assert len(store.rows_for_selection(None, tab="state")) == 1
+    assert len(store.rows_for_selection(category_node, tab="config")) == 1
+    assert len(store.rows_for_selection(group_node, tab="config_limits")) == 1
+    assert len(store.rows_for_selection(instance_node, tab="state")) == 1


### PR DESCRIPTION
## Summary
- add new `browse` command for fullscreen results exploration from JSON artifacts
- implement Textual 2-pane browse app (tree left, tabs + table right, watch dock placeholder)
- add tree/table search (`/`, `n/N`), focus cycling, tab switching (`1/2/3`), help overlay (`?`)
- keep write path gated behind `--allow-write` and show P2 placeholder status
- add non-TTY fallback summary output and tests for command + store filtering

## Validation
- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy src`
- `PYTHONPATH=src ./.venv/bin/pytest -q`

Closes #70
