### PR TITLE
scanner: align GROUP_CONFIG names and safe limits

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -29,14 +29,14 @@ class GroupConfig(TypedDict):
 # Source of truth: `AGENTS.md` (keep in sync).
 GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
     0x00: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x00FF},
-    0x01: {"desc": 3.0, "name": "Hot Water Circuit", "ii_max": 0x00, "rr_max": 0x1F},
+    0x01: {"desc": 3.0, "name": "Hot Water Circuit", "ii_max": 0x00, "rr_max": 0x13},
     0x02: {"desc": 1.0, "name": "Heating Circuits", "ii_max": 0x0A, "rr_max": 0x25},
     0x03: {"desc": 1.0, "name": "Zones", "ii_max": 0x0A, "rr_max": 0x2F},
-    0x04: {"desc": 6.0, "name": "Solar Circuit", "ii_max": 0x00, "rr_max": 0x0F},
-    0x05: {"desc": 1.0, "name": "Hot Water Cylinder", "ii_max": 0x0A, "rr_max": 0x0F},
-    0x09: {"desc": 1.0, "name": "RoomSensors", "ii_max": 0x0A, "rr_max": 0x2F},
-    0x0A: {"desc": 1.0, "name": "RoomState", "ii_max": 0x0A, "rr_max": 0x3F},
-    0x0C: {"desc": 1.0, "name": "Unrecognized", "ii_max": 0x0A, "rr_max": 0x3F},
+    0x04: {"desc": 6.0, "name": "Solar Circuit", "ii_max": 0x00, "rr_max": 0x0B},
+    0x05: {"desc": 1.0, "name": "Hot Water Cylinder", "ii_max": 0x01, "rr_max": 0x04},
+    0x09: {"desc": 1.0, "name": "Radio Sensors VRC7xx", "ii_max": 0x0A, "rr_max": 0x2F},
+    0x0A: {"desc": 1.0, "name": "Radio Sensors VR92", "ii_max": 0x0A, "rr_max": 0x3F},
+    0x0C: {"desc": 1.0, "name": "Remote Accessories / FM5 Slots", "ii_max": 0x0A, "rr_max": 0x2F},
 }
 
 

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -123,6 +123,13 @@ def test_group_00_rr_max_is_0x00ff() -> None:
     assert GROUP_CONFIG[0x00]["rr_max"] == 0x00FF
 
 
+def test_group_names_match_docs() -> None:
+    assert len(GROUP_CONFIG) == 9
+    assert GROUP_CONFIG[0x09]["name"] == "Radio Sensors VRC7xx"
+    assert GROUP_CONFIG[0x0A]["name"] == "Radio Sensors VR92"
+    assert GROUP_CONFIG[0x0C]["name"] == "Remote Accessories / FM5 Slots"
+
+
 def test_discover_groups_command_not_enabled_is_fatal() -> None:
     with pytest.raises(TransportCommandNotEnabled):
         discover_groups(FatalDirectoryTransport(), dst=0x15)


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: In review
Branch: codex/issue/114-group-config-names-safe-limits
Last verified (lint/tests): pytest -q tests/test_scanner_director.py PASS; ruff check . PASS; python scripts/check_protocol_terminology.py PASS; python scripts/check_docs_sync.py PASS; ruff format . made no changes; full pytest has one unrelated local failure in tests/test_scanner_scan.py::test_scan_b524_replan_textual_failure_prompts_classic_immediately; local mypy src hangs under the current Python 3.14 venv.
How to reproduce: checkout this branch, activate venv, run the commands above from repo root.
Next steps: wait for CI on Python 3.12, complete review, squash-merge if green.
Notes (no secrets, no private infra): This PR intentionally limits scope to GROUP_CONFIG naming and safe rr/ii reductions. No dual-namespace changes are included.
```

## Summary
- align B524 group names for 0x09, 0x0A, and 0x0C with the current docs terminology
- apply only safe rr_max reductions for 0x01, 0x04, 0x05, and 0x0C
- reduce GG=0x05 ii_max to the proof-backed two-instance range
- add a focused docs-parity test for the renamed groups

## Linked Issue
- Closes #114

## Checklist
- [x] `ruff check .`
- [x] `python scripts/check_protocol_terminology.py`
- [x] `python scripts/check_docs_sync.py`
- [x] `ruff format .`
- [ ] `pytest`
- [x] Manual SSH integration test (if required by the issue): NO
- [x] Audit: no private identifiers introduced (IPs other than 127.0.0.1, serial numbers, hostnames, internal repo names)

## Notes
- Local full `pytest` failure is outside this diff (`scan.py`/textual replanning path not touched here).
- Local `mypy src` appears blocked in the current Python 3.14 venv; CI on Python 3.12 is the authoritative signal for this PR.