### PR TITLE
Implement intelligent eBUSd retry policies in transport

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,10 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _no_scanner_time_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prevent unit tests from actually sleeping on scanner timeout retries."""
+    """Keep compatibility with legacy scanner timeout tests."""
 
     import helianthus_vrc_explorer.scanner.register as register
 
-    monkeypatch.setattr(register.time, "sleep", lambda _seconds: None)
+    time_module = getattr(register, "time", None)
+    if time_module is not None:
+        monkeypatch.setattr(time_module, "sleep", lambda _seconds: None)


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: ready for review
Branch: issue-90-transport-intelligent-retries
Last verified (lint/tests): ruff check .; ruff format --check .; mypy src; python scripts/check_protocol_terminology.py; PYTHONPATH=src pytest
How to reproduce: run commands above from repo root
Next steps: CI + bot review + maintainer review
Notes (no secrets, no private infra): scanner-level timeout retry removed; retry policy centralized in transport
```

## Summary
- implement transport-level intelligent retry policy in `EbusdTcpTransport` for:
  - `ERR: read timeout` => immediate retry up to 5 retries
  - collision errors (`ERR: SYN received`, `ERR: wrong symbol received`) => random 10-100ms backoff up to 5 retries
  - `ERR: no signal` => poll every 200ms for up to 15s
  - global per-command budget cap (`max_command_s`, default 30s)
- apply same policy to both `send()` and `send_proto()`
- preserve one reconnect retry for connection-level failures in session mode
- remove duplicate scanner-local timeout retry loop in `read_register()`
- expand tests for policy behavior and update scanner tests accordingly

## Linked Issue
- Closes #90

## Checklist
- [x] `ruff check .`
- [x] `python scripts/check_protocol_terminology.py`
- [x] `ruff format .`
- [x] `pytest`
- [ ] Manual SSH integration test (if required by the issue): NO
- [x] Audit: no private identifiers introduced (IPs other than 127.0.0.1, serial numbers, hostnames, internal repo names)

## Notes
- New config knobs in `EbusdTcpConfig` (defaults match requested strategy):
  - `timeout_max_retries`, `collision_max_retries`, `collision_backoff_min_ms`, `collision_backoff_max_ms`, `no_signal_poll_ms`, `no_signal_max_s`, `max_command_s`
