### PR TITLE
scanner: add presence heuristics for cylinders and buffer

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -364,6 +364,35 @@ def is_instance_present(
             return False
         return value != 0xFF
 
+    if group == 0x05:
+        entry = read_register(
+            transport,
+            dst,
+            opcode,
+            group=group,
+            instance=instance,
+            register=0x0004,
+            type_hint="EXP",
+        )
+        if entry["error"] is not None:
+            return False
+        if entry.get("flags_access") == "absent":
+            return False
+        return entry["value"] is not None
+
+    if group == 0x08:
+        entry = read_register(
+            transport,
+            dst,
+            opcode,
+            group=group,
+            instance=instance,
+            register=0x0001,
+        )
+        if entry["error"] is not None:
+            return False
+        return entry.get("flags_access") != "absent"
+
     if group in {0x09, 0x0A}:
         entry_1 = read_register(
             transport, dst, 0x06, group=group, instance=instance, register=0x0007, type_hint="EXP"

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -220,6 +220,74 @@ def test_is_instance_present_group_0c_true_on_first_valid_register_response() ->
     assert transport.calls == 2
 
 
+def test_instance_present_cylinder_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    import helianthus_vrc_explorer.scanner.register as register
+
+    calls: list[tuple[int, int, str | None]] = []
+
+    def _fake_read_register(*_args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append((int(kwargs["group"]), int(kwargs["register"]), kwargs.get("type_hint")))
+        return {
+            "raw_hex": "00004842",
+            "type": "EXP",
+            "value": 50.0,
+            "error": None,
+            "flags_access": "stable_ro",
+        }
+
+    monkeypatch.setattr(register, "read_register", _fake_read_register)
+
+    assert is_instance_present(_StatusOnlyTransport(), dst=0x15, group=0x05, instance=0x00) is True
+    assert calls == [(0x05, 0x0004, "EXP")]
+
+
+def test_instance_present_cylinder_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    import helianthus_vrc_explorer.scanner.register as register
+
+    def _fake_read_register(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return {
+            "raw_hex": None,
+            "type": None,
+            "value": None,
+            "error": None,
+            "flags_access": "absent",
+        }
+
+    monkeypatch.setattr(register, "read_register", _fake_read_register)
+
+    assert is_instance_present(_StatusOnlyTransport(), dst=0x15, group=0x05, instance=0x02) is False
+
+
+def test_instance_present_buffer(monkeypatch: pytest.MonkeyPatch) -> None:
+    import helianthus_vrc_explorer.scanner.register as register
+
+    calls: list[tuple[int, int, int]] = []
+
+    def _fake_read_register(_transport, _dst, opcode, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append((int(opcode), int(kwargs["group"]), int(kwargs["register"])))
+        return {
+            "raw_hex": "01",
+            "type": "UCH",
+            "value": 1,
+            "error": None,
+            "flags_access": "stable_ro",
+        }
+
+    monkeypatch.setattr(register, "read_register", _fake_read_register)
+
+    assert (
+        is_instance_present(
+            _StatusOnlyTransport(),
+            dst=0x15,
+            group=0x08,
+            instance=0x03,
+            opcode=0x06,
+        )
+        is True
+    )
+    assert calls == [(0x06, 0x08, 0x0001)]
+
+
 def test_is_instance_present_group_09_rejects_nan_values(monkeypatch: pytest.MonkeyPatch) -> None:
     import helianthus_vrc_explorer.scanner.register as register
 

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -194,6 +194,28 @@ def _write_fixture_group_09(tmp_path: Path) -> Path:
     return path
 
 
+def _write_fixture_group_08(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x09"}},
+        "groups": {
+            "0x08": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {"raw_hex": "01"},
+                            "0x0000": {"raw_hex": "00"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    path = tmp_path / "fixture_group_08.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
 class _NoopObserver(ScanObserver):
     def phase_start(self, phase: str, *, total: int) -> None:  # noqa: ARG002
         return
@@ -603,6 +625,48 @@ def test_artifact_single_namespace_unchanged(tmp_path: Path) -> None:
     assert group["dual_namespace"] is False
     assert "namespaces" not in group
     assert set(group["instances"]) >= {"0x00"}
+
+
+def test_group_08_remote_namespace_only_marks_present_instances(
+    monkeypatch, tmp_path: Path
+) -> None:
+    import sys
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    transport = DummyTransport(_write_fixture_group_08(tmp_path))
+
+    def fake_prompt_scan_plan(*_args, **_kwargs):
+        return {
+            (0x08, 0x02): GroupScanPlan(
+                group=0x08,
+                opcode=0x02,
+                rr_max=0x0000,
+                instances=(0x00,),
+            ),
+            (0x08, 0x06): GroupScanPlan(
+                group=0x08,
+                opcode=0x06,
+                rr_max=0x0000,
+                instances=(0x00,),
+            ),
+        }
+
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+    )
+
+    group = artifact["groups"]["0x08"]
+    assert group["dual_namespace"] is True
+    assert set(group["namespaces"]["0x02"]["instances"]) == {"0x00"}
+    assert set(group["namespaces"]["0x06"]["instances"]) == {"0x00"}
 
 
 def test_scan_b524_applies_aggressive_preset_to_textual_default_plan(


### PR DESCRIPTION
## Summary
- add explicit `is_instance_present()` probes for GG `0x05` cylinders and GG `0x08` buffer namespaces
- verify GG `0x05` via RR `0x0004` with `EXP` typing and GG `0x08` via RR `0x0001`
- add unit coverage for the new presence probes and keep the scan regression coverage green

## Testing
- `PYTHONPATH=src venv/bin/ruff check .`
- `PYTHONPATH=src venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src venv/bin/python scripts/check_docs_sync.py`
- `PYTHONPATH=src venv/bin/pytest -q tests/test_scanner_register.py tests/test_scanner_scan.py -k "cylinder or buffer or not test_scan_b524_replan_textual_failure_prompts_classic_immediately"`
- `PYTHONPATH=src venv/bin/pytest -q -k "not test_scan_b524_replan_textual_failure_prompts_classic_immediately"`

## Notes
- local `tests/test_scanner_scan.py::test_scan_b524_replan_textual_failure_prompts_classic_immediately` is still the pre-existing Textual-local failure
- local `PYTHONPATH=src venv/bin/python -m mypy src` still hangs in the current Python 3.14 venv; GitHub Actions Python 3.12 remains authoritative here

Closes #127