### PR TITLE
cli: avoid interactive scan planner during normal CLI runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,8 +604,9 @@ CI enforces this via `python scripts/check_docs_sync.py`.
 │ --b509-range                                         TEXT     B509 register range to dump (repeatable), format:      │
 │                                                               0x0000..0x00FF. If omitted, defaults to                │
 │                                                               0x0000..0x00FF.                                        │
-│ --planner-ui                                         TEXT     Interactive planner mode: auto, textual, or classic.   │
-│                                                               [default: auto]                                        │
+│ --planner-ui                                         TEXT     Interactive planner mode: disabled, auto, textual, or  │
+│                                                               classic.                                               │
+│                                                               [default: disabled]                                    │
 │ --preset                                             TEXT     Planner preset: conservative, recommended, full, or    │
 │                                                               custom. `full` scans every instance slot and full RR   │
 │                                                               ranges; expect very long runs.                         │

--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -597,9 +597,9 @@ def scan(
         ),
     ),
     planner_ui: str = typer.Option(  # noqa: B008
-        "auto",
+        "disabled",
         "--planner-ui",
-        help="Interactive planner mode: auto, textual, or classic.",
+        help="Interactive planner mode: disabled, auto, textual, or classic.",
     ),
     preset: str = typer.Option(  # noqa: B008
         "recommended",
@@ -640,9 +640,9 @@ def scan(
     dst_u8: int
     console = Console(stderr=True)
     planner_ui_value = planner_ui.strip().lower()
-    if planner_ui_value not in {"auto", "textual", "classic"}:
+    if planner_ui_value not in {"disabled", "auto", "textual", "classic"}:
         typer.echo(
-            "Invalid --planner-ui value. Expected one of: auto, textual, classic.",
+            "Invalid --planner-ui value. Expected one of: disabled, auto, textual, classic.",
             err=True,
         )
         raise typer.Exit(2)

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -56,7 +56,7 @@ _REMOTE_REGISTER_OPCODE: RegisterOpcode = 0x06
 _UNKNOWN_GROUP_DEFAULT_RR_MAX = 0x0030
 _UNKNOWN_GROUP_DEFAULT_II_MAX = 0x00
 
-PlannerUiMode = Literal["auto", "textual", "classic"]
+PlannerUiMode = Literal["disabled", "auto", "textual", "classic"]
 _KNOWN_DESCRIPTOR_TYPES = frozenset(
     float(desc) for config in GROUP_CONFIG.values() if (desc := config.get("desc")) is not None
 )
@@ -667,6 +667,8 @@ def _resolve_planner_mode(
     observer: ScanObserver | None,
 ) -> Literal["disabled", "textual", "classic"]:
     if not interactive:
+        return "disabled"
+    if planner_ui == "disabled":
         return "disabled"
     if planner_ui == "classic":
         return "classic"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_scan_command_is_present() -> None:
     assert "planner-ui" in plain
     assert "preset" in plain
     assert "no-tips" in plain
+    assert "disabled" in plain
     assert "auto" in plain
 
 
@@ -206,6 +207,101 @@ def test_scan_command_not_enabled_exits_with_enablehex_hint(
     result = runner.invoke(app, ["scan", "--dst", "0x15", "--output-dir", str(tmp_path)])
     assert result.exit_code == 2
     assert "--enablehex" in result.stderr
+
+
+def test_scan_cli_defaults_planner_ui_to_disabled(monkeypatch, tmp_path: Path) -> None:
+    import helianthus_vrc_explorer.cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    class _OkTransport:
+        @contextmanager
+        def session(self):
+            yield self
+
+    def _fake_build_transport(settings, *, trace_file):  # noqa: ANN001
+        _ = settings
+        _ = trace_file
+        return _OkTransport()
+
+    @contextmanager
+    def _fake_observer(*_args, **_kwargs):
+        yield None
+
+    def _fake_scan_vrc(*_args, **kwargs):
+        captured["planner_ui"] = kwargs["planner_ui"]
+        return {
+            "meta": {
+                "scan_timestamp": "2026-02-13T00:00:00Z",
+                "destination_address": "0x15",
+                "incomplete": False,
+                "schema_sources": [],
+            },
+            "groups": {},
+        }
+
+    monkeypatch.setattr(cli_mod, "_build_transport", _fake_build_transport)
+    monkeypatch.setattr(cli_mod, "_probe_scan_identity", lambda _transport, *, dst: {})
+    monkeypatch.setattr(cli_mod, "make_scan_observer", _fake_observer)
+    monkeypatch.setattr(cli_mod, "scan_vrc", _fake_scan_vrc)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["scan", "--dst", "0x15", "--output-dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert captured["planner_ui"] == "disabled"
+
+
+def test_scan_cli_passes_explicit_planner_ui(monkeypatch, tmp_path: Path) -> None:
+    import helianthus_vrc_explorer.cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    class _OkTransport:
+        @contextmanager
+        def session(self):
+            yield self
+
+    def _fake_build_transport(settings, *, trace_file):  # noqa: ANN001
+        _ = settings
+        _ = trace_file
+        return _OkTransport()
+
+    @contextmanager
+    def _fake_observer(*_args, **_kwargs):
+        yield None
+
+    def _fake_scan_vrc(*_args, **kwargs):
+        captured["planner_ui"] = kwargs["planner_ui"]
+        return {
+            "meta": {
+                "scan_timestamp": "2026-02-13T00:00:00Z",
+                "destination_address": "0x15",
+                "incomplete": False,
+                "schema_sources": [],
+            },
+            "groups": {},
+        }
+
+    monkeypatch.setattr(cli_mod, "_build_transport", _fake_build_transport)
+    monkeypatch.setattr(cli_mod, "_probe_scan_identity", lambda _transport, *, dst: {})
+    monkeypatch.setattr(cli_mod, "make_scan_observer", _fake_observer)
+    monkeypatch.setattr(cli_mod, "scan_vrc", _fake_scan_vrc)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--dst",
+            "0x15",
+            "--planner-ui",
+            "auto",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured["planner_ui"] == "auto"
 
 
 def test_discover_command_is_present() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -976,6 +976,39 @@ def test_scan_b524_applies_preset_in_non_interactive_mode(tmp_path: Path) -> Non
     assert group["instances"]["0x00"]["present"] is True
 
 
+def test_scan_b524_disabled_planner_skips_interactive_planner_even_on_tty(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    transport = DummyTransport(_write_fixture_unknown_group_69(tmp_path))
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("planner should stay disabled")
+
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", _unexpected)
+    monkeypatch.setattr(
+        "helianthus_vrc_explorer.ui.planner_textual.run_textual_scan_plan",
+        _unexpected,
+        raising=False,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="disabled",
+        planner_preset="recommended",
+    )
+
+    assert artifact["meta"]["incomplete"] is False
+
+
 def test_scan_unknown_group_defaults_to_singleton(tmp_path: Path) -> None:
     artifact = scan_b524(
         DummyTransport(_write_fixture_unknown_group_69(tmp_path)),


### PR DESCRIPTION
## Summary
- make the default CLI scan path pass 
- keep  available as explicit opt-in planner modes
- cover the new default and disabled scan-layer behavior with tests

## Testing
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff format src tests
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src tests
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m mypy --disable-error-code import-not-found src
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/pytest -q tests/test_cli.py tests/test_scanner_scan.py -k 'planner or disabled'

Closes #150