### PR TITLE
scanner: align descriptor zero handling with docs

### DIFF
--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -431,8 +431,9 @@ def _probe_group_descriptor(
         if len(response) < 4:
             continue
         descriptor = struct.unpack("<f", response[:4])[0]
-        if math.isnan(descriptor) or descriptor == 0.0:
+        if math.isnan(descriptor):
             continue
+        # Any valid 4-byte directory reply is transport-level evidence that B524 is supported.
         return descriptor
     return None
 

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class GroupConfig(TypedDict):
+    # Informational: last-observed descriptor value. NOT a structural authority.
     desc: float
     name: str
     ii_max: int
@@ -38,6 +39,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
     0x0A: {"desc": 1.0, "name": "Radio Sensors VR92", "ii_max": 0x0A, "rr_max": 0x3F},
     0x0C: {"desc": 1.0, "name": "Remote Accessories / FM5 Slots", "ii_max": 0x0A, "rr_max": 0x2F},
 }
+KNOWN_CORE_GROUPS: Final[frozenset[int]] = frozenset({0x02, 0x03})
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,7 +81,7 @@ def discover_groups(
     """Phase A: Probe GG=0x00..0xFF via directory probe (opcode 0x00).
 
     Terminator logic: stop on the first NaN descriptor.
-    Holes (descriptor==0.0) are skipped.
+    Descriptor `0.0` is a weak negative hint only: known core groups remain candidates.
     """
 
     discovered: list[DiscoveredGroup] = []
@@ -125,7 +127,18 @@ def discover_groups(
             continue
 
         if descriptor == 0.0:
-            # Hole: skip without changing terminator logic.
+            if gg in KNOWN_CORE_GROUPS:
+                discovered.append(DiscoveredGroup(group=gg, descriptor=descriptor))
+                if observer is not None:
+                    observer.log(
+                        f"GG=0x{gg:02X} descriptor=0.0 but known core group - included",
+                        level="info",
+                    )
+            elif observer is not None:
+                observer.log(
+                    f"GG=0x{gg:02X} descriptor=0.0, non-core group - skipped (weak hint)",
+                    level="info",
+                )
             continue
 
         if math.isnan(descriptor):
@@ -151,7 +164,7 @@ def classify_groups(
 ) -> list[ClassifiedGroup]:
     """Phase C (per issue wording): Map discovered groups using GROUP_CONFIG.
 
-    Emits a warning when a known group's descriptor doesn't match `GROUP_CONFIG`.
+    Descriptors are opaque hints, not structural authority.
     """
 
     classified: list[ClassifiedGroup] = []
@@ -172,7 +185,7 @@ def classify_groups(
         expected = config["desc"]
         mismatch = expected != group.descriptor
         if mismatch:
-            logger.warning(
+            logger.info(
                 "Descriptor mismatch for GG=0x%02X: expected %s, got %s",
                 group.group,
                 expected,
@@ -182,7 +195,7 @@ def classify_groups(
                 observer.log(
                     f"Descriptor mismatch for GG=0x{group.group:02X}: "
                     f"expected {expected}, got {group.descriptor}",
-                    level="warn",
+                    level="info",
                 )
         classified.append(
             ClassifiedGroup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from helianthus_vrc_explorer.cli import (
     _format_fw,
     _load_default_dry_run_fixture_text,
     _load_ebus_model_name_map,
+    _probe_group_descriptor,
     _probe_scan_identity,
     _resolve_scan_destination,
     app,
@@ -556,3 +557,24 @@ def test_resolve_scan_destination_auto_retries_0704_probe_once() -> None:
     assert _resolve_scan_destination(transport, dst="auto") == 0x15
     # 1 wake-up + 2 probe attempts.
     assert transport.send_proto_calls == 3
+
+
+def test_probe_group_descriptor_returns_zero() -> None:
+    transport = _AutoResolveTransport(
+        info_lines=[],
+        ident_payloads={},
+        descriptors={0x15: struct.pack("<f", 0.0)},
+    )
+
+    assert _probe_group_descriptor(transport, dst=0x15, group=0x00) == 0.0
+
+
+def test_resolve_scan_destination_accepts_zero_descriptor() -> None:
+    vaillant_ident = bytes.fromhex("b556524320373230662f3205071704")
+    transport = _AutoResolveTransport(
+        info_lines=[f"address 15: {_ROLE_TARGET_TOKEN}, scanned Vaillant;XYZ"],
+        ident_payloads={0x15: vaillant_ident},
+        descriptors={0x15: struct.pack("<f", 0.0)},
+    )
+
+    assert _resolve_scan_destination(transport, dst="auto") == 0x15

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -8,6 +8,7 @@ import pytest
 
 from helianthus_vrc_explorer.scanner.director import (
     GROUP_CONFIG,
+    KNOWN_CORE_GROUPS,
     DiscoveredGroup,
     classify_groups,
     discover_groups,
@@ -32,15 +33,24 @@ class RecordingTransport(TransportInterface):
         return self._inner.send(dst, payload)
 
 
-def _write_directory_fixture(tmp_path: Path) -> Path:
+def _write_directory_fixture(
+    tmp_path: Path,
+    *,
+    groups: dict[str, dict[str, object]] | None = None,
+    terminator_group: str | None = "0x05",
+) -> Path:
     fixture = {
-        "meta": {"dummy_transport": {"directory_terminator_group": "0x05"}},
-        "groups": {
+        "meta": {"dummy_transport": {}},
+        "groups": groups
+        if groups is not None
+        else {
             "0x00": {"descriptor_type": 3.0, "instances": {}},
             # Intentional hole at 0x01/0x02 (unknown groups => descriptor==0.0)
             "0x03": {"descriptor_type": 1.0, "instances": {}},
         },
     }
+    if terminator_group is not None:
+        fixture["meta"]["dummy_transport"]["directory_terminator_group"] = terminator_group
     fixture_path = tmp_path / "fixture.json"
     fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
     return fixture_path
@@ -51,11 +61,65 @@ def test_discover_groups_stops_after_first_nan_and_skips_holes(tmp_path: Path) -
 
     discovered = discover_groups(transport, dst=0x15)
 
-    # Holes (descriptor==0.0) should not be recorded as discovered groups.
-    assert [group.group for group in discovered] == [0x00, 0x03]
+    # Known core groups remain scan candidates even when descriptor==0.0.
+    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
 
     # Terminator is triggered by the first NaN (GG=0x05), so probing stops there.
     assert transport.probed_groups == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05]
+
+
+def test_discover_groups_includes_core_with_zero_descriptor(tmp_path: Path) -> None:
+    fixture_path = _write_directory_fixture(
+        tmp_path,
+        groups={
+            "0x00": {"descriptor_type": 3.0, "instances": {}},
+            "0x02": {"descriptor_type": 0.0, "instances": {}},
+        },
+        terminator_group="0x04",
+    )
+    transport = RecordingTransport(DummyTransport(fixture_path))
+
+    discovered = discover_groups(transport, dst=0x15)
+
+    assert frozenset({0x02, 0x03}) == KNOWN_CORE_GROUPS
+    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+
+
+def test_discover_groups_skips_non_core_known_with_zero_descriptor(tmp_path: Path) -> None:
+    fixture_path = _write_directory_fixture(
+        tmp_path,
+        groups={
+            "0x00": {"descriptor_type": 3.0, "instances": {}},
+            "0x09": {"descriptor_type": 0.0, "instances": {}},
+        },
+        terminator_group="0x0A",
+    )
+    transport = RecordingTransport(DummyTransport(fixture_path))
+
+    discovered = discover_groups(transport, dst=0x15)
+
+    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+    assert 0x09 in transport.probed_groups
+
+
+def test_discover_groups_skips_unknown_with_zero_descriptor(tmp_path: Path) -> None:
+    fixture_path = _write_directory_fixture(tmp_path, groups={}, terminator_group=None)
+    transport = RecordingTransport(DummyTransport(fixture_path))
+
+    discovered = discover_groups(transport, dst=0x15)
+
+    assert [group.group for group in discovered] == [0x02, 0x03]
+    assert transport.probed_groups[0] == 0x00
+    assert transport.probed_groups[-1] == 0xFF
+    assert 0xFF not in [group.group for group in discovered]
+
+
+def test_discover_groups_still_terminates_on_nan(tmp_path: Path) -> None:
+    transport = RecordingTransport(DummyTransport(_write_directory_fixture(tmp_path)))
+
+    discover_groups(transport, dst=0x15)
+
+    assert transport.probed_groups[-1] == 0x05
 
 
 class FlakyDirectoryTransport(TransportInterface):
@@ -102,21 +166,24 @@ def test_discover_groups_does_not_terminate_on_transient_transport_failures(tmp_
 
     discovered = discover_groups(transport, dst=0x15)
 
-    assert [group.group for group in discovered] == [0x00, 0x03]
+    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
     # Failures at 0x04/0x05/0x06 must not terminate discovery early.
     assert transport.probed_groups == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
 
 
-def test_classify_groups_warns_on_descriptor_mismatch(
+def test_classify_groups_logs_descriptor_mismatch_at_info(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    caplog.set_level(logging.WARNING, logger="helianthus_vrc_explorer.scanner.director")
+    caplog.set_level(logging.INFO, logger="helianthus_vrc_explorer.scanner.director")
 
     classified = classify_groups([DiscoveredGroup(group=0x02, descriptor=3.0)])
 
     assert classified[0].descriptor_mismatch is True
     assert classified[0].expected_descriptor == 1.0
-    assert any("Descriptor mismatch for GG=0x02" in record.message for record in caplog.records)
+    assert any(
+        record.levelno == logging.INFO and "Descriptor mismatch for GG=0x02" in record.message
+        for record in caplog.records
+    )
 
 
 def test_group_00_rr_max_is_0x00ff() -> None:


### PR DESCRIPTION
## Agent State (required while PR is open)

```text
Status: In review
Branch: codex/issue/118-desc-zero-core-groups-autodetect
Last verified (lint/tests): pytest -q tests/test_scanner_director.py tests/test_cli.py PASS; ruff check . PASS; python scripts/check_protocol_terminology.py PASS; python scripts/check_docs_sync.py PASS; ruff format . made no changes; full pytest has the same single local failure in tests/test_scanner_scan.py::test_scan_b524_replan_textual_failure_prompts_classic_immediately.
How to reproduce: checkout this branch, activate venv, run the commands above from repo root.
Next steps: wait for CI on Python 3.12, complete review, squash-merge if green.
Notes (no secrets, no private infra): D1 is merged via helianthus-docs-ebus PR #196. Bug report #107 will be closed only after this PR merges.
```

## Summary
- treat `descriptor == 0.0` as a valid transport-level B524 compatibility signal in CLI autodetection
- keep only `GG=0x02` and `GG=0x03` as forced scan candidates when discovery sees `descriptor == 0.0`
- downgrade descriptor mismatch logging from warning to informational output
- add focused tests for discovery and autodetection behavior around zero descriptors

## Linked Issue
- Closes #118

## Checklist
- [x] `ruff check .`
- [x] `python scripts/check_protocol_terminology.py`
- [x] `python scripts/check_docs_sync.py`
- [x] `ruff format .`
- [ ] `pytest`
- [x] Manual SSH integration test (if required by the issue): NO
- [x] Audit: no private identifiers introduced (IPs other than 127.0.0.1, serial numbers, hostnames, internal repo names)

## Notes
- Local full `pytest` failure is the same pre-existing Textual replanning test outside this diff.
- D1 prerequisite is satisfied by docs PR #196.