### PR TITLE
scanner: add opcode-aware dual-namespace plan data structures

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -4,7 +4,7 @@ import logging
 import math
 import struct
 from dataclasses import dataclass
-from typing import Final, TypedDict
+from typing import Final, NotRequired, TypedDict
 
 from ..protocol.b524 import build_directory_probe_payload
 from ..transport.base import (
@@ -20,24 +20,91 @@ logger = logging.getLogger(__name__)
 
 class GroupConfig(TypedDict):
     # Informational: last-observed descriptor value. NOT a structural authority.
-    desc: float
+    desc: NotRequired[float]
     name: str
     ii_max: int
     rr_max: int
+    opcodes: list[int]
+    rr_max_by_opcode: NotRequired[dict[int, int]]
+    ii_max_by_opcode: NotRequired[dict[int, int]]
 
 
 # Known groups (hardcoded reference, validated against CSV).
 # Source of truth: `AGENTS.md` (keep in sync).
 GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
-    0x00: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x00FF},
-    0x01: {"desc": 3.0, "name": "Hot Water Circuit", "ii_max": 0x00, "rr_max": 0x13},
-    0x02: {"desc": 1.0, "name": "Heating Circuits", "ii_max": 0x0A, "rr_max": 0x25},
-    0x03: {"desc": 1.0, "name": "Zones", "ii_max": 0x0A, "rr_max": 0x2F},
-    0x04: {"desc": 6.0, "name": "Solar Circuit", "ii_max": 0x00, "rr_max": 0x0B},
-    0x05: {"desc": 1.0, "name": "Hot Water Cylinder", "ii_max": 0x01, "rr_max": 0x04},
-    0x09: {"desc": 1.0, "name": "Radio Sensors VRC7xx", "ii_max": 0x0A, "rr_max": 0x2F},
-    0x0A: {"desc": 1.0, "name": "Radio Sensors VR92", "ii_max": 0x0A, "rr_max": 0x3F},
-    0x0C: {"desc": 1.0, "name": "Remote Accessories / FM5 Slots", "ii_max": 0x0A, "rr_max": 0x2F},
+    0x00: {
+        "desc": 3.0,
+        "name": "Regulator Parameters",
+        "ii_max": 0x00,
+        "rr_max": 0x00FF,
+        "opcodes": [0x02],
+    },
+    0x01: {
+        "desc": 3.0,
+        "name": "Hot Water Circuit",
+        "ii_max": 0x00,
+        "rr_max": 0x0013,
+        "opcodes": [0x02],
+    },
+    0x02: {
+        "desc": 1.0,
+        "name": "Heating Circuits",
+        "ii_max": 0x0A,
+        "rr_max": 0x0025,
+        "opcodes": [0x02],
+    },
+    0x03: {
+        "desc": 1.0,
+        "name": "Zones",
+        "ii_max": 0x0A,
+        "rr_max": 0x002E,
+        "opcodes": [0x02],
+    },
+    0x04: {
+        "desc": 6.0,
+        "name": "Solar Circuit",
+        "ii_max": 0x00,
+        "rr_max": 0x000B,
+        "opcodes": [0x02],
+    },
+    0x05: {
+        "desc": 1.0,
+        "name": "Hot Water Cylinder",
+        "ii_max": 0x01,
+        "rr_max": 0x0004,
+        "opcodes": [0x02],
+    },
+    0x08: {
+        "name": "Buffer / Solar Cylinder 2",
+        "ii_max": 0x0A,
+        "rr_max": 0x0007,
+        "opcodes": [0x02, 0x06],
+        "rr_max_by_opcode": {0x02: 0x0007, 0x06: 0x0004},
+        "ii_max_by_opcode": {0x02: 0x00, 0x06: 0x0A},
+    },
+    0x09: {
+        "desc": 1.0,
+        "name": "Radio Sensors VRC7xx",
+        "ii_max": 0x0A,
+        "rr_max": 0x0035,
+        "opcodes": [0x02, 0x06],
+        "rr_max_by_opcode": {0x02: 0x000F, 0x06: 0x0035},
+    },
+    0x0A: {
+        "desc": 1.0,
+        "name": "Radio Sensors VR92",
+        "ii_max": 0x0A,
+        "rr_max": 0x004D,
+        "opcodes": [0x02, 0x06],
+        "rr_max_by_opcode": {0x02: 0x004D, 0x06: 0x0035},
+    },
+    0x0C: {
+        "desc": 1.0,
+        "name": "Remote Accessories / FM5 Slots",
+        "ii_max": 0x0A,
+        "rr_max": 0x002F,
+        "opcodes": [0x06],
+    },
 }
 KNOWN_CORE_GROUPS: Final[frozenset[int]] = frozenset({0x02, 0x03})
 
@@ -182,8 +249,8 @@ def classify_groups(
             )
             continue
 
-        expected = config["desc"]
-        mismatch = expected != group.descriptor
+        expected = config.get("desc")
+        mismatch = expected is not None and expected != group.descriptor
         if mismatch:
             logger.info(
                 "Descriptor mismatch for GG=0x%02X: expected %s, got %s",

--- a/src/helianthus_vrc_explorer/scanner/plan.py
+++ b/src/helianthus_vrc_explorer/scanner/plan.py
@@ -115,11 +115,13 @@ def _hex_u16(value: int) -> str:
 @dataclass(frozen=True, slots=True)
 class GroupScanPlan:
     group: int
+    opcode: int
     rr_max: int
     instances: tuple[int, ...]
 
     def to_meta(self) -> dict[str, object]:
         return {
+            "opcode": _hex_u8(self.opcode),
             "rr_max": _hex_u16(self.rr_max),
             "instances": [_hex_u8(ii) for ii in self.instances],
         }
@@ -128,6 +130,7 @@ class GroupScanPlan:
 @dataclass(frozen=True, slots=True, order=True)
 class RegisterTask:
     group: int
+    opcode: int
     instance: int
     register: int
 
@@ -144,7 +147,12 @@ def build_work_queue(
         group_plan = plan[gg]
         for ii in group_plan.instances:
             for rr in range(0x0000, group_plan.rr_max + 1):
-                task = RegisterTask(group=gg, instance=ii, register=rr)
+                task = RegisterTask(
+                    group=gg,
+                    opcode=group_plan.opcode,
+                    instance=ii,
+                    register=rr,
+                )
                 if task in done:
                     continue
                 tasks.append(task)

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Final, NotRequired, TypedDict
+from typing import Final, NotRequired, TypedDict, cast
 
 from ..protocol.b524 import RegisterOpcode, build_register_read_payload
 from ..protocol.parser import ValueParseError, parse_typed_value
@@ -13,6 +13,7 @@ from ..transport.base import (
     TransportTimeout,
     emit_trace_label,
 )
+from .director import GROUP_CONFIG
 from .observer import ScanObserver
 
 logger = logging.getLogger(__name__)
@@ -53,7 +54,16 @@ class RegisterEntry(TypedDict):
 def opcode_for_group(group: int) -> RegisterOpcode:
     """Return the B524 register opcode family for a group."""
 
-    return 0x06 if group in _REMOTE_GROUPS else 0x02
+    return opcodes_for_group(group)[0]
+
+
+def opcodes_for_group(group: int) -> list[RegisterOpcode]:
+    """Return all B524 register opcode families for a group."""
+
+    config = GROUP_CONFIG.get(group)
+    if config is None:
+        return [0x02]
+    return [cast(RegisterOpcode, opcode) for opcode in config["opcodes"]]
 
 
 def _interpret_flags(flags: int, *, response_len: int) -> str:
@@ -318,13 +328,21 @@ def read_register(
     }
 
 
-def is_instance_present(transport: TransportInterface, dst: int, group: int, instance: int) -> bool:
+def is_instance_present(
+    transport: TransportInterface,
+    dst: int,
+    group: int,
+    instance: int,
+    *,
+    opcode: RegisterOpcode | None = None,
+) -> bool:
     """Presence heuristic for instanced groups (desc==1.0).
 
     Source of truth: `AGENTS.md` (keep in sync).
     """
 
-    opcode = opcode_for_group(group)
+    if opcode is None:
+        opcode = opcode_for_group(group)
 
     if group == 0x02:
         entry = read_register(

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -46,7 +46,9 @@ _UNKNOWN_GROUP_DEFAULT_RR_MAX = 0x0030
 _UNKNOWN_GROUP_DEFAULT_II_MAX = 0x0A
 
 PlannerUiMode = Literal["auto", "textual", "classic"]
-_KNOWN_DESCRIPTOR_TYPES = frozenset(float(config["desc"]) for config in GROUP_CONFIG.values())
+_KNOWN_DESCRIPTOR_TYPES = frozenset(
+    float(desc) for config in GROUP_CONFIG.values() if (desc := config.get("desc")) is not None
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -758,12 +760,14 @@ def scan_b524(
                         present_instances_for_plan.append(int(ii_key, 0))
                 plan[group.group] = GroupScanPlan(
                     group=group.group,
+                    opcode=opcode_for_group(group.group),
                     rr_max=rr_max,
                     instances=tuple(sorted(present_instances_for_plan)),
                 )
             else:
                 plan[group.group] = GroupScanPlan(
                     group=group.group,
+                    opcode=opcode_for_group(group.group),
                     rr_max=rr_max,
                     instances=(0x00,),
                 )

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -17,6 +17,7 @@ from ..scanner.plan import (
     parse_int_set,
     parse_int_token,
 )
+from ..scanner.register import opcode_for_group
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +117,7 @@ def _build_default_plan(
             continue
         selected[g.group] = GroupScanPlan(
             group=g.group,
+            opcode=opcode_for_group(g.group),
             rr_max=g.rr_max,
             instances=((0x00,) if g.ii_max is None else g.present_instances),
         )
@@ -141,6 +143,7 @@ def build_plan_from_preset(
             continue
         selected[group.group] = GroupScanPlan(
             group=group.group,
+            opcode=opcode_for_group(group.group),
             rr_max=group.rr_max,
             instances=_instances_for_preset(group, preset),
         )
@@ -368,6 +371,7 @@ def prompt_scan_plan(
                 gg,
                 GroupScanPlan(
                     group=gg,
+                    opcode=opcode_for_group(gg),
                     rr_max=eligible[gg].rr_max,
                     instances=(
                         (0x00,) if eligible[gg].ii_max is None else eligible[gg].present_instances
@@ -397,6 +401,7 @@ def prompt_scan_plan(
                         continue
                     selected_plan[gg] = GroupScanPlan(
                         group=gg,
+                        opcode=current.opcode,
                         rr_max=rr_max,
                         instances=current.instances,
                     )
@@ -410,6 +415,7 @@ def prompt_scan_plan(
                     continue
                 selected_plan[gg] = GroupScanPlan(
                     group=gg,
+                    opcode=current.opcode,
                     rr_max=current.rr_max,
                     instances=_ask_instances(
                         console,

--- a/src/helianthus_vrc_explorer/ui/planner_textual.py
+++ b/src/helianthus_vrc_explorer/ui/planner_textual.py
@@ -10,6 +10,7 @@ from ..scanner.plan import (
     parse_int_set,
     parse_int_token,
 )
+from ..scanner.register import opcode_for_group
 from .planner import PlannerGroup, PlannerPreset, _format_seconds, build_plan_from_preset
 
 
@@ -61,7 +62,12 @@ def _estimate_footer(
     request_rate_rps: float | None,
 ) -> str:
     plan = {
-        gg: GroupScanPlan(group=gg, rr_max=st.rr_max, instances=st.instances)
+        gg: GroupScanPlan(
+            group=gg,
+            opcode=opcode_for_group(gg),
+            rr_max=st.rr_max,
+            instances=st.instances,
+        )
         for (gg, st) in states.items()
         if st.enabled
     }
@@ -401,7 +407,12 @@ def run_textual_scan_plan(
 
         def action_save(self) -> None:
             plan = {
-                gg: GroupScanPlan(group=gg, rr_max=st.rr_max, instances=st.instances)
+                gg: GroupScanPlan(
+                    group=gg,
+                    opcode=opcode_for_group(gg),
+                    rr_max=st.rr_max,
+                    instances=st.instances,
+                )
                 for (gg, st) in sorted(self._states.items())
                 if st.enabled
             }

--- a/tests/test_planner_unknown_groups.py
+++ b/tests/test_planner_unknown_groups.py
@@ -84,6 +84,7 @@ def test_prompt_scan_plan_accepts_lowercase_yes_and_aggressive_preset(monkeypatc
     assert plan == {
         0x69: GroupScanPlan(
             group=0x69,
+            opcode=0x02,
             rr_max=0x30,
             instances=tuple(range(0x0A + 1)),
         )

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -191,10 +191,31 @@ def test_group_00_rr_max_is_0x00ff() -> None:
 
 
 def test_group_names_match_docs() -> None:
-    assert len(GROUP_CONFIG) == 9
+    assert len(GROUP_CONFIG) == 10
     assert GROUP_CONFIG[0x09]["name"] == "Radio Sensors VRC7xx"
     assert GROUP_CONFIG[0x0A]["name"] == "Radio Sensors VR92"
     assert GROUP_CONFIG[0x0C]["name"] == "Remote Accessories / FM5 Slots"
+
+
+def test_group_config_completeness() -> None:
+    assert set(GROUP_CONFIG) == {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x08, 0x09, 0x0A, 0x0C}
+    assert GROUP_CONFIG[0x08]["name"] == "Buffer / Solar Cylinder 2"
+    assert GROUP_CONFIG[0x08]["opcodes"] == [0x02, 0x06]
+    assert GROUP_CONFIG[0x08]["rr_max_by_opcode"] == {0x02: 0x0007, 0x06: 0x0004}
+    assert GROUP_CONFIG[0x08]["ii_max_by_opcode"] == {0x02: 0x00, 0x06: 0x0A}
+    assert "desc" not in GROUP_CONFIG[0x08]
+    assert GROUP_CONFIG[0x09]["rr_max"] == 0x0035
+    assert GROUP_CONFIG[0x09]["rr_max_by_opcode"] == {0x02: 0x000F, 0x06: 0x0035}
+    assert GROUP_CONFIG[0x0A]["rr_max"] == 0x004D
+    assert GROUP_CONFIG[0x0A]["rr_max_by_opcode"] == {0x02: 0x004D, 0x06: 0x0035}
+
+
+def test_classify_groups_missing_desc() -> None:
+    classified = classify_groups([DiscoveredGroup(group=0x08, descriptor=0.0)])
+
+    assert classified[0].name == "Buffer / Solar Cylinder 2"
+    assert classified[0].expected_descriptor is None
+    assert classified[0].descriptor_mismatch is False
 
 
 def test_discover_groups_command_not_enabled_is_fatal() -> None:

--- a/tests/test_scanner_plan.py
+++ b/tests/test_scanner_plan.py
@@ -41,8 +41,8 @@ def test_parse_int_set_rejects_out_of_range() -> None:
 
 def test_estimate_register_requests() -> None:
     plan = {
-        0x02: GroupScanPlan(group=0x02, rr_max=0x0003, instances=(0x00, 0x01)),
-        0x01: GroupScanPlan(group=0x01, rr_max=0x0001, instances=(0x00,)),
+        0x02: GroupScanPlan(group=0x02, opcode=0x02, rr_max=0x0003, instances=(0x00, 0x01)),
+        0x01: GroupScanPlan(group=0x01, opcode=0x02, rr_max=0x0001, instances=(0x00,)),
     }
     # GG=0x02: 2 instances * (3+1) regs = 8
     # GG=0x01: 1 instance * (1+1) regs = 2
@@ -57,13 +57,13 @@ def test_format_int_set_compacts_ranges() -> None:
 
 def test_build_work_queue_skips_done_tasks() -> None:
     plan = {
-        0x02: GroupScanPlan(group=0x02, rr_max=0x0002, instances=(0x00,)),
+        0x02: GroupScanPlan(group=0x02, opcode=0x02, rr_max=0x0002, instances=(0x00,)),
     }
-    done = {RegisterTask(group=0x02, instance=0x00, register=0x0001)}
+    done = {RegisterTask(group=0x02, opcode=0x02, instance=0x00, register=0x0001)}
     tasks = build_work_queue(plan, done=done)
     assert tasks == [
-        RegisterTask(group=0x02, instance=0x00, register=0x0000),
-        RegisterTask(group=0x02, instance=0x00, register=0x0002),
+        RegisterTask(group=0x02, opcode=0x02, instance=0x00, register=0x0000),
+        RegisterTask(group=0x02, opcode=0x02, instance=0x00, register=0x0002),
     ]
 
 

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -5,6 +5,8 @@ import pytest
 from helianthus_vrc_explorer.scanner.register import (
     _interpret_flags,
     is_instance_present,
+    opcode_for_group,
+    opcodes_for_group,
     read_register,
 )
 from helianthus_vrc_explorer.transport.base import (
@@ -165,6 +167,20 @@ def test_flags_interpretation_multi_byte() -> None:
     assert _interpret_flags(0x01, response_len=7) == "stable_ro"
     assert _interpret_flags(0x02, response_len=7) == "technical_rw"
     assert _interpret_flags(0x03, response_len=7) == "user_rw"
+
+
+def test_opcodes_for_group_dual_namespace() -> None:
+    assert opcodes_for_group(0x09) == [0x02, 0x06]
+
+
+def test_opcodes_for_group_single_namespace() -> None:
+    assert opcodes_for_group(0x00) == [0x02]
+    assert opcodes_for_group(0x0C) == [0x06]
+
+
+def test_opcode_for_group_deprecated_compat() -> None:
+    assert opcode_for_group(0x09) == 0x02
+    assert opcode_for_group(0x0C) == 0x06
 
 
 def test_read_register_infers_hex_for_unparseable_u24_values() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -369,7 +369,7 @@ def test_scan_b524_scans_enabled_unknown_group_via_planner(monkeypatch, tmp_path
     transport = DummyTransport(_write_fixture_unknown_group_69(tmp_path))
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
-        return {0x69: GroupScanPlan(group=0x69, rr_max=0x0000, instances=(0x00,))}
+        return {0x69: GroupScanPlan(group=0x69, opcode=0x02, rr_max=0x0000, instances=(0x00,))}
 
     monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
@@ -411,6 +411,7 @@ def test_scan_b524_scans_absent_instances_when_planner_overrides(
         return {
             0x02: GroupScanPlan(
                 group=0x02,
+                opcode=0x02,
                 rr_max=0x0002,
                 instances=(
                     0x00,  # present (fixture)
@@ -670,7 +671,7 @@ def test_scan_b524_replan_textual_failure_prompts_classic_immediately(
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         classic_calls["count"] += 1
-        return {0x02: GroupScanPlan(group=0x02, rr_max=0x0000, instances=(0x00,))}
+        return {0x02: GroupScanPlan(group=0x02, opcode=0x02, rr_max=0x0000, instances=(0x00,))}
 
     monkeypatch.setattr(scan_mod, "_PlannerHotkeyReader", _FakeHotkeys)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- extend `GroupConfig` with opcode-aware metadata and make `desc` optional for GG `0x08`
- add GG `0x08`, widen GG `0x09`/`0x0A` bounds safely via per-opcode overrides, and expose `opcodes_for_group()`
- propagate primary opcode through `GroupScanPlan` and `RegisterTask`, updating planner/scan code and tests

## Testing
- `PYTHONPATH=src venv/bin/ruff format .`
- `PYTHONPATH=src venv/bin/ruff check .`
- `PYTHONPATH=src venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src venv/bin/python scripts/check_docs_sync.py`
- `PYTHONPATH=src venv/bin/pytest -q -k 'not test_scan_b524_replan_textual_failure_prompts_classic_immediately'`
- `PYTHONPATH=src venv/bin/pytest -q tests/test_scanner_plan.py tests/test_scanner_register.py tests/test_scanner_director.py tests/test_planner_unknown_groups.py tests/test_scanner_scan.py`  # expected single local failure in `test_scan_b524_replan_textual_failure_prompts_classic_immediately`

## Notes
- `venv/bin/python -m mypy src` still hangs locally under Python 3.14 in the current environment; CI remains the authoritative type-check gate.

Closes #120
