### PR TITLE
report: clarify absent rows and add HTML controls

### DIFF
--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..scanner.director import GROUP_CONFIG
 from .browse_models import BrowseTab, RegisterAddress, RegisterRow, TreeNodeRef
+from .register_semantics import entry_display_value_text, visible_rr_keys
 
 
 def _safe_int_hex(value: str) -> int:
@@ -16,15 +17,7 @@ def _safe_int_hex(value: str) -> int:
 
 
 def _fmt_value(entry: dict[str, Any]) -> str:
-    value_display = entry.get("value_display")
-    if isinstance(value_display, str) and value_display.strip():
-        return value_display
-    value = entry.get("value")
-    if value is None:
-        return "null"
-    if isinstance(value, float):
-        return f"{value:.6g}"
-    return str(value)
+    return entry_display_value_text(entry)
 
 
 def _parse_timestamp(meta: dict[str, Any]) -> datetime | None:
@@ -271,6 +264,7 @@ class BrowseStore:
                     (k for k in instances if isinstance(k, str)),
                     key=_safe_int_hex,
                 )
+                visible_registers = set(visible_rr_keys(instances))
                 for instance_key in instance_keys:
                     instance_obj = instances.get(instance_key)
                     if not isinstance(instance_obj, dict):
@@ -305,6 +299,8 @@ class BrowseStore:
                         (k for k in registers if isinstance(k, str)),
                         key=_safe_int_hex,
                     ):
+                        if register_key not in visible_registers:
+                            continue
                         entry = registers.get(register_key)
                         if not isinstance(entry, dict):
                             continue

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -236,6 +236,49 @@ _TEMPLATE = """<!doctype html>
         word-break: break-word;
       }
 
+      .cell-status {
+        margin-top: 5px;
+      }
+
+      .status-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 7px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-family: var(--mono);
+        border: 1px solid transparent;
+      }
+
+      .status-absent {
+        color: #ffe1a3;
+        background: rgba(255, 207, 110, 0.14);
+        border-color: rgba(255, 207, 110, 0.28);
+      }
+
+      .status-transport {
+        color: #ffb3b3;
+        background: rgba(255, 122, 122, 0.16);
+        border-color: rgba(255, 122, 122, 0.32);
+      }
+
+      .status-decode {
+        color: #ffd8b1;
+        background: rgba(255, 166, 77, 0.16);
+        border-color: rgba(255, 166, 77, 0.32);
+      }
+
+      .status-error {
+        color: var(--muted);
+        background: rgba(255, 255, 255, 0.05);
+        border-color: rgba(255, 255, 255, 0.08);
+      }
+
+      .cell-value-muted {
+        color: var(--muted);
+        font-weight: 500;
+      }
+
       .cell-missing {
         color: rgba(255, 255, 255, 0.5);
         font-family: var(--mono);
@@ -258,6 +301,13 @@ _TEMPLATE = """<!doctype html>
         flex-wrap: wrap;
         align-items: center;
         margin-bottom: 8px;
+      }
+
+      .subtabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 4px;
       }
 
       .filter-chip {
@@ -603,7 +653,11 @@ __ARTIFACT_JSON__
 
       const state = {
         activeTab: null,
+        activeNamespaceByGroup: {},
         overrides: (meta && typeof meta === "object" && meta.type_overrides) || {},
+        b524Filters: {
+          hideAbsent: false,
+        },
         b509Filters: {
           search: "",
           hideTimeout: false,
@@ -647,6 +701,92 @@ __ARTIFACT_JSON__
         if (!namespaceKey) return raw;
         if (raw.startsWith("0x")) return raw;
         return `${raw.charAt(0).toUpperCase()}${raw.slice(1)} (${namespaceKey})`;
+      }
+
+      function entryStatusKind(entry) {
+        if (!entry || typeof entry !== "object") return "error";
+        const errTxt = typeof entry.error === "string" ? entry.error.trim() : "";
+        if (errTxt) {
+          const lower = errTxt.toLowerCase();
+          if (lower.startsWith("parse_error:") || lower.startsWith("decode_error:")) return "decode_error";
+          if (lower === "timeout" || lower.startsWith("transport_error:") || lower.startsWith("mcp_error:")) {
+            return "transport_failure";
+          }
+          return "error";
+        }
+        const access = typeof entry.flags_access === "string" ? entry.flags_access.trim().toLowerCase() : "";
+        if (access === "absent") return "absent";
+        const replyHex = typeof entry.reply_hex === "string" ? entry.reply_hex.trim().toLowerCase() : "";
+        if (replyHex === "00") return "absent";
+        return "ok";
+      }
+
+      function entryStatusLabel(entry) {
+        const kind = entryStatusKind(entry);
+        if (kind === "absent") return "Absent / no data";
+        if (kind === "transport_failure") return "Transport failure";
+        if (kind === "decode_error") return "Decode error";
+        if (kind === "error") return "Error";
+        return "OK";
+      }
+
+      function statusChipClass(kind) {
+        if (kind === "absent") return "status-chip status-absent";
+        if (kind === "transport_failure") return "status-chip status-transport";
+        if (kind === "decode_error") return "status-chip status-decode";
+        return "status-chip status-error";
+      }
+
+      function rowHasExplicitName(instancesObj, rrKey) {
+        if (!instancesObj || typeof instancesObj !== "object") return false;
+        for (const instanceObj of Object.values(instancesObj)) {
+          if (!instanceObj || typeof instanceObj !== "object") continue;
+          const registers = instanceObj.registers;
+          if (!registers || typeof registers !== "object") continue;
+          const entry = registers[rrKey];
+          if (!entry || typeof entry !== "object") continue;
+          for (const field of ["myvaillant_name", "ebusd_name"]) {
+            const value = entry[field];
+            if (typeof value === "string" && value.trim()) return true;
+          }
+        }
+        return false;
+      }
+
+      function rowIsAbsent(instancesObj, rrKey) {
+        if (!instancesObj || typeof instancesObj !== "object") return false;
+        let sawEntry = false;
+        for (const instanceObj of Object.values(instancesObj)) {
+          if (!instanceObj || typeof instanceObj !== "object") continue;
+          const registers = instanceObj.registers;
+          if (!registers || typeof registers !== "object") continue;
+          const entry = registers[rrKey];
+          if (!entry || typeof entry !== "object") continue;
+          sawEntry = true;
+          if (entryStatusKind(entry) !== "absent") return false;
+        }
+        return sawEntry;
+      }
+
+      function visibleRegisterKeys(instancesObj) {
+        const rrSet = new Set();
+        if (!instancesObj || typeof instancesObj !== "object") return [];
+        for (const instanceObj of Object.values(instancesObj)) {
+          if (!instanceObj || typeof instanceObj !== "object") continue;
+          const registers = instanceObj.registers;
+          if (!registers || typeof registers !== "object") continue;
+          for (const rrKey of Object.keys(registers)) rrSet.add(rrKey);
+        }
+        const rrKeys = sortedHexKeys(Array.from(rrSet)).filter((rrKey) => rrKey !== "0x0000");
+        let lastKeep = -1;
+        for (let idx = 0; idx < rrKeys.length; idx += 1) {
+          const rrKey = rrKeys[idx];
+          if (rowHasExplicitName(instancesObj, rrKey) || !rowIsAbsent(instancesObj, rrKey)) {
+            lastKeep = idx;
+          }
+        }
+        if (lastKeep < 0) return [];
+        return rrKeys.slice(0, lastKeep + 1);
       }
 
       function accessChipClass(accessValue) {
@@ -960,13 +1100,10 @@ __ARTIFACT_JSON__
 
         function buildGroupTable(title, instancesObj, namespaceKey = null) {
           const instanceKeys = sortedHexKeys(Object.keys(instancesObj || {}));
-          let rrSet = new Set();
-          for (const iiKey of instanceKeys) {
-            const inst = getInstanceObject(instancesObj[iiKey]);
-            const regs = inst.registers || {};
-            for (const rrKey of Object.keys(regs)) rrSet.add(rrKey);
+          let rrKeys = visibleRegisterKeys(instancesObj);
+          if (state.b524Filters.hideAbsent) {
+            rrKeys = rrKeys.filter((rrKey) => !rowIsAbsent(instancesObj, rrKey));
           }
-          const rrKeys = sortedHexKeys(Array.from(rrSet));
 
           const fragment = document.createElement("div");
           const heading = document.createElement("div");
@@ -977,7 +1114,7 @@ __ARTIFACT_JSON__
           if (!rrKeys.length) {
             const empty = document.createElement("div");
             empty.className = "subtitle";
-            empty.textContent = "No registers scanned.";
+            empty.textContent = "No visible registers.";
             fragment.appendChild(empty);
             return fragment;
           }
@@ -1110,13 +1247,16 @@ __ARTIFACT_JSON__
               const displayValue = (typeof entry.value_display === "string" && entry.value_display.length)
                 ? entry.value_display
                 : entry.value;
+              const statusKind = entryStatusKind(entry);
+              const statusLabel = entryStatusLabel(entry);
               const decoded = selectedType && valueBytes
                 ? parseTypedValue(selectedType, valueBytes)
                 : { value: displayValue, error: null };
 
-              const valueTxt = formatValue(decoded.value);
+              const valueTxt = statusKind === "absent" ? "absent" : formatValue(decoded.value);
               const valueEl = document.createElement("div");
               valueEl.className = "cell-value";
+              if (statusKind === "absent") valueEl.classList.add("cell-value-muted");
               valueEl.textContent = valueTxt;
               td.appendChild(valueEl);
 
@@ -1128,7 +1268,16 @@ __ARTIFACT_JSON__
               }
 
               const errTxt = typeof entry.error === "string" ? entry.error : decoded.error;
-              if (errTxt) {
+              if (statusKind !== "ok") {
+                const statusEl = document.createElement("div");
+                statusEl.className = "cell-status";
+                const badge = document.createElement("span");
+                badge.className = statusChipClass(statusKind);
+                badge.textContent = statusLabel;
+                statusEl.appendChild(badge);
+                td.appendChild(statusEl);
+              }
+              if (errTxt && statusKind !== "absent") {
                 td.classList.add("cell-bad");
                 const errEl = document.createElement("div");
                 errEl.className = "cell-error";
@@ -1169,16 +1318,59 @@ __ARTIFACT_JSON__
         title.textContent = `${groupKey} · ${groupName}`;
         container.appendChild(title);
 
+        const filters = document.createElement("div");
+        filters.className = "filters";
+        const hideAbsentLabel = document.createElement("label");
+        hideAbsentLabel.className = "filter-chip";
+        const hideAbsentCb = document.createElement("input");
+        hideAbsentCb.type = "checkbox";
+        hideAbsentCb.checked = !!state.b524Filters.hideAbsent;
+        hideAbsentCb.addEventListener("change", () => {
+          state.b524Filters.hideAbsent = !!hideAbsentCb.checked;
+          renderActiveGroup(groupKey);
+        });
+        hideAbsentLabel.appendChild(hideAbsentCb);
+        hideAbsentLabel.appendChild(document.createTextNode("Hide absent"));
+        filters.appendChild(hideAbsentLabel);
+        container.appendChild(filters);
+
         if (groupObj.dual_namespace && groupObj.namespaces && typeof groupObj.namespaces === "object") {
-          for (const namespaceKey of sortedHexKeys(Object.keys(groupObj.namespaces))) {
-            const namespaceObj = groupObj.namespaces[namespaceKey];
-            if (!namespaceObj || typeof namespaceObj !== "object") continue;
-            const tableTitle = `${namespaceLabel(namespaceKey, namespaceObj.label)} Registers`;
-            container.appendChild(buildGroupTable(tableTitle, namespaceObj.instances || {}, namespaceKey));
+          const namespaceKeys = sortedHexKeys(Object.keys(groupObj.namespaces));
+          if (!namespaceKeys.length) {
+            const empty = document.createElement("div");
+            empty.className = "subtitle";
+            empty.textContent = "No namespaces scanned.";
+            container.appendChild(empty);
+          } else {
+            const subtabs = document.createElement("div");
+            subtabs.className = "subtabs";
+            let activeNamespace = state.activeNamespaceByGroup[groupKey];
+            if (!namespaceKeys.includes(activeNamespace)) activeNamespace = namespaceKeys[0];
+            state.activeNamespaceByGroup[groupKey] = activeNamespace;
+
+            for (const namespaceKey of namespaceKeys) {
+              const namespaceObj = groupObj.namespaces[namespaceKey];
+              if (!namespaceObj || typeof namespaceObj !== "object") continue;
+              const btn = document.createElement("div");
+              btn.className = "tab";
+              if (namespaceKey === activeNamespace) btn.classList.add("active");
+              btn.textContent = namespaceLabel(namespaceKey, namespaceObj.label);
+              btn.addEventListener("click", () => {
+                state.activeNamespaceByGroup[groupKey] = namespaceKey;
+                renderActiveGroup(groupKey);
+              });
+              subtabs.appendChild(btn);
+            }
+            container.appendChild(subtabs);
+
+            const namespaceObj = groupObj.namespaces[activeNamespace];
+            if (namespaceObj && typeof namespaceObj === "object") {
+              const tableTitle = `${namespaceLabel(activeNamespace, namespaceObj.label)} Registers`;
+              container.appendChild(buildGroupTable(tableTitle, namespaceObj.instances || {}, activeNamespace));
+            }
           }
         } else {
-          const tableTitle = groupObj.dual_namespace ? "Registers" : "Registers";
-          container.appendChild(buildGroupTable(tableTitle, groupObj.instances || {}, null));
+          container.appendChild(buildGroupTable("Registers", groupObj.instances || {}, null));
         }
 
         sheetArea.innerHTML = "";

--- a/src/helianthus_vrc_explorer/ui/register_semantics.py
+++ b/src/helianthus_vrc_explorer/ui/register_semantics.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Literal
+
+RegisterStatusKind = Literal["ok", "absent", "transport_failure", "decode_error", "error"]
+
+
+def _sorted_hex_keys(keys: Iterable[str]) -> list[str]:
+    parsed: list[tuple[int, str]] = []
+    for key in keys:
+        if not isinstance(key, str):
+            continue
+        try:
+            parsed.append((int(key, 0), key))
+        except ValueError:
+            continue
+    parsed.sort(key=lambda item: item[0])
+    return [key for (_num, key) in parsed]
+
+
+def entry_status_kind(entry: dict[str, Any] | None) -> RegisterStatusKind:
+    if not isinstance(entry, dict):
+        return "error"
+
+    error = entry.get("error")
+    if isinstance(error, str) and error.strip():
+        lowered = error.strip().lower()
+        if lowered.startswith("parse_error:") or lowered.startswith("decode_error:"):
+            return "decode_error"
+        if (
+            lowered == "timeout"
+            or lowered.startswith("transport_error:")
+            or lowered.startswith("mcp_error:")
+        ):
+            return "transport_failure"
+        return "error"
+
+    flags_access = entry.get("flags_access")
+    if isinstance(flags_access, str) and flags_access.strip().lower() == "absent":
+        return "absent"
+
+    reply_hex = entry.get("reply_hex")
+    if isinstance(reply_hex, str) and reply_hex.strip().lower() == "00":
+        return "absent"
+
+    return "ok"
+
+
+def entry_status_label(entry: dict[str, Any] | None) -> str:
+    match entry_status_kind(entry):
+        case "absent":
+            return "Absent / no data"
+        case "transport_failure":
+            return "Transport failure"
+        case "decode_error":
+            return "Decode error"
+        case "error":
+            return "Error"
+        case _:
+            return "OK"
+
+
+def entry_display_value_text(entry: dict[str, Any]) -> str:
+    status = entry_status_kind(entry)
+    if status == "absent":
+        return "absent"
+    if status == "transport_failure":
+        return "transport failure"
+    if status == "decode_error":
+        return "decode error"
+    if status == "error":
+        return "error"
+
+    value_display = entry.get("value_display")
+    if isinstance(value_display, str) and value_display.strip():
+        return value_display
+
+    value = entry.get("value")
+    if value is None:
+        return "null"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def row_has_explicit_name(instances_obj: dict[str, Any], rr_key: str) -> bool:
+    for instance_obj in instances_obj.values():
+        if not isinstance(instance_obj, dict):
+            continue
+        registers = instance_obj.get("registers")
+        if not isinstance(registers, dict):
+            continue
+        entry = registers.get(rr_key)
+        if not isinstance(entry, dict):
+            continue
+        for field in ("myvaillant_name", "ebusd_name"):
+            value = entry.get(field)
+            if isinstance(value, str) and value.strip():
+                return True
+    return False
+
+
+def row_is_absent(instances_obj: dict[str, Any], rr_key: str) -> bool:
+    saw_entry = False
+    for instance_obj in instances_obj.values():
+        if not isinstance(instance_obj, dict):
+            continue
+        registers = instance_obj.get("registers")
+        if not isinstance(registers, dict):
+            continue
+        entry = registers.get(rr_key)
+        if not isinstance(entry, dict):
+            continue
+        saw_entry = True
+        if entry_status_kind(entry) != "absent":
+            return False
+    return saw_entry
+
+
+def visible_rr_keys(instances_obj: dict[str, Any]) -> list[str]:
+    rr_keys: set[str] = set()
+    for instance_obj in instances_obj.values():
+        if not isinstance(instance_obj, dict):
+            continue
+        registers = instance_obj.get("registers")
+        if not isinstance(registers, dict):
+            continue
+        for rr_key in registers:
+            if isinstance(rr_key, str):
+                rr_keys.add(rr_key)
+
+    visible = [rr_key for rr_key in _sorted_hex_keys(rr_keys) if rr_key != "0x0000"]
+    last_keep = -1
+    for idx, rr_key in enumerate(visible):
+        if row_has_explicit_name(instances_obj, rr_key) or not row_is_absent(instances_obj, rr_key):
+            last_keep = idx
+    if last_keep < 0:
+        return []
+    return visible[: last_keep + 1]

--- a/src/helianthus_vrc_explorer/ui/viewer.py
+++ b/src/helianthus_vrc_explorer/ui/viewer.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ..protocol.parser import ValueParseError, parse_typed_value
+from .register_semantics import entry_status_kind, entry_status_label, visible_rr_keys
 
 
 def candidate_type_specs_for_length(length: int) -> tuple[str, ...]:
@@ -283,18 +284,7 @@ def _build_sheets(artifact: dict[str, Any]) -> list[_Sheet]:
         for ns_key, ns_label, instances in namespace_views:
             instance_keys = _sorted_hex_keys([k for k in instances if isinstance(k, str)])
 
-            rr_key_set: set[str] = set()
-            for instance_obj in instances.values():
-                if not isinstance(instance_obj, dict):
-                    continue
-                registers = instance_obj.get("registers")
-                if not isinstance(registers, dict):
-                    continue
-                for rr_key in registers:
-                    if isinstance(rr_key, str):
-                        rr_key_set.add(rr_key)
-
-            rr_keys = _sorted_hex_keys(sorted(rr_key_set))
+            rr_keys = visible_rr_keys(instances)
 
             sheets.append(
                 _Sheet(
@@ -343,7 +333,9 @@ def _cell_text(entry: dict[str, Any] | None, *, selected: bool) -> Text:
     raw_hex = entry.get("raw_hex")
     error = entry.get("error")
 
-    val_txt = _format_value(value)
+    status_kind = entry_status_kind(entry)
+    status_label = entry_status_label(entry)
+    val_txt = status_label.lower() if status_kind == "absent" else _format_value(value)
     raw_txt = raw_hex if isinstance(raw_hex, str) else ""
     raw_short = raw_txt[:16] + ("…" if len(raw_txt) > 16 else "")
 
@@ -351,10 +343,18 @@ def _cell_text(entry: dict[str, Any] | None, *, selected: bool) -> Text:
     err_short = err_txt.split(":", 1)[0] if err_txt else ""
 
     line2 = raw_short
-    if err_short:
+    if status_kind == "absent":
+        line2 = "valid no-data"
+    elif err_short:
         line2 = f"{raw_short} !{err_short}"
 
-    text = Text(f"{val_txt}\n{line2}", style="red" if err_txt else "white")
+    style = "white"
+    if status_kind == "absent":
+        style = "yellow"
+    elif err_txt:
+        style = "red"
+
+    text = Text(f"{val_txt}\n{line2}", style=style)
     if selected:
         text.stylize("reverse")
     return text
@@ -470,6 +470,7 @@ def _render(
         f"type={selected_entry.get('type') if selected_entry else None} override={override}"
     )
     details_lines.append(f"raw_len={raw_len} raw_hex={raw_hex}")
+    details_lines.append(f"status={entry_status_label(selected_entry)}")
     details_lines.append(f"error={selected_entry.get('error') if selected_entry else None}")
     details = Text("\n".join(details_lines), style="dim")
 

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -250,3 +250,113 @@ def test_browse_store_treats_unknown_singleton_group_as_singleton() -> None:
 
     store = BrowseStore.from_artifact(artifact)
     assert not any(node.level == "instance" for node in store.tree_nodes)
+
+
+def test_browse_store_distinguishes_absent_from_transport_failure() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {
+            "0x00": {
+                "name": "Regulator Parameters",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {
+                                "reply_hex": "00",
+                                "flags_access": "absent",
+                                "error": None,
+                            },
+                            "0x0002": {
+                                "reply_hex": None,
+                                "flags_access": None,
+                                "error": "transport_error: ERR: arbitration lost",
+                            },
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    by_register = {row.register_key: row for row in store.rows}
+    assert by_register["0x0001"].value_text == "absent"
+    assert by_register["0x0002"].value_text == "transport failure"
+
+
+def test_browse_store_hides_rr_zero_and_trailing_unnamed_absent_rows_per_namespace() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {
+            "0x0c": {
+                "name": "Accessories",
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "label": "local",
+                        "instances": {
+                            "0x01": {
+                                "registers": {
+                                    "0x0000": {
+                                        "reply_hex": "00",
+                                        "flags_access": "absent",
+                                        "error": None,
+                                    },
+                                    "0x0035": {
+                                        "value": 1,
+                                        "raw_hex": "01",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    },
+                                    "0x0036": {
+                                        "value": 2,
+                                        "raw_hex": "02",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "0x06": {
+                        "label": "remote",
+                        "instances": {
+                            "0x01": {
+                                "registers": {
+                                    "0x0000": {
+                                        "reply_hex": "00",
+                                        "flags_access": "absent",
+                                        "error": None,
+                                    },
+                                    "0x0035": {
+                                        "value": 7,
+                                        "raw_hex": "07",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    },
+                                    "0x0036": {
+                                        "reply_hex": "00",
+                                        "flags_access": "absent",
+                                        "error": None,
+                                    },
+                                    "0x0037": {
+                                        "reply_hex": "00",
+                                        "flags_access": "absent",
+                                        "error": None,
+                                    },
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    row_ids = {row.row_id for row in store.rows}
+    assert "0x0c:0x02:0x01:0x0000" not in row_ids
+    assert "0x0c:0x06:0x01:0x0000" not in row_ids
+    assert "0x0c:0x02:0x01:0x0036" in row_ids
+    assert "0x0c:0x06:0x01:0x0036" not in row_ids
+    assert "0x0c:0x06:0x01:0x0037" not in row_ids

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -37,6 +37,7 @@ def test_html_report_supports_b509_tab_and_dual_naming() -> None:
 
     assert "B509 Dump" in html
     assert "Hide timeouts" in html
+    assert "hideAbsent" in html
     assert "ebusd: " in html
 
 
@@ -96,5 +97,6 @@ def test_html_report_renders_namespace_totals_and_flags_access_for_dual_namespac
     assert "Namespace Totals" in html
     assert "FLAGS Access" in html
     assert "Radio Sensors VRC7xx" in html
+    assert "activeNamespaceByGroup" in html
     assert '"label":"local"' in html
     assert '"label":"remote"' in html

--- a/tests/test_register_semantics.py
+++ b/tests/test_register_semantics.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from helianthus_vrc_explorer.ui.register_semantics import (
+    entry_display_value_text,
+    entry_status_kind,
+    entry_status_label,
+    visible_rr_keys,
+)
+
+
+def test_entry_status_kind_distinguishes_absent_transport_and_decode() -> None:
+    assert (
+        entry_status_kind({"reply_hex": "00", "flags_access": "absent", "error": None}) == "absent"
+    )
+    assert entry_status_kind({"error": "timeout"}) == "transport_failure"
+    assert (
+        entry_status_kind({"error": "transport_error: ERR: arbitration lost"})
+        == "transport_failure"
+    )
+    assert entry_status_kind({"error": "parse_error: bad thing"}) == "decode_error"
+
+
+def test_entry_display_value_text_uses_semantic_labels_for_absent_and_transport() -> None:
+    assert (
+        entry_display_value_text({"reply_hex": "00", "flags_access": "absent", "error": None})
+        == "absent"
+    )
+    assert (
+        entry_display_value_text({"error": "transport_error: ERR: arbitration lost"})
+        == "transport failure"
+    )
+    assert entry_display_value_text({"value": 38.0, "raw_hex": "00001842", "error": None}) == "38"
+    assert (
+        entry_status_label({"reply_hex": "00", "flags_access": "absent", "error": None})
+        == "Absent / no data"
+    )
+
+
+def test_visible_rr_keys_trims_rr_zero_and_final_unnamed_absent_tail() -> None:
+    instances = {
+        "0x00": {
+            "registers": {
+                "0x0000": {"reply_hex": "00", "flags_access": "absent", "error": None},
+                "0x0001": {"value": 1, "raw_hex": "01", "flags_access": "stable_ro", "error": None},
+                "0x0002": {"reply_hex": "00", "flags_access": "absent", "error": None},
+                "0x0003": {"reply_hex": "00", "flags_access": "absent", "error": None},
+            }
+        }
+    }
+
+    assert visible_rr_keys(instances) == ["0x0001"]
+
+
+def test_visible_rr_keys_keeps_named_absent_rows_and_trims_per_namespace() -> None:
+    local_instances = {
+        "0x01": {
+            "registers": {
+                "0x0035": {"value": 1, "raw_hex": "01", "flags_access": "stable_ro", "error": None},
+                "0x0036": {"value": 2, "raw_hex": "02", "flags_access": "stable_ro", "error": None},
+            }
+        }
+    }
+    remote_instances = {
+        "0x01": {
+            "registers": {
+                "0x0035": {
+                    "myvaillant_name": "named_absent_remote",
+                    "reply_hex": "00",
+                    "flags_access": "absent",
+                    "error": None,
+                },
+                "0x0036": {"reply_hex": "00", "flags_access": "absent", "error": None},
+                "0x0037": {"reply_hex": "00", "flags_access": "absent", "error": None},
+            }
+        }
+    }
+
+    assert visible_rr_keys(local_instances) == ["0x0035", "0x0036"]
+    assert visible_rr_keys(remote_instances) == ["0x0035"]


### PR DESCRIPTION
## Summary
- clarify report semantics for valid absent/no-data vs transport failures
- add HTML hide-absent toggle and secondary namespace tabs for dual-namespace groups
- trim RR=0x0000 and trailing unnamed absent rows from visible register lists

## Testing
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/pytest -q tests/test_register_semantics.py tests/test_browse_store.py tests/test_html_report.py tests/test_results_viewer_overrides.py tests/test_scanner_register.py
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/ui tests/test_register_semantics.py tests/test_browse_store.py tests/test_html_report.py
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff format src/helianthus_vrc_explorer/ui tests/test_register_semantics.py tests/test_browse_store.py tests/test_html_report.py
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py
- PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py

## Issues
- closes #160
- closes #161
- closes #162
- closes #163
