### PR TITLE
scanner: tolerate transient GG=0x00 no-data over ebusd-tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Key scan UX flags:
 
 If startup fails on default transport (`tcp://127.0.0.1:8888`) in an interactive TTY, scan opens a retry dialog so you can adjust protocol/host/port and retry or cancel.
 
+Transport note:
+- On shared live `ebusd-tcp` setups, the first B524 directory probe (`GG=0x00`) can transiently return a status-only `00`. The scanner treats this as transient noise and continues discovery instead of declaring B524 unsupported immediately.
+
 Output:
 - JSON artifact: `b524_scan_0x??_<timestamp>.json`
 - HTML report: `b524_scan_0x??_<timestamp>.html`

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -124,10 +124,6 @@ class ClassifiedGroup:
     descriptor_mismatch: bool
 
 
-class B524UnsupportedError(RuntimeError):
-    """Raised when directory probing indicates B524 is unsupported on target."""
-
-
 def _parse_directory_descriptor(resp: bytes, group: int) -> float:
     if len(resp) < 4:
         # A short response isn't evidence of a terminator (NaN). Treat it as a transient
@@ -181,9 +177,14 @@ def discover_groups(
             continue
 
         if gg == 0x00 and resp == b"\x00":
-            raise B524UnsupportedError(
-                "B524 unsupported: directory probe GG=0x00 returned status-only 0x00"
+            message = (
+                "Directory probe GG=0x00 returned status-only 0x00; "
+                "treating as transient and continuing"
             )
+            logger.warning("%s", message)
+            if observer is not None:
+                observer.log(message, level="warn")
+            continue
 
         try:
             descriptor = _parse_directory_descriptor(resp, gg)

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -26,7 +26,7 @@ from ..transport.base import (
 from ..transport.instrumented import CountingTransport
 from ..ui.planner import PlannerGroup, PlannerPreset, build_plan_from_preset, prompt_scan_plan
 from .b509 import scan_b509
-from .director import GROUP_CONFIG, B524UnsupportedError, classify_groups, discover_groups
+from .director import GROUP_CONFIG, classify_groups, discover_groups
 from .observer import ScanObserver
 from .plan import (
     GroupScanPlan,
@@ -748,16 +748,7 @@ def scan_b524(
         emit_trace_label(transport, "Discovering Groups")
         group_discovery_start = time.perf_counter()
         group_discovery_start_calls = counting_transport.counters.send_calls
-        try:
-            discovered = discover_groups(transport, dst=dst, observer=observer)
-        except B524UnsupportedError as exc:
-            if observer is not None:
-                observer.phase_finish("group_discovery")
-                observer.log(str(exc), level="warn")
-            artifact["meta"]["b524_supported"] = False
-            artifact["meta"]["b524_skip_reason"] = "first_directory_probe_no_data"
-            artifact["meta"]["scan_duration_seconds"] = round(time.perf_counter() - start_perf, 4)
-            return artifact
+        discovered = discover_groups(transport, dst=dst, observer=observer)
         group_discovery_duration_s = time.perf_counter() - group_discovery_start
         group_discovery_requests = (
             counting_transport.counters.send_calls - group_discovery_start_calls

--- a/tests/test_scanner_b509.py
+++ b/tests/test_scanner_b509.py
@@ -44,15 +44,11 @@ class _HybridTransport(TransportInterface):
         raise TransportError("unmapped register")
 
 
-class _UnsupportedB524HybridTransport(TransportInterface):
-    def __init__(self) -> None:
-        self._send_calls = 0
-
-    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
-        self._send_calls += 1
+class _TransientFirstProbeHybridTransport(_HybridTransport):
+    def send(self, dst: int, payload: bytes) -> bytes:
         if payload == bytes((0x00, 0x00, 0x00)):
             return bytes.fromhex("00")
-        raise TransportError(f"unexpected b524 payload: {payload.hex()}")
+        return super().send(dst, payload)
 
     def send_proto(
         self,
@@ -118,16 +114,16 @@ def test_scan_vrc_adds_b509_dump_section(tmp_path: Path) -> None:
     assert regs["0x2702"]["error"] == "timeout"
 
 
-def test_scan_vrc_keeps_b509_when_b524_is_unsupported() -> None:
+def test_scan_vrc_keeps_b509_when_first_directory_probe_is_status_only(tmp_path: Path) -> None:
     artifact = scan_vrc(
-        _UnsupportedB524HybridTransport(),
+        _TransientFirstProbeHybridTransport(_write_fixture_group_02(tmp_path)),
         dst=0x15,
         b509_ranges=[(0x2700, 0x2700)],
     )
 
-    assert artifact["meta"]["b524_supported"] is False
-    assert artifact["meta"]["b524_skip_reason"] == "first_directory_probe_no_data"
-    assert artifact["groups"] == {}
+    assert "b524_supported" not in artifact["meta"]
+    assert "b524_skip_reason" not in artifact["meta"]
+    assert "0x02" in artifact["groups"]
     assert artifact["meta"]["incomplete"] is False
 
     b509_dump = artifact.get("b509_dump")

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -171,6 +171,17 @@ def test_discover_groups_does_not_terminate_on_transient_transport_failures(tmp_
     assert transport.probed_groups == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
 
 
+def test_discover_groups_treats_status_only_gg00_as_transient(tmp_path: Path) -> None:
+    inner = DummyTransport(_write_directory_fixture(tmp_path))
+    flaky = FlakyDirectoryTransport(inner, short_responses={0x00})
+    transport = RecordingTransport(flaky)
+
+    discovered = discover_groups(transport, dst=0x15)
+
+    assert [group.group for group in discovered] == [0x02, 0x03]
+    assert transport.probed_groups == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05]
+
+
 def test_classify_groups_logs_descriptor_mismatch_at_info(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -67,16 +67,17 @@ class ConstraintAwareTransport(TransportInterface):
         return self._inner.send(dst, payload)
 
 
-class _B524UnsupportedTransport(TransportInterface):
-    def __init__(self) -> None:
+class _TransientFirstProbeTransport(TransportInterface):
+    def __init__(self, inner: TransportInterface) -> None:
+        self._inner = inner
         self.calls: list[bytes] = []
 
-    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+    def send(self, dst: int, payload: bytes) -> bytes:
         self.calls.append(payload)
         if payload == bytes((0x00, 0x00, 0x00)):
-            # status-only "no data" on first directory probe => unsupported B524
+            # Shared-bus ebusd-tcp can transiently return status-only 0x00 on the first probe.
             return b"\x00"
-        raise AssertionError(f"Unexpected payload after unsupported probe: {payload.hex()}")
+        return self._inner.send(dst, payload)
 
 
 def _write_fixture_group_02(
@@ -304,34 +305,37 @@ def test_scan_b524_scans_all_instances_and_register_range(tmp_path: Path) -> Non
     assert scanned_registers == set(range(0x25 + 1))
 
 
-def test_scan_b524_skips_flow_when_first_directory_probe_is_status_only(
+def test_scan_b524_continues_when_first_directory_probe_is_status_only(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     import sys
 
     import helianthus_vrc_explorer.scanner.scan as scan_mod
 
-    transport = _B524UnsupportedTransport()
+    transport = _TransientFirstProbeTransport(DummyTransport(_write_fixture_group_02(tmp_path)))
 
     def _unexpected_planner(*_args, **_kwargs):
-        raise AssertionError("planner should not run when B524 is unsupported")
+        raise AssertionError("planner should not run for non-interactive scan")
 
     monkeypatch.setattr(scan_mod, "prompt_scan_plan", _unexpected_planner)
-    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
 
     artifact = scan_b524(
         transport,
         dst=0x15,
         observer=_NoopObserver(),
-        console=Console(force_terminal=True),
+        console=Console(force_terminal=False),
         planner_ui="classic",
     )
 
     assert artifact["meta"]["incomplete"] is False
-    assert artifact["meta"]["b524_supported"] is False
-    assert artifact["meta"]["b524_skip_reason"] == "first_directory_probe_no_data"
-    assert artifact["groups"] == {}
-    assert transport.calls == [bytes((0x00, 0x00, 0x00))]
+    assert "b524_supported" not in artifact["meta"]
+    assert "b524_skip_reason" not in artifact["meta"]
+    assert "0x02" in artifact["groups"]
+    assert artifact["groups"]["0x02"]["instances"]["0x00"]["present"] is True
+    assert transport.calls[0] == bytes((0x00, 0x00, 0x00))
+    assert bytes((0x00, 0x02, 0x00)) in transport.calls
 
 
 def test_scan_b524_collects_constraint_dictionary_entries(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- treat a status-only `GG=0x00` B524 directory reply as transient instead of declaring B524 unsupported
- keep group discovery running and remove the early scanner abort / skip metadata path
- add regression tests and a short README transport note for shared live `ebusd-tcp` setups

Closes #148.

## Verification
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus Project/helianthus-vrc-explorer/venv/bin/python -m ruff check src tests`
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus Project/helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus Project/helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus Project/helianthus-vrc-explorer/venv/bin/python -m pytest -q tests/test_scanner_director.py::test_discover_groups_treats_status_only_gg00_as_transient tests/test_scanner_scan.py::test_scan_b524_continues_when_first_directory_probe_is_status_only tests/test_scanner_b509.py::test_scan_vrc_keeps_b509_when_first_directory_probe_is_status_only`
- live ebusd-tcp smoke scan on 2026-03-09 against `192.168.100.4:8888` with reduced in-memory scan bounds; artifact written to `/tmp/vrc-ebusd-smoke-148.json` and returned real groups without `b524_skip_reason`

## Notes
- The larger targeted pytest run still hits the pre-existing unrelated failure in `tests/test_scanner_scan.py::test_scan_b524_replan_textual_failure_prompts_classic_immediately`.
