### PR TITLE
Abort on ebusd 'command not enabled' (require --enablehex)

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/b509.py
+++ b/src/helianthus_vrc_explorer/scanner/b509.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol, TypedDict
 from ..protocol.b509 import build_b509_register_read_payload
 from ..protocol.parser import ValueParseError, parse_typed_value
 from ..schema.ebusd_csv import EbusdCsvSchema
-from ..transport.base import TransportError, TransportTimeout
+from ..transport.base import TransportCommandNotEnabled, TransportError, TransportTimeout
 from .observer import ScanObserver
 from .plan import parse_int_token
 
@@ -172,6 +172,8 @@ def scan_b509(
                 except TransportTimeout:
                     error = "timeout"
                 except TransportError as exc:
+                    if isinstance(exc, TransportCommandNotEnabled):
+                        raise
                     error = f"transport_error: {exc}"
 
                 read_count += 1

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from typing import Final, TypedDict
 
 from ..protocol.b524 import build_directory_probe_payload
-from ..transport.base import TransportError, TransportInterface, TransportTimeout
+from ..transport.base import (
+    TransportCommandNotEnabled,
+    TransportError,
+    TransportInterface,
+    TransportTimeout,
+)
 from .observer import ScanObserver
 
 logger = logging.getLogger(__name__)
@@ -92,6 +97,8 @@ def discover_groups(
             # NaN streak.
             continue
         except TransportError as exc:
+            if isinstance(exc, TransportCommandNotEnabled):
+                raise
             logger.warning("Directory probe transport error for GG=0x%02X: %s", gg, exc)
             if observer is not None:
                 observer.log(

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -6,7 +6,13 @@ from typing import Final, NotRequired, TypedDict
 
 from ..protocol.b524 import RegisterOpcode, build_register_read_payload
 from ..protocol.parser import ValueParseError, parse_typed_value
-from ..transport.base import TransportError, TransportInterface, TransportTimeout, emit_trace_label
+from ..transport.base import (
+    TransportCommandNotEnabled,
+    TransportError,
+    TransportInterface,
+    TransportTimeout,
+    emit_trace_label,
+)
 from .observer import ScanObserver
 
 logger = logging.getLogger(__name__)
@@ -216,6 +222,8 @@ def read_register(
             "error": "timeout",
         }
     except TransportError as exc:
+        if isinstance(exc, TransportCommandNotEnabled):
+            raise
         return {
             "read_opcode": read_opcode,
             "reply_hex": None,

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -17,7 +17,12 @@ from rich.console import Console
 from ..protocol.b524 import RegisterOpcode, build_constraint_probe_payload
 from ..schema.ebusd_csv import EbusdCsvSchema
 from ..schema.myvaillant_map import MyvaillantRegisterMap
-from ..transport.base import TransportError, TransportInterface, emit_trace_label
+from ..transport.base import (
+    TransportCommandNotEnabled,
+    TransportError,
+    TransportInterface,
+    emit_trace_label,
+)
 from ..transport.instrumented import CountingTransport
 from ..ui.planner import PlannerGroup, PlannerPreset, build_plan_from_preset, prompt_scan_plan
 from .b509 import scan_b509
@@ -176,7 +181,9 @@ def _probe_group_constraints(
             payload = build_constraint_probe_payload(group=group, register=rr)
             try:
                 response = transport.send(dst, payload)
-            except TransportError:
+            except TransportError as exc:
+                if isinstance(exc, TransportCommandNotEnabled):
+                    raise
                 continue
             except Exception:
                 continue

--- a/src/helianthus_vrc_explorer/transport/base.py
+++ b/src/helianthus_vrc_explorer/transport/base.py
@@ -12,6 +12,14 @@ class TransportTimeout(TransportError):
     """Raised when a transport request times out."""
 
 
+class TransportCommandNotEnabled(TransportError):
+    """Raised when ebusd rejects a command because it is not enabled.
+
+    Most commonly this happens when the `hex` command is disabled and ebusd is not
+    started with `--enablehex`.
+    """
+
+
 class TransportInterface(ABC):
     """Transport interface for sending B524 payloads and receiving raw responses."""
 

--- a/src/helianthus_vrc_explorer/transport/ebusd_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/ebusd_tcp.py
@@ -12,7 +12,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final
 
-from .base import TransportError, TransportInterface, TransportTimeout
+from .base import (
+    TransportCommandNotEnabled,
+    TransportError,
+    TransportInterface,
+    TransportTimeout,
+)
 
 
 @dataclass(frozen=True)
@@ -118,6 +123,8 @@ def _parse_ebusd_response_lines(lines: Sequence[str]) -> bytes:
 
         if line.lower().startswith("err"):
             lowered = line.lower()
+            if "command not enabled" in lowered:
+                raise TransportCommandNotEnabled(line)
             if "timeout" in lowered or "timed out" in lowered or "no answer" in lowered:
                 raise TransportTimeout(line)
             raise TransportError(line)
@@ -156,6 +163,8 @@ def _parse_ebusd_info_lines(lines: Sequence[str]) -> None:
             continue
         if line.lower().startswith("err"):
             lowered = line.lower()
+            if "command not enabled" in lowered:
+                raise TransportCommandNotEnabled(line)
             if "timeout" in lowered or "timed out" in lowered or "no answer" in lowered:
                 raise TransportTimeout(line)
             raise TransportError(line)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -11,6 +11,7 @@ from queue import Queue
 import pytest
 
 from helianthus_vrc_explorer.transport.base import (
+    TransportCommandNotEnabled,
     TransportError,
     TransportTimeout,
     emit_trace_label,
@@ -168,6 +169,11 @@ def test_parse_ebusd_response_lines_returns_first_hex_payload_line() -> None:
 def test_parse_ebusd_response_lines_timeout_errors_raise_transport_timeout(line: str) -> None:
     with pytest.raises(TransportTimeout, match=r"ERR:"):
         _parse_ebusd_response_lines([line])
+
+
+def test_parse_ebusd_response_lines_command_not_enabled_raises() -> None:
+    with pytest.raises(TransportCommandNotEnabled, match=r"command not enabled"):
+        _parse_ebusd_response_lines(["ERR: command not enabled"])
 
 
 def test_transport_send_parses_multiline_response_and_ignores_trailing_err() -> None:


### PR DESCRIPTION
When ebusd returns `ERR: command not enabled` (typically because the `hex` command is disabled), abort immediately and show a clear instruction to restart ebusd with `--enablehex`.

Changes:
- Add `TransportCommandNotEnabled` and raise it from ebusd TCP parsing.
- Treat it as fatal across scan/discovery helpers (do not continue probing/register loops).
- CLI `scan`/`discover` exit with code 2 and print the `--enablehex` hint.
- Tests for parsing + fatal propagation.