### PR TITLE
scanner: rename TT to FLAGS and fix access semantics

### DIFF
--- a/fixtures/demo_browse.json
+++ b/fixtures/demo_browse.json
@@ -34,8 +34,8 @@
               "raw_hex": "122109",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 1,
-              "tt_kind": "live",
+              "flags": 1,
+              "flags_access": "stable_ro",
               "type": "HTI",
               "value": "12:21:09"
             },
@@ -46,8 +46,8 @@
               "raw_hex": "01",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 3,
-              "tt_kind": "parameter_config",
+              "flags": 3,
+              "flags_access": "user_rw",
               "type": "BOOL",
               "value": true
             },
@@ -58,8 +58,8 @@
               "raw_hex": "010113",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 3,
-              "tt_kind": "parameter_config",
+              "flags": 3,
+              "flags_access": "user_rw",
               "type": "HDA:3",
               "value": "2013-01-01"
             }
@@ -81,8 +81,8 @@
               "raw_hex": "01",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 3,
-              "tt_kind": "parameter_config",
+              "flags": 3,
+              "flags_access": "user_rw",
               "type": "UCH",
               "value": 1
             },
@@ -93,8 +93,8 @@
               "raw_hex": "00004842",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 2,
-              "tt_kind": "parameter_limit",
+              "flags": 2,
+              "flags_access": "technical_rw",
               "type": "EXP",
               "value": 50.0
             },
@@ -105,8 +105,8 @@
               "raw_hex": "00004242",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 1,
-              "tt_kind": "live",
+              "flags": 1,
+              "flags_access": "stable_ro",
               "type": "EXP",
               "value": 48.5
             }
@@ -128,8 +128,8 @@
               "raw_hex": "00003642",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 1,
-              "tt_kind": "live",
+              "flags": 1,
+              "flags_access": "stable_ro",
               "type": "EXP",
               "value": 45.5
             },
@@ -140,8 +140,8 @@
               "raw_hex": "9a99d93f",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 3,
-              "tt_kind": "parameter_config",
+              "flags": 3,
+              "flags_access": "user_rw",
               "type": "EXP",
               "value": 1.7
             },
@@ -152,8 +152,8 @@
               "raw_hex": "00008c42",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 2,
-              "tt_kind": "parameter_limit",
+              "flags": 2,
+              "flags_access": "technical_rw",
               "type": "EXP",
               "value": 70.0
             }
@@ -175,8 +175,8 @@
               "raw_hex": "0000b041",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 2,
-              "tt_kind": "parameter_limit",
+              "flags": 2,
+              "flags_access": "technical_rw",
               "type": "EXP",
               "value": 22.0
             },
@@ -187,8 +187,8 @@
               "raw_hex": "0000a841",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 1,
-              "tt_kind": "live",
+              "flags": 1,
+              "flags_access": "stable_ro",
               "type": "EXP",
               "value": 21.0
             },
@@ -199,8 +199,8 @@
               "raw_hex": "5a6f6e65203100",
               "read_opcode": "0x02",
               "reply_hex": null,
-              "tt": 3,
-              "tt_kind": "parameter_config",
+              "flags": 3,
+              "flags_access": "user_rw",
               "type": "STR:*",
               "value": "Zone 1"
             }

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -25,12 +25,12 @@ class RegisterEntry(TypedDict):
     # B524 register read opcode family used for this entry: 0x02 (local) or 0x06 (remote).
     read_opcode: str
     # Full raw reply payload (after ebusd length-prefix stripping), if available.
-    # For register reads this is typically: <TT> <GG> <RR_LO> <RR_HI> <VALUE_BYTES...>
+    # For register reads this is typically: <FLAGS> <GG> <RR_LO> <RR_HI> <VALUE_BYTES...>
     reply_hex: str | None
-    # TT byte extracted from the reply, if present.
-    tt: int | None
-    # Interpretation of TT (see user-observed semantics).
-    tt_kind: str | None
+    # FLAGS byte extracted from the reply, if present.
+    flags: int | None
+    # Access semantics derived from FLAGS and payload shape.
+    flags_access: str | None
     # Optional register name annotations.
     ebusd_name: str | None
     myvaillant_name: str | None
@@ -56,25 +56,23 @@ def opcode_for_group(group: int) -> RegisterOpcode:
     return 0x06 if group in _REMOTE_GROUPS else 0x02
 
 
-def _interpret_tt(tt: int) -> str:
-    """Interpret the leading TT byte of a B524 register reply.
+def _interpret_flags(flags: int, *, response_len: int) -> str:
+    """Interpret the leading FLAGS byte of a B524 register reply."""
 
-    User-observed semantics:
-    - 0x00: no data / not present / invalid
-    - 0x01: live/operational value
-    - 0x02: parameter/limit
-    - 0x03: parameter/config
-    """
+    if response_len == 1:
+        if flags == 0x00:
+            return "absent"
+        return "unknown_status"
 
-    match tt:
+    match flags:
         case 0x00:
-            return "no_data"
+            return "volatile_ro"
         case 0x01:
-            return "live"
+            return "stable_ro"
         case 0x02:
-            return "parameter_limit"
+            return "technical_rw"
         case 0x03:
-            return "parameter_config"
+            return "user_rw"
         case _:
             return "unknown"
 
@@ -212,8 +210,8 @@ def read_register(
         return {
             "read_opcode": read_opcode,
             "reply_hex": None,
-            "tt": None,
-            "tt_kind": None,
+            "flags": None,
+            "flags_access": None,
             "ebusd_name": None,
             "myvaillant_name": None,
             "raw_hex": None,
@@ -227,8 +225,8 @@ def read_register(
         return {
             "read_opcode": read_opcode,
             "reply_hex": None,
-            "tt": None,
-            "tt_kind": None,
+            "flags": None,
+            "flags_access": None,
             "ebusd_name": None,
             "myvaillant_name": None,
             "raw_hex": None,
@@ -238,17 +236,19 @@ def read_register(
         }
 
     reply_hex = response.hex()
-    tt: int | None = response[0] if response else None
-    tt_kind: str | None = _interpret_tt(tt) if tt is not None else None
+    flags: int | None = response[0] if response else None
+    flags_access: str | None = (
+        _interpret_flags(flags, response_len=len(response)) if flags is not None else None
+    )
 
     # Some registers respond with a single status byte (no GG/RR echo and no value bytes).
-    # We treat this as a valid "no data" reply rather than a decoder bug.
+    # We treat this as a valid "absent register" reply rather than a decoder bug.
     if len(response) == 1:
         return {
             "read_opcode": read_opcode,
             "reply_hex": reply_hex,
-            "tt": tt,
-            "tt_kind": tt_kind,
+            "flags": flags,
+            "flags_access": flags_access,
             "ebusd_name": None,
             "myvaillant_name": None,
             "raw_hex": None,
@@ -263,8 +263,8 @@ def read_register(
         return {
             "read_opcode": read_opcode,
             "reply_hex": reply_hex,
-            "tt": tt,
-            "tt_kind": tt_kind,
+            "flags": flags,
+            "flags_access": flags_access,
             "ebusd_name": None,
             "myvaillant_name": None,
             "raw_hex": None,
@@ -280,8 +280,8 @@ def read_register(
             return {
                 "read_opcode": read_opcode,
                 "reply_hex": reply_hex,
-                "tt": tt,
-                "tt_kind": tt_kind,
+                "flags": flags,
+                "flags_access": flags_access,
                 "ebusd_name": None,
                 "myvaillant_name": None,
                 "raw_hex": raw_hex,
@@ -293,8 +293,8 @@ def read_register(
             return {
                 "read_opcode": read_opcode,
                 "reply_hex": reply_hex,
-                "tt": tt,
-                "tt_kind": tt_kind,
+                "flags": flags,
+                "flags_access": flags_access,
                 "ebusd_name": None,
                 "myvaillant_name": None,
                 "raw_hex": raw_hex,
@@ -307,8 +307,8 @@ def read_register(
     return {
         "read_opcode": read_opcode,
         "reply_hex": reply_hex,
-        "tt": tt,
-        "tt_kind": tt_kind,
+        "flags": flags,
+        "flags_access": flags_access,
         "ebusd_name": None,
         "myvaillant_name": None,
         "raw_hex": raw_hex,
@@ -332,7 +332,7 @@ def is_instance_present(transport: TransportInterface, dst: int, group: int, ins
         )
         if entry["error"] is not None:
             return False
-        if entry.get("tt_kind") == "no_data":
+        if entry.get("flags_access") == "absent":
             return False
         value = entry["value"]
         if value is None:
@@ -347,7 +347,7 @@ def is_instance_present(transport: TransportInterface, dst: int, group: int, ins
         )
         if entry["error"] is not None:
             return False
-        if entry.get("tt_kind") == "no_data":
+        if entry.get("flags_access") == "absent":
             return False
         value = entry["value"]
         if not isinstance(value, int) or isinstance(value, bool):
@@ -361,7 +361,7 @@ def is_instance_present(transport: TransportInterface, dst: int, group: int, ins
         value_1 = entry_1["value"]
         if (
             entry_1["error"] is None
-            and entry_1.get("tt_kind") != "no_data"
+            and entry_1.get("flags_access") != "absent"
             and value_1 is not None
             and not (isinstance(value_1, float) and math.isnan(value_1))
         ):
@@ -372,7 +372,7 @@ def is_instance_present(transport: TransportInterface, dst: int, group: int, ins
         value_2 = entry_2["value"]
         return (
             entry_2["error"] is None
-            and entry_2.get("tt_kind") != "no_data"
+            and entry_2.get("flags_access") != "absent"
             and value_2 is not None
             and not (isinstance(value_2, float) and math.isnan(value_2))
         )
@@ -380,7 +380,7 @@ def is_instance_present(transport: TransportInterface, dst: int, group: int, ins
     if group == 0x0C:
         for rr in (0x0002, 0x0007, 0x000F, 0x0016):
             entry = read_register(transport, dst, 0x06, group=group, instance=instance, register=rr)
-            if entry["error"] is None and entry.get("tt_kind") != "no_data":
+            if entry["error"] is None and entry.get("flags_access") != "absent":
                 return True
         return False
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -246,7 +246,7 @@ def _entry_has_valid_value(entry: RegisterEntry) -> bool:
 
     if entry.get("error") is not None:
         return False
-    if entry.get("tt_kind") == "no_data":
+    if entry.get("flags_access") == "absent":
         return False
     raw_hex = entry.get("raw_hex")
     if raw_hex in (None, ""):

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -45,10 +45,10 @@ def _tab_from_entry(entry: dict[str, Any]) -> BrowseTab:
     if register_class == "state":
         return "state"
 
-    tt_kind = entry.get("tt_kind")
-    if tt_kind == "parameter_config":
+    flags_access = entry.get("flags_access")
+    if flags_access == "user_rw":
         return "config"
-    if tt_kind == "parameter_limit":
+    if flags_access == "technical_rw":
         return "config_limits"
     return "state"
 

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -931,7 +931,8 @@ __ARTIFACT_JSON__
             }
 
             const tipParts = [];
-            if (entry.tt_kind) tipParts.push(`tt_kind=${entry.tt_kind}`);
+            if (typeof entry.flags !== "undefined" && entry.flags !== null) tipParts.push(`flags=${entry.flags}`);
+            if (entry.flags_access) tipParts.push(`flags_access=${entry.flags_access}`);
             if (entry.reply_hex) tipParts.push(`reply_hex=${entry.reply_hex}`);
             if (entry.type) tipParts.push(`original_type=${entry.type}`);
             if (typeof entry.value !== "undefined") tipParts.push(`original_value=${formatValue(entry.value)}`);

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -18,7 +18,7 @@ def _sample_artifact() -> dict[str, object]:
                             "0x0001": {
                                 "value": 1.0,
                                 "raw_hex": "00",
-                                "tt_kind": "parameter_config",
+                                "flags_access": "user_rw",
                                 "read_opcode": "0x02",
                                 "ebusd_name": "regulator_param_1",
                             },
@@ -26,14 +26,14 @@ def _sample_artifact() -> dict[str, object]:
                                 "value": 2.0,
                                 "value_display": "HEATING_OR_COOLING (HEATING)",
                                 "raw_hex": "0102",
-                                "tt_kind": "parameter_limit",
+                                "flags_access": "technical_rw",
                                 "read_opcode": "0x06",
                                 "myvaillant_name": "limit_value",
                             },
                             "0x0003": {
                                 "value": 3.0,
                                 "raw_hex": "03",
-                                "tt_kind": "live_operational",
+                                "flags_access": "stable_ro",
                                 "read_opcode": "0x02",
                             },
                         }
@@ -81,7 +81,7 @@ def test_browse_store_filters_rows_for_tree_selection() -> None:
     assert len(store.rows_for_selection(group_node, tab="state")) == 1
 
 
-def test_browse_store_prefers_register_class_over_tt_kind_for_tab() -> None:
+def test_browse_store_prefers_register_class_over_flags_access_for_tab() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
         "groups": {
@@ -93,7 +93,7 @@ def test_browse_store_prefers_register_class_over_tt_kind_for_tab() -> None:
                             "0x0021": {
                                 "value": 37,
                                 "raw_hex": "25",
-                                "tt_kind": "parameter_limit",
+                                "flags_access": "technical_rw",
                                 "register_class": "state",
                             }
                         }

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from helianthus_vrc_explorer.scanner.register import is_instance_present, read_register
+from helianthus_vrc_explorer.scanner.register import (
+    _interpret_flags,
+    is_instance_present,
+    read_register,
+)
 from helianthus_vrc_explorer.transport.base import (
     TransportCommandNotEnabled,
     TransportError,
@@ -144,12 +148,23 @@ def test_read_register_status_only_response_is_not_decode_error() -> None:
     )
 
     assert entry["reply_hex"] == "00"
-    assert entry["tt"] == 0x00
-    assert entry["tt_kind"] == "no_data"
+    assert entry["flags"] == 0x00
+    assert entry["flags_access"] == "absent"
     assert entry["raw_hex"] is None
     assert entry["type"] is None
     assert entry["value"] is None
     assert entry["error"] is None
+
+
+def test_flags_interpretation_single_byte() -> None:
+    assert _interpret_flags(0x00, response_len=1) == "absent"
+
+
+def test_flags_interpretation_multi_byte() -> None:
+    assert _interpret_flags(0x00, response_len=7) == "volatile_ro"
+    assert _interpret_flags(0x01, response_len=7) == "stable_ro"
+    assert _interpret_flags(0x02, response_len=7) == "technical_rw"
+    assert _interpret_flags(0x03, response_len=7) == "user_rw"
 
 
 def test_read_register_infers_hex_for_unparseable_u24_values() -> None:
@@ -165,8 +180,8 @@ def test_read_register_infers_hex_for_unparseable_u24_values() -> None:
     )
 
     assert entry["reply_hex"] == "030035000e3803"
-    assert entry["tt"] == 0x03
-    assert entry["tt_kind"] == "parameter_config"
+    assert entry["flags"] == 0x03
+    assert entry["flags_access"] == "user_rw"
     assert entry["raw_hex"] == "0e3803"
     assert entry["type"] == "HEX:3"
     assert entry["value"] == "0x0e3803"


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: In review
Branch: codex/issue/116-flags-byte-rename-and-interpretation
Last verified (lint/tests): targeted impacted tests PASS; ruff check . PASS; python scripts/check_protocol_terminology.py PASS; python scripts/check_docs_sync.py PASS; ruff format . made no changes; full pytest has the same single local failure in tests/test_scanner_scan.py::test_scan_b524_replan_textual_failure_prompts_classic_immediately; local mypy src hangs under the current Python 3.14 venv.
How to reproduce: checkout this branch, activate venv, run the commands above from repo root.
Next steps: wait for CI on Python 3.12, complete review, squash-merge if green.
Notes (no secrets, no private infra): No compatibility layer for old tt/tt_kind fields; all in-repo B524 consumers are migrated together here.
```

## Summary
- rename B524 register artifact fields from `tt` / `tt_kind` to `flags` / `flags_access`
- interpret single-byte `0x00` replies as `absent` while mapping multi-byte `0x00..0x03` replies to access classes
- update scanner presence heuristics, browse-store tab classification, HTML tooltips, fixtures, and tests to the new field names
- add explicit tests for single-byte and multi-byte FLAGS interpretation

## Linked Issue
- Closes #116

## Checklist
- [x] `ruff check .`
- [x] `python scripts/check_protocol_terminology.py`
- [x] `python scripts/check_docs_sync.py`
- [x] `ruff format .`
- [ ] `pytest`
- [x] Manual SSH integration test (if required by the issue): NO
- [x] Audit: no private identifiers introduced (IPs other than 127.0.0.1, serial numbers, hostnames, internal repo names)

## Notes
- Local full `pytest` failure is the same pre-existing Textual replanning test seen before this diff; the touched register/browse/html paths pass locally.
- Local `mypy src` appears blocked in the current Python 3.14 venv; CI on Python 3.12 is the authoritative signal for this PR.