### PR TITLE
Browse TUI: simplify left tree (groups/instances only) + show B509 ranges

### DIFF
--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -572,8 +572,8 @@ def scan(
         None,
         "--b509-range",
         help=(
-            "B509 register range to dump (repeatable), format: 0x2700..0x27FF. "
-            "If omitted, defaults to 0x2700..0x27FF."
+            "B509 register range to dump (repeatable), format: 0x0000..0x00FF. "
+            "If omitted, defaults to 0x0000..0x00FF."
         ),
     ),
     planner_ui: str = typer.Option(  # noqa: B008
@@ -679,7 +679,7 @@ def scan(
                     typer.echo(f"Invalid --b509-range {spec!r}: {exc}", err=True)
                     raise typer.Exit(2) from exc
         else:
-            b509_ranges = [(0x2700, 0x27FF)]
+            b509_ranges = [(0x0000, 0x00FF)]
         while True:
             transport = _build_transport(transport_settings, trace_file=trace_file)
             opened_session = False

--- a/src/helianthus_vrc_explorer/ui/browse_models.py
+++ b/src/helianthus_vrc_explorer/ui/browse_models.py
@@ -4,29 +4,34 @@ from dataclasses import dataclass
 from typing import Literal
 
 BrowseTab = Literal["config", "config_limits", "state"]
+ProtocolKey = Literal["b524", "b509"]
 
 
 @dataclass(frozen=True, slots=True)
 class RegisterAddress:
-    group_key: str
-    instance_key: str
+    protocol: ProtocolKey
+    group_key: str | None
+    instance_key: str | None
     register_key: str
     read_opcode: str | None
 
     @property
     def label(self) -> str:
         suffix = f" {self.read_opcode}" if self.read_opcode else ""
-        return f"GG={self.group_key} II={self.instance_key} RR={self.register_key}{suffix}"
+        if self.protocol == "b509":
+            return f"B509 RR={self.register_key}{suffix}"
+        group_key = self.group_key or "0x??"
+        instance_key = self.instance_key or "0x??"
+        return f"GG={group_key} II={instance_key} RR={self.register_key}{suffix}"
 
 
 @dataclass(frozen=True, slots=True)
 class RegisterRow:
     row_id: str
-    category_key: str
-    category_label: str
-    group_key: str
+    protocol: ProtocolKey
+    group_key: str | None
     group_name: str
-    instance_key: str
+    instance_key: str | None
     register_key: str
     name: str
     myvaillant_name: str
@@ -44,12 +49,15 @@ class RegisterRow:
     search_blob: str
 
 
+TreeNodeLevel = Literal["root", "protocol", "group", "instance", "range"]
+
+
 @dataclass(frozen=True, slots=True)
 class TreeNodeRef:
     node_id: str
     label: str
-    level: Literal["root", "category", "group", "instance", "register"]
-    category_key: str | None = None
+    level: TreeNodeLevel
+    protocol: ProtocolKey | None = None
     group_key: str | None = None
     instance_key: str | None = None
-    register_key: str | None = None
+    range_key: str | None = None

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -63,30 +63,22 @@ def test_browse_store_builds_rows_and_left_tree_uses_only_myvaillant_name() -> N
     assert by_register["0x0002"].ebusd_name == ""
 
     by_node_id = {node.node_id: node for node in store.tree_nodes}
-    assert by_node_id["reg:0x00:0x00:0x0001"].label == "0x0001"
-    assert by_node_id["reg:0x00:0x00:0x0002"].label == "0x0002 limit_value"
+    assert by_node_id["proto:b524"].label == "B524"
+    assert by_node_id["b524:group:0x00"].label == "Regulator Parameters (0x00)"
+    assert not any(node.level == "register" for node in store.tree_nodes)
 
 
 def test_browse_store_filters_rows_for_tree_selection() -> None:
     store = BrowseStore.from_artifact(_sample_artifact())
-    category_node = next(
-        node
-        for node in store.tree_nodes
-        if node.level == "category" and node.category_key == "regulator"
-    )
+    protocol_node = next(node for node in store.tree_nodes if node.level == "protocol")
     group_node = next(
         node for node in store.tree_nodes if node.level == "group" and node.group_key == "0x00"
     )
-    instance_node = next(
-        node
-        for node in store.tree_nodes
-        if node.level == "instance" and node.group_key == "0x00" and node.instance_key == "0x00"
-    )
 
     assert len(store.rows_for_selection(None, tab="state")) == 1
-    assert len(store.rows_for_selection(category_node, tab="config")) == 1
+    assert len(store.rows_for_selection(protocol_node, tab="config")) == 1
     assert len(store.rows_for_selection(group_node, tab="config_limits")) == 1
-    assert len(store.rows_for_selection(instance_node, tab="state")) == 1
+    assert len(store.rows_for_selection(group_node, tab="state")) == 1
 
 
 def test_browse_store_prefers_register_class_over_tt_kind_for_tab() -> None:


### PR DESCRIPTION
Changes:
- Left tree no longer expands to per-register nodes; leaves are Group (singleton) or Instance (instanced).
- Remove category meta-groups; under B524 show only discovered groups as "Name (0xGG)".
- Instance nodes use discovered names when available (e.g. zone name), otherwise semantic fallback "Heating Circuit N (0xII)" etc.
- Add B509 to the tree in parallel with B524 as range nodes; B509 rows appear in State tab.
- Change default B509 dump range to 0x0000..0x00FF.

Tests: ruff, mypy, pytest