### PR TITLE
cli: avoid crashing when textual is unavailable

### DIFF
--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -335,6 +335,13 @@ def _can_launch_interactive_browse(console: Console) -> bool:
     )
 
 
+def _is_missing_textual_module(exc: ModuleNotFoundError) -> bool:
+    name = getattr(exc, "name", None)
+    if isinstance(name, str) and (name == "textual" or name.startswith("textual.")):
+        return True
+    return "textual" in str(exc)
+
+
 def _can_prompt_transport_retry(console: Console) -> bool:
     return (
         console.is_terminal
@@ -801,7 +808,16 @@ def scan(
 
     if _can_launch_interactive_browse(console):
         # Post-scan default UX: enter the new fullscreen browse UI directly.
-        run_browse_from_artifact(artifact, allow_write=False)
+        try:
+            run_browse_from_artifact(artifact, allow_write=False)
+        except ModuleNotFoundError as exc:
+            if not _is_missing_textual_module(exc):
+                raise
+            typer.echo(
+                "Interactive browse UI unavailable in this environment (missing "
+                "'textual'); continuing without browse.",
+                err=True,
+            )
 
     html_path = output_path.with_suffix(".html")
     html_path.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -304,6 +304,61 @@ def test_scan_cli_passes_explicit_planner_ui(monkeypatch, tmp_path: Path) -> Non
     assert captured["planner_ui"] == "auto"
 
 
+def test_scan_cli_missing_textual_browse_falls_back_to_html_and_summary(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import helianthus_vrc_explorer.cli as cli_mod
+
+    class _OkTransport:
+        @contextmanager
+        def session(self):
+            yield self
+
+    def _fake_build_transport(settings, *, trace_file):  # noqa: ANN001
+        _ = settings
+        _ = trace_file
+        return _OkTransport()
+
+    @contextmanager
+    def _fake_observer(*_args, **_kwargs):
+        yield None
+
+    def _fake_scan_vrc(*_args, **_kwargs):
+        return {
+            "meta": {
+                "scan_timestamp": "2026-02-13T00:00:00Z",
+                "destination_address": "0x15",
+                "incomplete": False,
+                "schema_sources": [],
+            },
+            "groups": {},
+        }
+
+    def _fake_browse(*_args, **_kwargs):
+        exc = ModuleNotFoundError("No module named 'textual'")
+        exc.name = "textual"
+        raise exc
+
+    monkeypatch.setattr(cli_mod, "_build_transport", _fake_build_transport)
+    monkeypatch.setattr(cli_mod, "_probe_scan_identity", lambda _transport, *, dst: {})
+    monkeypatch.setattr(cli_mod, "make_scan_observer", _fake_observer)
+    monkeypatch.setattr(cli_mod, "scan_vrc", _fake_scan_vrc)
+    monkeypatch.setattr(cli_mod, "_can_launch_interactive_browse", lambda _console: True)
+    monkeypatch.setattr(cli_mod, "run_browse_from_artifact", _fake_browse)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["scan", "--dst", "0x15", "--output-dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    output_path = Path(result.stdout.strip())
+    assert output_path.exists()
+    assert output_path.with_suffix(".html").exists()
+    assert "missing 'textual'" in result.stderr
+    assert "Scan Summary" in result.stderr
+    assert str(output_path) in result.stdout
+
+
 def test_discover_command_is_present() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["discover", "--help"])


### PR DESCRIPTION
## Summary
- catch missing `textual` only in the post-scan browse handoff
- continue writing HTML, rendering summary, and printing the artifact path
- cover the fallback path with a CLI regression test

## Testing
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff format src tests`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src tests`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m mypy --disable-error-code import-not-found src`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/pytest -q tests/test_cli.py -k 'textual or planner_ui or browse'`

Closes #147
