### PR TITLE
B524 fallback: skip unsupported op=00 and continue with B509

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -55,6 +55,10 @@ class ClassifiedGroup:
     descriptor_mismatch: bool
 
 
+class B524UnsupportedError(RuntimeError):
+    """Raised when directory probing indicates B524 is unsupported on target."""
+
+
 def _parse_directory_descriptor(resp: bytes, group: int) -> float:
     if len(resp) < 4:
         # A short response isn't evidence of a terminator (NaN). Treat it as a transient
@@ -106,6 +110,11 @@ def discover_groups(
                     level="warn",
                 )
             continue
+
+        if gg == 0x00 and resp == b"\x00":
+            raise B524UnsupportedError(
+                "B524 unsupported: directory probe GG=0x00 returned status-only 0x00"
+            )
 
         try:
             descriptor = _parse_directory_descriptor(resp, gg)

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -26,7 +26,7 @@ from ..transport.base import (
 from ..transport.instrumented import CountingTransport
 from ..ui.planner import PlannerGroup, PlannerPreset, build_plan_from_preset, prompt_scan_plan
 from .b509 import scan_b509
-from .director import GROUP_CONFIG, classify_groups, discover_groups
+from .director import GROUP_CONFIG, B524UnsupportedError, classify_groups, discover_groups
 from .observer import ScanObserver
 from .plan import GroupScanPlan, RegisterTask, build_work_queue, estimate_register_requests
 from .register import RegisterEntry, is_instance_present, opcode_for_group, read_register
@@ -554,7 +554,16 @@ def scan_b524(
         emit_trace_label(transport, "Discovering Groups")
         group_discovery_start = time.perf_counter()
         group_discovery_start_calls = counting_transport.counters.send_calls
-        discovered = discover_groups(transport, dst=dst, observer=observer)
+        try:
+            discovered = discover_groups(transport, dst=dst, observer=observer)
+        except B524UnsupportedError as exc:
+            if observer is not None:
+                observer.phase_finish("group_discovery")
+                observer.log(str(exc), level="warn")
+            artifact["meta"]["b524_supported"] = False
+            artifact["meta"]["b524_skip_reason"] = "first_directory_probe_no_data"
+            artifact["meta"]["scan_duration_seconds"] = round(time.perf_counter() - start_perf, 4)
+            return artifact
         group_discovery_duration_s = time.perf_counter() - group_discovery_start
         group_discovery_requests = (
             counting_transport.counters.send_calls - group_discovery_start_calls

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -173,16 +173,18 @@ class BrowseStore:
                 _row_by_id={},
             )
 
-        tree_nodes.append(
-            TreeNodeRef(
-                node_id="proto:b524",
-                label="B524",
-                level="protocol",
-                protocol="b524",
+        group_keys = sorted((k for k in groups if isinstance(k, str)), key=_safe_int_hex)
+        if group_keys:
+            tree_nodes.append(
+                TreeNodeRef(
+                    node_id="proto:b524",
+                    label="B524",
+                    level="protocol",
+                    protocol="b524",
+                )
             )
-        )
 
-        for group_key in sorted((k for k in groups if isinstance(k, str)), key=_safe_int_hex):
+        for group_key in group_keys:
             group_obj = groups.get(group_key)
             if not isinstance(group_obj, dict):
                 continue

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -106,3 +106,31 @@ def test_browse_store_prefers_register_class_over_tt_kind_for_tab() -> None:
     row = store.rows[0]
     assert row.register_key == "0x0021"
     assert row.tab == "state"
+
+
+def test_browse_store_hides_b524_protocol_when_no_groups_present() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {},
+        "b509_dump": {
+            "meta": {"ranges": ["0x2700..0x2700"]},
+            "devices": {
+                "0x15": {
+                    "registers": {
+                        "0x2700": {
+                            "addr": "0x2700",
+                            "reply_hex": "00",
+                            "raw_hex": "",
+                            "value": None,
+                            "error": None,
+                        }
+                    }
+                }
+            },
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    node_ids = {node.node_id for node in store.tree_nodes}
+    assert "proto:b524" not in node_ids
+    assert "proto:b509" in node_ids

--- a/tests/test_scanner_b509.py
+++ b/tests/test_scanner_b509.py
@@ -44,6 +44,37 @@ class _HybridTransport(TransportInterface):
         raise TransportError("unmapped register")
 
 
+class _UnsupportedB524HybridTransport(TransportInterface):
+    def __init__(self) -> None:
+        self._send_calls = 0
+
+    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+        self._send_calls += 1
+        if payload == bytes((0x00, 0x00, 0x00)):
+            return bytes.fromhex("00")
+        raise TransportError(f"unexpected b524 payload: {payload.hex()}")
+
+    def send_proto(
+        self,
+        dst: int,
+        primary: int,
+        secondary: int,
+        payload: bytes,
+        *,
+        expect_response: bool = True,
+    ) -> bytes:
+        _ = dst
+        _ = expect_response
+        if primary != 0xB5 or secondary != 0x09:
+            raise TransportError("unexpected proto selector")
+        if len(payload) != 3 or payload[0] != 0x0D:
+            raise TransportError("unexpected b509 payload")
+        register = (payload[1] << 8) | payload[2]
+        if register == 0x2700:
+            return bytes.fromhex("00")
+        raise TransportError("unmapped register")
+
+
 def _write_fixture_group_02(tmp_path: Path) -> Path:
     fixture = {
         "meta": {"dummy_transport": {"directory_terminator_group": "0x05"}},
@@ -85,3 +116,21 @@ def test_scan_vrc_adds_b509_dump_section(tmp_path: Path) -> None:
     assert regs["0x2700"]["reply_hex"] == "00"
     assert regs["0x2701"]["reply_hex"] == "004574616a00"
     assert regs["0x2702"]["error"] == "timeout"
+
+
+def test_scan_vrc_keeps_b509_when_b524_is_unsupported() -> None:
+    artifact = scan_vrc(
+        _UnsupportedB524HybridTransport(),
+        dst=0x15,
+        b509_ranges=[(0x2700, 0x2700)],
+    )
+
+    assert artifact["meta"]["b524_supported"] is False
+    assert artifact["meta"]["b524_skip_reason"] == "first_directory_probe_no_data"
+    assert artifact["groups"] == {}
+    assert artifact["meta"]["incomplete"] is False
+
+    b509_dump = artifact.get("b509_dump")
+    assert isinstance(b509_dump, dict)
+    devices = b509_dump["devices"]
+    assert devices["0x15"]["registers"]["0x2700"]["reply_hex"] == "00"

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -66,6 +66,18 @@ class ConstraintAwareTransport(TransportInterface):
         return self._inner.send(dst, payload)
 
 
+class _B524UnsupportedTransport(TransportInterface):
+    def __init__(self) -> None:
+        self.calls: list[bytes] = []
+
+    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+        self.calls.append(payload)
+        if payload == bytes((0x00, 0x00, 0x00)):
+            # status-only "no data" on first directory probe => unsupported B524
+            return b"\x00"
+        raise AssertionError(f"Unexpected payload after unsupported probe: {payload.hex()}")
+
+
 def _write_fixture_group_02(tmp_path: Path) -> Path:
     fixture = {
         "meta": {"dummy_transport": {"directory_terminator_group": "0x05"}},
@@ -219,6 +231,36 @@ def test_scan_b524_scans_all_instances_and_register_range(tmp_path: Path) -> Non
         rr for (gg, ii, rr) in transport.register_reads if gg == 0x02 and ii == 0x00
     }
     assert scanned_registers == set(range(0x25 + 1))
+
+
+def test_scan_b524_skips_flow_when_first_directory_probe_is_status_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    transport = _B524UnsupportedTransport()
+
+    def _unexpected_planner(*_args, **_kwargs):
+        raise AssertionError("planner should not run when B524 is unsupported")
+
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", _unexpected_planner)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+    )
+
+    assert artifact["meta"]["incomplete"] is False
+    assert artifact["meta"]["b524_supported"] is False
+    assert artifact["meta"]["b524_skip_reason"] == "first_directory_probe_no_data"
+    assert artifact["groups"] == {}
+    assert transport.calls == [bytes((0x00, 0x00, 0x00))]
 
 
 def test_scan_b524_collects_constraint_dictionary_entries(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- detect unsupported B524 early: if the very first directory probe (`opcode=0x00`, `GG=0x00`) returns status-only `00`, abort B524 scan path for this session.
- skip planner + register scan in this case and return an artifact with `groups={}` plus explicit metadata:
  - `meta.b524_supported=false`
  - `meta.b524_skip_reason=first_directory_probe_no_data`
- keep `scan_vrc` flow intact so B509 dump still runs.
- hide empty B524 protocol node in browse tree when there are no B524 groups.

## Tests
- `tests/test_scanner_scan.py`
  - added `test_scan_b524_skips_flow_when_first_directory_probe_is_status_only`
  - verifies no planner invocation and no B524 groups when first probe is `00`.
- `tests/test_scanner_b509.py`
  - added `test_scan_vrc_keeps_b509_when_b524_is_unsupported`
  - verifies B509 dump still executes in fallback path.
- `tests/test_browse_store.py`
  - added `test_browse_store_hides_b524_protocol_when_no_groups_present`
  - verifies tree shows only B509 node.

## Validation
- `PYTHONPATH=src .venv/bin/python -m ruff check src/helianthus_vrc_explorer/scanner/director.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/ui/browse_store.py tests/test_scanner_scan.py tests/test_scanner_b509.py tests/test_browse_store.py`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_scanner_scan.py tests/test_scanner_b509.py tests/test_browse_store.py`

Closes #108
