### PR TITLE
fix: restore dummy fixture opcode compatibility

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -20,9 +20,12 @@ A fixture is a JSON object with:
 
 Each group entry contains:
 
-- `descriptor_type` (number): Value returned by the B524 directory probe (`opcode=0x00`), encoded
-  as float32 little-endian on the wire.
+- `descriptor_type` or `descriptor_observed` (number): Value returned by the B524 directory probe
+  (`opcode=0x00`), encoded as float32 little-endian on the wire.
 - `instances` (object, optional): Mapping of instance id -> instance data.
+- `namespaces` (object, optional): Artifact v2 namespace mapping keyed by read opcode (`0x02`,
+  `0x06`, etc.). When present, this is the source of register data even if `dual_namespace` is
+  omitted.
 
 Each instance entry contains:
 
@@ -32,6 +35,9 @@ Each register entry contains:
 
 - `raw_hex` (string): Hex-encoded **value bytes only** for a register read response (no 4-byte echo
   header).
+- `read_opcode` (string, optional): Explicit opcode for flat fixtures that should only answer one
+  namespace/opcode. If omitted, DummyTransport falls back to the configured opcode set for that
+  group.
 
 ### Example
 
@@ -59,3 +65,6 @@ Each register entry contains:
   `0.0`.
 - Register read (`02/06 00 <GG> <II> <RR_LO> <RR_HI>`): returns `echo(4 bytes) + value_bytes`
   where `value_bytes = bytes.fromhex(raw_hex)`. If missing, `TransportTimeout` is raised.
+- Flat legacy fixtures without `read_opcode` follow the configured group opcode(s). Single-opcode
+  groups answer only that opcode; legacy dual-opcode groups answer both until the fixture is
+  upgraded to `namespaces`.

--- a/src/helianthus_vrc_explorer/transport/dummy.py
+++ b/src/helianthus_vrc_explorer/transport/dummy.py
@@ -5,6 +5,7 @@ import struct
 from pathlib import Path
 from typing import Any
 
+from ..scanner.director import GROUP_CONFIG
 from .base import TransportError, TransportInterface, TransportTimeout
 
 
@@ -121,6 +122,19 @@ class DummyTransport(TransportInterface):
             raise ValueError(f"{field} opcode out of range 0..255: {value!r}")
         return opcode
 
+    @staticmethod
+    def _fallback_opcodes(*, group: int, default_opcode: int | None) -> tuple[int, ...]:
+        if default_opcode is not None:
+            return (default_opcode,)
+
+        config = GROUP_CONFIG.get(group)
+        if config is not None:
+            configured = tuple(int(opcode) for opcode in config["opcodes"])
+            if configured:
+                return configured
+
+        return (0x02,)
+
     def _load_instances(
         self,
         *,
@@ -155,12 +169,11 @@ class DummyTransport(TransportInterface):
                     raise ValueError(f"Register {register_key!r} must be a JSON object")
 
                 read_opcode = register_value.get("read_opcode")
+                opcodes: tuple[int, ...]
                 if isinstance(read_opcode, str):
-                    opcode = self._parse_opcode(read_opcode, "register")
-                elif default_opcode is not None:
-                    opcode = default_opcode
+                    opcodes = (self._parse_opcode(read_opcode, "register"),)
                 else:
-                    opcode = 0x02
+                    opcodes = self._fallback_opcodes(group=group, default_opcode=default_opcode)
 
                 raw_hex = register_value.get("raw_hex")
                 if isinstance(raw_hex, str):
@@ -170,12 +183,14 @@ class DummyTransport(TransportInterface):
                         raise ValueError(
                             f"Register {register_key!r} has invalid raw_hex: {raw_hex!r}"
                         ) from exc
-                    self._register_values[(opcode, group, instance, register)] = value_bytes
+                    for opcode in opcodes:
+                        self._register_values[(opcode, group, instance, register)] = value_bytes
                     continue
 
                 error = register_value.get("error")
                 if isinstance(error, str) and error == "timeout":
-                    self._register_timeouts.add((opcode, group, instance, register))
+                    for opcode in opcodes:
+                        self._register_timeouts.add((opcode, group, instance, register))
                     continue
 
                 raise ValueError(
@@ -226,8 +241,8 @@ class DummyTransport(TransportInterface):
                 )
             self._group_descriptor[group] = float(descriptor)
 
-            if bool(group_value.get("dual_namespace")):
-                namespaces = group_value.get("namespaces", {})
+            namespaces = group_value.get("namespaces")
+            if namespaces is not None:
                 if not isinstance(namespaces, dict):
                     raise ValueError(f'Group {group_key!r} field "namespaces" must be an object')
                 for namespace_key, namespace_value in namespaces.items():
@@ -245,6 +260,11 @@ class DummyTransport(TransportInterface):
                         default_opcode=opcode,
                     )
                 continue
+
+            if bool(group_value.get("dual_namespace")):
+                raise ValueError(
+                    f'Group {group_key!r} sets "dual_namespace" but is missing "namespaces"'
+                )
 
             self._load_instances(
                 group_key=group_key,

--- a/tests/test_dummy_transport.py
+++ b/tests/test_dummy_transport.py
@@ -81,3 +81,104 @@ def test_dummy_transport_artifact_v2_separates_local_and_remote_registers(
 
     assert transport.send(0x15, local_payload) == bytes.fromhex("01090400031702")
     assert transport.send(0x15, remote_payload) == bytes.fromhex("01090400021703")
+
+
+def test_dummy_transport_legacy_remote_only_group_defaults_to_group_opcode(
+    tmp_path: Path,
+) -> None:
+    fixture = {
+        "meta": {},
+        "groups": {
+            "0x0C": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0004": {"raw_hex": "080500"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture_remote_only.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    transport = DummyTransport(fixture_path)
+    remote_payload = build_register_read_payload(0x06, group=0x0C, instance=0x00, register=0x0004)
+    local_payload = build_register_read_payload(0x02, group=0x0C, instance=0x00, register=0x0004)
+
+    assert transport.send(0x15, remote_payload) == bytes.fromhex("010c0400080500")
+    with pytest.raises(TransportTimeout):
+        transport.send(0x15, local_payload)
+
+
+def test_dummy_transport_legacy_dual_group_flat_fixture_supports_both_opcodes(
+    tmp_path: Path,
+) -> None:
+    fixture = {
+        "meta": {},
+        "groups": {
+            "0x09": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0004": {"raw_hex": "021703"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture_dual_flat.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    transport = DummyTransport(fixture_path)
+    local_payload = build_register_read_payload(0x02, group=0x09, instance=0x00, register=0x0004)
+    remote_payload = build_register_read_payload(0x06, group=0x09, instance=0x00, register=0x0004)
+
+    assert transport.send(0x15, local_payload) == bytes.fromhex("01090400021703")
+    assert transport.send(0x15, remote_payload) == bytes.fromhex("01090400021703")
+
+
+def test_dummy_transport_artifact_v2_namespaces_do_not_require_dual_namespace_flag(
+    tmp_path: Path,
+) -> None:
+    fixture = {
+        "meta": {},
+        "groups": {
+            "0x09": {
+                "descriptor_observed": 1.0,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0004": {"raw_hex": "031702"},
+                                }
+                            }
+                        }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0004": {"raw_hex": "021703"},
+                                }
+                            }
+                        }
+                    },
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture_namespaces_only.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    transport = DummyTransport(fixture_path)
+    local_payload = build_register_read_payload(0x02, group=0x09, instance=0x00, register=0x0004)
+    remote_payload = build_register_read_payload(0x06, group=0x09, instance=0x00, register=0x0004)
+
+    assert transport.send(0x15, local_payload) == bytes.fromhex("01090400031702")
+    assert transport.send(0x15, remote_payload) == bytes.fromhex("01090400021703")

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -701,7 +701,7 @@ def test_type_hint_propagation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
                 "instances": {
                     "0x00": {
                         "registers": {
-                            "0x0004": {"raw_hex": "021703", "read_opcode": "0x06"},
+                            "0x0004": {"raw_hex": "021703"},
                         }
                     }
                 },


### PR DESCRIPTION
## What
Restore DummyTransport compatibility for legacy flat fixtures and make artifact v2 namespace loading infer from `namespaces` instead of depending on a redundant boolean flag.

## Why
The I10 changes made opcode replay schema-aware, but they regressed remote-only flat fixtures and caused namespaced artifacts to fail unless they repeated `dual_namespace=true`. That regression was caught during follow-up review before closing live validation.

## Acceptance Criteria
- [x] Flat fixtures for single-opcode groups default to the configured opcode
- [x] Flat fixtures for dual-opcode groups remain readable without explicit `read_opcode`
- [x] `namespaces` artifacts load even when `dual_namespace` is omitted
- [x] Regression tests cover the legacy and v2 cases
- [x] Unit tests cover the implemented code
- [x] CI green
- [ ] Smoke test required: NO

## Dependencies
- Depends on #144
