### PR TITLE
Planner: cap GG 0x00 RR_max and fix Enter handling

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -23,7 +23,7 @@ class GroupConfig(TypedDict):
 # Known groups (hardcoded reference, validated against CSV).
 # Source of truth: `AGENTS.md` (keep in sync).
 GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
-    0x00: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x01FF},
+    0x00: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x00FF},
     0x01: {"desc": 3.0, "name": "Hot Water Circuit", "ii_max": 0x00, "rr_max": 0x1F},
     0x02: {"desc": 1.0, "name": "Heating Circuits", "ii_max": 0x0A, "rr_max": 0x21},
     0x03: {"desc": 1.0, "name": "Zones", "ii_max": 0x0A, "rr_max": 0x2F},

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -113,5 +113,5 @@ def test_classify_groups_warns_on_descriptor_mismatch(
     assert any("Descriptor mismatch for GG=0x02" in record.message for record in caplog.records)
 
 
-def test_group_00_rr_max_is_0x01ff() -> None:
-    assert GROUP_CONFIG[0x00]["rr_max"] == 0x01FF
+def test_group_00_rr_max_is_0x00ff() -> None:
+    assert GROUP_CONFIG[0x00]["rr_max"] == 0x00FF


### PR DESCRIPTION
## Summary
- cap default GG `0x00` scan range to `RR_max=0x00FF`
- harden Textual planner Enter/Return handling for row edit and modal submission
- avoid Enter key conflicts while modal screens are open
- add/adjust regression expectation for GG `0x00` default range

## Validation
- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy src`
- `PYTHONPATH=src ./.venv/bin/pytest -q`

Closes #72
