### PR TITLE
Browse UI P2: safe write mode with confirmation

### DIFF
--- a/src/helianthus_vrc_explorer/protocol/parser.py
+++ b/src/helianthus_vrc_explorer/protocol/parser.py
@@ -9,6 +9,10 @@ class ValueParseError(Exception):
     """Raised when response bytes cannot be parsed into a typed value."""
 
 
+class ValueEncodeError(Exception):
+    """Raised when a typed value cannot be encoded into bytes."""
+
+
 def _expect_len(type_spec: str, data: bytes, expected_len: int) -> None:
     if len(data) != expected_len:
         raise ValueParseError(f"{type_spec} expects {expected_len} bytes, got {len(data)} bytes")
@@ -22,6 +26,16 @@ def _decode_bcd(type_spec: str, field: str, value: int) -> int:
     if high > 9 or low > 9:
         raise ValueParseError(f"{type_spec} invalid BCD for {field}: 0x{value:02X}")
     return high * 10 + low
+
+
+def _encode_bcd(type_spec: str, field: str, value: int) -> int:
+    """Encode a 0..99 integer into a single BCD byte."""
+
+    if not (0 <= value <= 99):
+        raise ValueEncodeError(f"{type_spec} {field} must be 0..99, got {value}")
+    tens = value // 10
+    ones = value % 10
+    return (tens << 4) | ones
 
 
 def parse_exp(data: bytes) -> float | None:
@@ -148,6 +162,202 @@ def parse_hti_time(data: bytes) -> str:
         raise ValueParseError(f"HTI second must be 0..59, got {second}")
 
     return f"{hour:02d}:{minute:02d}:{second:02d}"
+
+
+def encode_exp(value: float) -> bytes:
+    """Encode an `EXP` value (float32le)."""
+
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueEncodeError(f"EXP expects float, got {type(value).__name__}")
+    if math.isnan(float(value)):
+        raise ValueEncodeError("EXP cannot encode NaN")
+    return struct.pack("<f", float(value))
+
+
+def encode_uin(value: int) -> bytes:
+    """Encode an `UIN` value (u16le)."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueEncodeError(f"UIN expects int, got {type(value).__name__}")
+    if not (0 <= value <= 0xFFFF):
+        raise ValueEncodeError(f"UIN out of range 0..65535, got {value}")
+    return int(value).to_bytes(2, byteorder="little", signed=False)
+
+
+def encode_uch(value: int) -> bytes:
+    """Encode an `UCH` value (u8)."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueEncodeError(f"UCH expects int, got {type(value).__name__}")
+    if not (0 <= value <= 0xFF):
+        raise ValueEncodeError(f"UCH out of range 0..255, got {value}")
+    return bytes((int(value),))
+
+
+def encode_i8(value: int) -> bytes:
+    """Encode an `I8` value (i8)."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueEncodeError(f"I8 expects int, got {type(value).__name__}")
+    if not (-0x80 <= value <= 0x7F):
+        raise ValueEncodeError(f"I8 out of range -128..127, got {value}")
+    return int(value).to_bytes(1, byteorder="little", signed=True)
+
+
+def encode_i16(value: int) -> bytes:
+    """Encode an `I16` value (i16le)."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueEncodeError(f"I16 expects int, got {type(value).__name__}")
+    if not (-0x8000 <= value <= 0x7FFF):
+        raise ValueEncodeError(f"I16 out of range -32768..32767, got {value}")
+    return int(value).to_bytes(2, byteorder="little", signed=True)
+
+
+def encode_u32(value: int) -> bytes:
+    """Encode an `U32` value (u32le)."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueEncodeError(f"U32 expects int, got {type(value).__name__}")
+    if not (0 <= value <= 0xFFFFFFFF):
+        raise ValueEncodeError(f"U32 out of range 0..4294967295, got {value}")
+    return int(value).to_bytes(4, byteorder="little", signed=False)
+
+
+def encode_i32(value: int) -> bytes:
+    """Encode an `I32` value (i32le)."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueEncodeError(f"I32 expects int, got {type(value).__name__}")
+    if not (-0x80000000 <= value <= 0x7FFFFFFF):
+        raise ValueEncodeError(f"I32 out of range -2147483648..2147483647, got {value}")
+    return int(value).to_bytes(4, byteorder="little", signed=True)
+
+
+def encode_bool(value: bool) -> bytes:
+    """Encode a `BOOL` value as a single u8 byte."""
+
+    if not isinstance(value, bool):
+        raise ValueEncodeError(f"BOOL expects bool, got {type(value).__name__}")
+    return b"\x01" if value else b"\x00"
+
+
+def encode_str_cstring(value: str) -> bytes:
+    """Encode a `STR:*` value as latin1 + NUL terminator."""
+
+    if not isinstance(value, str):
+        raise ValueEncodeError(f"STR expects str, got {type(value).__name__}")
+    return value.encode("latin1") + b"\x00"
+
+
+def encode_hex(type_spec: str, value: str, expected_len: int) -> bytes:
+    """Encode a `HEX:n` value from a hex string."""
+
+    if not isinstance(value, str):
+        raise ValueEncodeError(f"{type_spec} expects hex string, got {type(value).__name__}")
+    text = value.strip().lower()
+    if text.startswith("0x"):
+        text = text[2:]
+    if len(text) % 2:
+        raise ValueEncodeError(f"{type_spec} hex string must have even length")
+    try:
+        data = bytes.fromhex(text)
+    except ValueError as exc:
+        raise ValueEncodeError(f"{type_spec} invalid hex string") from exc
+    if len(data) != expected_len:
+        raise ValueEncodeError(f"{type_spec} expects {expected_len} bytes, got {len(data)} bytes")
+    return data
+
+
+def encode_hda3_date(value: str) -> bytes:
+    """Encode an `HDA:3` value from `YYYY-MM-DD`."""
+
+    if not isinstance(value, str):
+        raise ValueEncodeError(f"HDA:3 expects str, got {type(value).__name__}")
+    try:
+        yyyy_s, mm_s, dd_s = value.split("-", 2)
+        yyyy = int(yyyy_s)
+        mm = int(mm_s)
+        dd = int(dd_s)
+    except Exception as exc:
+        raise ValueEncodeError("HDA:3 expects YYYY-MM-DD") from exc
+    if not (2000 <= yyyy <= 2099):
+        raise ValueEncodeError(f"HDA:3 year must be 2000..2099, got {yyyy}")
+    yy = yyyy - 2000
+    return bytes(
+        (
+            _encode_bcd("HDA:3", "day", dd),
+            _encode_bcd("HDA:3", "month", mm),
+            _encode_bcd("HDA:3", "year", yy),
+        )
+    )
+
+
+def encode_hti_time(value: str) -> bytes:
+    """Encode an `HTI` value from `HH:MM:SS`."""
+
+    if not isinstance(value, str):
+        raise ValueEncodeError(f"HTI expects str, got {type(value).__name__}")
+    try:
+        hh_s, mm_s, ss_s = value.split(":", 2)
+        hh = int(hh_s)
+        mm = int(mm_s)
+        ss = int(ss_s)
+    except Exception as exc:
+        raise ValueEncodeError("HTI expects HH:MM:SS") from exc
+    if not (0 <= hh <= 23):
+        raise ValueEncodeError(f"HTI hour must be 0..23, got {hh}")
+    if not (0 <= mm <= 59):
+        raise ValueEncodeError(f"HTI minute must be 0..59, got {mm}")
+    if not (0 <= ss <= 59):
+        raise ValueEncodeError(f"HTI second must be 0..59, got {ss}")
+    return bytes(
+        (
+            _encode_bcd("HTI", "hour", hh),
+            _encode_bcd("HTI", "minute", mm),
+            _encode_bcd("HTI", "second", ss),
+        )
+    )
+
+
+def encode_typed_value(type_spec: str, value: object) -> bytes:
+    """Encode a typed value into bytes compatible with ebusd schema type specs."""
+
+    normalized = type_spec.strip().upper()
+
+    if normalized.startswith("STR:"):
+        return encode_str_cstring(value)  # type: ignore[arg-type]
+
+    if normalized.startswith("HEX:"):
+        try:
+            expected = int(normalized.split(":", 1)[1], 10)
+        except ValueError as exc:
+            raise ValueEncodeError(f"Invalid HEX length in type spec: {type_spec!r}") from exc
+        return encode_hex(normalized, value, expected_len=expected)  # type: ignore[arg-type]
+
+    match normalized:
+        case "EXP":
+            return encode_exp(value)  # type: ignore[arg-type]
+        case "UIN":
+            return encode_uin(value)  # type: ignore[arg-type]
+        case "UCH":
+            return encode_uch(value)  # type: ignore[arg-type]
+        case "I8":
+            return encode_i8(value)  # type: ignore[arg-type]
+        case "I16":
+            return encode_i16(value)  # type: ignore[arg-type]
+        case "U32":
+            return encode_u32(value)  # type: ignore[arg-type]
+        case "I32":
+            return encode_i32(value)  # type: ignore[arg-type]
+        case "BOOL":
+            return encode_bool(value)  # type: ignore[arg-type]
+        case "HDA:3":
+            return encode_hda3_date(value)  # type: ignore[arg-type]
+        case "HTI":
+            return encode_hti_time(value)  # type: ignore[arg-type]
+        case _:
+            raise ValueEncodeError(f"Unknown type spec: {type_spec!r}")
 
 
 def parse_typed_value(type_spec: str, data: bytes) -> object:

--- a/tests/test_b524_value_encoder.py
+++ b/tests/test_b524_value_encoder.py
@@ -1,0 +1,58 @@
+import pytest
+
+from helianthus_vrc_explorer.protocol.parser import (
+    ValueEncodeError,
+    encode_typed_value,
+    parse_typed_value,
+)
+
+
+def test_encode_uin_roundtrips() -> None:
+    data = encode_typed_value("UIN", 0x1234)
+    assert data.hex() == "3412"
+    assert parse_typed_value("UIN", data) == 0x1234
+
+
+def test_encode_uch_roundtrips() -> None:
+    data = encode_typed_value("UCH", 0x7F)
+    assert data.hex() == "7f"
+    assert parse_typed_value("UCH", data) == 0x7F
+
+
+def test_encode_bool_roundtrips() -> None:
+    assert encode_typed_value("BOOL", True).hex() == "01"
+    assert encode_typed_value("BOOL", False).hex() == "00"
+    assert parse_typed_value("BOOL", encode_typed_value("BOOL", True)) is True
+    assert parse_typed_value("BOOL", encode_typed_value("BOOL", False)) is False
+
+
+def test_encode_exp_roundtrips() -> None:
+    data = encode_typed_value("EXP", 1.0)
+    assert parse_typed_value("EXP", data) == 1.0
+
+
+def test_encode_str_roundtrips() -> None:
+    data = encode_typed_value("STR:*", "Etaj")
+    assert data.endswith(b"\x00")
+    assert parse_typed_value("STR:*", data) == "Etaj"
+
+
+def test_encode_hda3_roundtrips() -> None:
+    data = encode_typed_value("HDA:3", "2026-02-06")
+    assert parse_typed_value("HDA:3", data) == "2026-02-06"
+
+
+def test_encode_hti_roundtrips() -> None:
+    data = encode_typed_value("HTI", "23:59:58")
+    assert parse_typed_value("HTI", data) == "23:59:58"
+
+
+def test_encode_hex_enforces_length() -> None:
+    assert encode_typed_value("HEX:2", "0x3412").hex() == "3412"
+    with pytest.raises(ValueEncodeError):
+        encode_typed_value("HEX:2", "0x00")
+
+
+def test_encode_unknown_type_raises() -> None:
+    with pytest.raises(ValueEncodeError, match=r"Unknown type spec"):
+        encode_typed_value("NOPE", 1)


### PR DESCRIPTION
## Summary
- implement P2 safe write mode for browse UI behind `--allow-write`
- type-aware value parsing + byte encoding (protocol encoder) and confirmation modal
- Enter/Return also triggers edit when table focused (TTY)
- write updates are applied to in-memory artifact/store and reflected in table + watch dock (✎ marker)

## UX
- `E` or `Enter`: edit selected row (Config/Config-Limits tabs only)
- confirmation required before applying

## Validation
- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy src`
- `PYTHONPATH=src ./.venv/bin/pytest -q`

Closes #76
