### PR TITLE
Render *emphasis* in eBUS model names

### DIFF
--- a/data/ebus_model_names.csv
+++ b/data/ebus_model_names.csv
@@ -1,8 +1,14 @@
 ebus_model,friendly_name
-BASS2,Wireless 720-series Regulator Base Station Saunier Duval-branded Revision 2
-BASV2,Wireless 720-series Regulator Base Station Vaillant-branded Revision 2
-BASV3,Wireless 720-series Regulator Base Station Vaillant-branded Revision 3
-CTLV2,Wired 720-series Regulator Vaillant-branded Revision 2
-CTLV3,Wired 720-series Regulator Vaillant-branded Revision 3
-CTLS2,Wired 720-series Regulator Saunier Duval-branded Revision 2
-CTLS3,Wired 720-series Regulator Saunier Duval-branded Revision 3
+72000,Wired 720-series Regulator Controller Revision 0
+BASS0,Wireless 720-series Regulator *BA*se *S*tation *S*aunier Duval-branded Revision 1 (implied)
+BASS2,Wireless 720-series Regulator *BA*se *S*tation *S*aunier Duval-branded Revision *2*
+BASS3,Wireless 720-series Regulator *BA*se *S*tation *S*aunier Duval-branded Revision *3*
+BASV0,Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision 1 (implied)
+BASV2,Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *2*
+BASV3,Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *3*
+CTLS0,Wired 720-series Regulator *C*on*T*ro*L*ler *S*aunier Duval-branded Revision 1 (implied)
+CTLS2,Wired 720-series Regulator *C*on*T*ro*L*ler *S*aunier Duval-branded Revision *2*
+CTLS3,Wired 720-series Regulator *C*on*T*ro*L*ler *S*aunier Duval-branded Revision *3*
+CTLV0,Wired 720-series Regulator *C*on*T*ro*L*ler *V*aillant-branded Revision 1 (implied)
+CTLV2,Wired 720-series Regulator *C*on*T*ro*L*ler *V*aillant-branded Revision *2*
+CTLV3,Wired 720-series Regulator *C*on*T*ro*L*ler *V*aillant-branded Revision *3*

--- a/src/helianthus_vrc_explorer/data/ebus_model_names.csv
+++ b/src/helianthus_vrc_explorer/data/ebus_model_names.csv
@@ -1,8 +1,14 @@
 ebus_model,friendly_name
-BASS2,Wireless 720-series Regulator Base Station Saunier Duval-branded Revision 2
-BASV2,Wireless 720-series Regulator Base Station Vaillant-branded Revision 2
-BASV3,Wireless 720-series Regulator Base Station Vaillant-branded Revision 3
-CTLV2,Wired 720-series Regulator Vaillant-branded Revision 2
-CTLV3,Wired 720-series Regulator Vaillant-branded Revision 3
-CTLS2,Wired 720-series Regulator Saunier Duval-branded Revision 2
-CTLS3,Wired 720-series Regulator Saunier Duval-branded Revision 3
+72000,Wired 720-series Regulator Controller Revision 0
+BASS0,Wireless 720-series Regulator *BA*se *S*tation *S*aunier Duval-branded Revision 1 (implied)
+BASS2,Wireless 720-series Regulator *BA*se *S*tation *S*aunier Duval-branded Revision *2*
+BASS3,Wireless 720-series Regulator *BA*se *S*tation *S*aunier Duval-branded Revision *3*
+BASV0,Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision 1 (implied)
+BASV2,Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *2*
+BASV3,Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *3*
+CTLS0,Wired 720-series Regulator *C*on*T*ro*L*ler *S*aunier Duval-branded Revision 1 (implied)
+CTLS2,Wired 720-series Regulator *C*on*T*ro*L*ler *S*aunier Duval-branded Revision *2*
+CTLS3,Wired 720-series Regulator *C*on*T*ro*L*ler *S*aunier Duval-branded Revision *3*
+CTLV0,Wired 720-series Regulator *C*on*T*ro*L*ler *V*aillant-branded Revision 1 (implied)
+CTLV2,Wired 720-series Regulator *C*on*T*ro*L*ler *V*aillant-branded Revision *2*
+CTLV3,Wired 720-series Regulator *C*on*T*ro*L*ler *V*aillant-branded Revision *3*

--- a/src/helianthus_vrc_explorer/ui/live.py
+++ b/src/helianthus_vrc_explorer/ui/live.py
@@ -55,12 +55,35 @@ class ScanSessionPreface:
     rows: tuple[tuple[str, str], ...]
 
 
+def _render_star_bold(text: str) -> Text:
+    """Render `*like this*` segments as bold, stripping the `*` markers.
+
+    We keep the underlying CSV values human-editable without forcing Rich markup.
+    """
+
+    out = Text()
+    cursor = 0
+    while True:
+        start = text.find("*", cursor)
+        if start < 0:
+            out.append(text[cursor:])
+            break
+        end = text.find("*", start + 1)
+        if end < 0:
+            out.append(text[cursor:])
+            break
+        out.append(text[cursor:start])
+        out.append(text[start + 1 : end], style="bold")
+        cursor = end + 1
+    return out
+
+
 def _render_session_preface(preface: ScanSessionPreface) -> Panel:
     rows = Table.grid(expand=True)
     rows.add_column(style="bold")
     rows.add_column()
     for label, value in preface.rows:
-        rows.add_row(f"{label}:", value)
+        rows.add_row(f"{label}:", _render_star_bold(value))
 
     body = Group(
         Text(preface.app_line, style="bold"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -340,7 +340,8 @@ def test_default_dry_run_fixture_is_bundled() -> None:
 def test_default_ebus_model_name_map_includes_basv2() -> None:
     names = _load_ebus_model_name_map()
     assert (
-        names["BASV2"] == "Wireless 720-series Regulator Base Station Vaillant-branded Revision 2"
+        names["BASV2"]
+        == "Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *2*"
     )
 
 
@@ -466,7 +467,7 @@ def test_probe_scan_identity_formats_basv2_friendly_name() -> None:
     identity = _probe_scan_identity(_FakeTransportBasv(), dst=0x15)  # type: ignore[arg-type]
     assert (
         identity["device"]
-        == "Wireless 720-series Regulator Base Station Vaillant-branded Revision 2 (BASV2)"
+        == "Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *2* (BASV2)"
     )
     assert identity["model"] == "Vaillant sensoCOMFORT RF (VRC 720f/2) 0020262148"
     assert identity["serial"] == "21213400202621480000000001N7"

--- a/tests/test_ebus_model_names.py
+++ b/tests/test_ebus_model_names.py
@@ -10,7 +10,7 @@ def test_ebus_model_name_map_contains_basv2() -> None:
         rows = {str(row.get("ebus_model") or "").strip(): row for row in csv.DictReader(handle)}
     assert (
         rows["BASV2"]["friendly_name"]
-        == "Wireless 720-series Regulator Base Station Vaillant-branded Revision 2"
+        == "Wireless 720-series Regulator *BA*se *S*tation *V*aillant-branded Revision *2*"
     )
 
 


### PR DESCRIPTION
- Expand `ebus_model_names.csv` with 720-series BAS/CTL variants and simple `*...*` emphasis markers
- Render `*...*` segments as bold in the Rich session preface (scan TUI)
- Keep repo + packaged CSV copies in sync and update tests
