### PR TITLE
scanner: version artifact schema and propagate CSV type hints

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -23,6 +23,8 @@ _PRINTABLE_LATIN1: Final[set[int]] = set(range(0x20, 0x7F)) | set(range(0xA0, 0x
 class RegisterEntry(TypedDict):
     # B524 register read opcode family used for this entry: 0x02 (local) or 0x06 (remote).
     read_opcode: str
+    # Human-readable opcode family label.
+    read_opcode_label: str
     # Full raw reply payload (after ebusd length-prefix stripping), if available.
     # For register reads this is typically: <FLAGS> <GG> <RR_LO> <RR_HI> <VALUE_BYTES...>
     reply_hex: str | None
@@ -77,6 +79,16 @@ def _interpret_flags(flags: int, *, response_len: int) -> str:
             return "user_rw"
         case _:
             return "unknown"
+
+
+def _opcode_label(opcode: int) -> str:
+    match opcode:
+        case 0x02:
+            return "local"
+        case 0x06:
+            return "remote"
+        case _:
+            return f"0x{opcode:02x}"
 
 
 def _looks_like_nul_terminated_latin1(value_bytes: bytes) -> bool:
@@ -201,6 +213,7 @@ def read_register(
     """Read a B524 register and parse it into an artifact-ready entry."""
 
     read_opcode = f"0x{opcode:02x}"
+    read_opcode_label = _opcode_label(opcode)
     emit_trace_label(
         transport,
         f"Reading dst=0x{dst:02X} GG=0x{group:02X} II=0x{instance:02X} RR=0x{register:04X}",
@@ -211,6 +224,7 @@ def read_register(
     except TransportTimeout:
         return {
             "read_opcode": read_opcode,
+            "read_opcode_label": read_opcode_label,
             "reply_hex": None,
             "flags": None,
             "flags_access": None,
@@ -226,6 +240,7 @@ def read_register(
             raise
         return {
             "read_opcode": read_opcode,
+            "read_opcode_label": read_opcode_label,
             "reply_hex": None,
             "flags": None,
             "flags_access": None,
@@ -248,6 +263,7 @@ def read_register(
     if len(response) == 1:
         return {
             "read_opcode": read_opcode,
+            "read_opcode_label": read_opcode_label,
             "reply_hex": reply_hex,
             "flags": flags,
             "flags_access": flags_access,
@@ -264,6 +280,7 @@ def read_register(
     except ValueError as exc:
         return {
             "read_opcode": read_opcode,
+            "read_opcode_label": read_opcode_label,
             "reply_hex": reply_hex,
             "flags": flags,
             "flags_access": flags_access,
@@ -281,6 +298,7 @@ def read_register(
             value = parse_typed_value(type_hint, value_bytes)
             return {
                 "read_opcode": read_opcode,
+                "read_opcode_label": read_opcode_label,
                 "reply_hex": reply_hex,
                 "flags": flags,
                 "flags_access": flags_access,
@@ -294,6 +312,7 @@ def read_register(
         except ValueParseError as exc:
             return {
                 "read_opcode": read_opcode,
+                "read_opcode_label": read_opcode_label,
                 "reply_hex": reply_hex,
                 "flags": flags,
                 "flags_access": flags_access,
@@ -308,6 +327,7 @@ def read_register(
     inferred_type, inferred_value, inferred_error = _parse_inferred_value(value_bytes)
     return {
         "read_opcode": read_opcode,
+        "read_opcode_label": read_opcode_label,
         "reply_hex": reply_hex,
         "flags": flags,
         "flags_access": flags_access,

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -716,6 +716,7 @@ def scan_b524(
     transport = counting_transport
 
     artifact: dict[str, Any] = {
+        "schema_version": "2.0",
         "meta": {
             "scan_timestamp": scan_timestamp,
             "scan_duration_seconds": 0.0,
@@ -1258,7 +1259,21 @@ def scan_b524(
                         if ebusd_schema is not None
                         else None
                     )
-                    type_hint = schema_entry.type_spec if schema_entry is not None else None
+                    myvaillant_entry = (
+                        myvaillant_map.lookup(
+                            group=task.group,
+                            instance=task.instance,
+                            register=task.register,
+                            opcode=opcode,
+                        )
+                        if myvaillant_map is not None
+                        else None
+                    )
+                    type_hint = (
+                        myvaillant_entry.type_hint
+                        if myvaillant_entry is not None and myvaillant_entry.type_hint is not None
+                        else (schema_entry.type_spec if schema_entry is not None else None)
+                    )
 
                     candidate = read_register(
                         transport,

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -556,6 +556,12 @@ def test_scan_singleton_group_nonzero_descriptor(tmp_path: Path) -> None:
     assert scanned_instances == {0x00}
 
 
+def test_artifact_schema_version(tmp_path: Path) -> None:
+    artifact = scan_b524(DummyTransport(_write_fixture_group_00(tmp_path)), dst=0x15)
+
+    assert artifact["schema_version"] == "2.0"
+
+
 def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     import sys
 
@@ -604,7 +610,9 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     assert local_ns["label"] == "local"
     assert remote_ns["label"] == "remote"
     assert local_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode"] == "0x02"
+    assert local_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode_label"] == "local"
     assert remote_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode"] == "0x06"
+    assert remote_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode_label"] == "remote"
 
     scan_plan = artifact["meta"]["scan_plan"]["groups"]["0x09"]
     assert scan_plan["dual_namespace"] is True
@@ -625,6 +633,16 @@ def test_artifact_single_namespace_unchanged(tmp_path: Path) -> None:
     assert group["dual_namespace"] is False
     assert "namespaces" not in group
     assert set(group["instances"]) >= {"0x00"}
+
+
+def test_artifact_register_flags_present(tmp_path: Path) -> None:
+    artifact = scan_b524(DummyTransport(_write_fixture_group_02(tmp_path)), dst=0x15)
+
+    entry = artifact["groups"]["0x02"]["instances"]["0x00"]["registers"]["0x0002"]
+
+    assert entry["flags"] == 0x01
+    assert entry["flags_access"] == "stable_ro"
+    assert entry["read_opcode_label"] == "local"
 
 
 def test_group_08_remote_namespace_only_marks_present_instances(
@@ -667,6 +685,73 @@ def test_group_08_remote_namespace_only_marks_present_instances(
     assert group["dual_namespace"] is True
     assert set(group["namespaces"]["0x02"]["instances"]) == {"0x00"}
     assert set(group["namespaces"]["0x06"]["instances"]) == {"0x00"}
+
+
+def test_type_hint_propagation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+    from helianthus_vrc_explorer.schema.myvaillant_map import MyvaillantRegisterMap
+
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x0a"}},
+        "groups": {
+            "0x09": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0004": {"raw_hex": "021703"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture_fw.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    map_path = tmp_path / "myvaillant_map.csv"
+    map_path.write_text(
+        "\n".join(
+            [
+                "group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode",
+                "0x09,*,0x0004,radio_device_firmware,,state,FW,0x06",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fake_prompt_scan_plan(*_args, **_kwargs):
+        return {
+            (0x09, 0x06): GroupScanPlan(
+                group=0x09,
+                opcode=0x06,
+                rr_max=0x0004,
+                instances=(0x00,),
+            ),
+        }
+
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
+    monkeypatch.setattr(scan_mod, "is_instance_present", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        DummyTransport(fixture_path),
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+        myvaillant_map=MyvaillantRegisterMap.from_path(map_path),
+    )
+
+    entry = artifact["groups"]["0x09"]["namespaces"]["0x06"]["instances"]["0x00"]["registers"][
+        "0x0004"
+    ]
+    assert entry["myvaillant_name"] == "radio_device_firmware"
+    assert entry["type"] == "FW"
+    assert entry["value"] == "02.17.03"
 
 
 def test_scan_b524_applies_aggressive_preset_to_textual_default_plan(


### PR DESCRIPTION
## Summary
- add artifact schema versioning and human-readable opcode labels to register entries
- let myVaillant CSV type hints override inferred parsing during scans while preserving flags metadata
- cover schema version, flags preservation, dual namespace labels, and type-hint propagation in tests

## Testing
- PYTHONPATH=src venv/bin/ruff check src tests
- PYTHONPATH=src venv/bin/python scripts/check_protocol_terminology.py
- PYTHONPATH=src venv/bin/python scripts/check_docs_sync.py
- PYTHONPATH=src venv/bin/python -m mypy --disable-error-code import-not-found src
- PYTHONPATH=src venv/bin/pytest -q tests/test_scanner_scan.py -k "artifact_schema_version or flags_present or type_hint_propagation or dual_namespace_structure"
- PYTHONPATH=src venv/bin/pytest -q -k "not test_scan_b524_replan_textual_failure_prompts_classic_immediately"

Closes #135