### PR TITLE
scanner: tighten GG=0x0C remote-slot presence detection

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -439,11 +439,20 @@ def is_instance_present(
         )
 
     if group == 0x0C:
-        for rr in (0x0002, 0x0007, 0x000F, 0x0016):
-            entry = read_register(transport, dst, 0x06, group=group, instance=instance, register=rr)
-            if entry["error"] is None and entry.get("flags_access") != "absent":
-                return True
-        return False
+        entry = read_register(
+            transport,
+            dst,
+            0x06,
+            group=group,
+            instance=instance,
+            register=0x0001,
+            type_hint="BOOL",
+        )
+        if entry["error"] is not None:
+            return False
+        if entry.get("flags_access") == "absent":
+            return False
+        return entry["value"] is True
 
     logger.debug(
         "No presence heuristic for GG=0x%02X; assuming present for II=0x%02X", group, instance

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -29,7 +29,7 @@ class _FlakyOnceTransport(TransportInterface):
         group = payload[2]
         rr = payload[4:6]
         header = bytes((0x01, group)) + rr
-        return header + b"\x01\x00"
+        return header + b"\x01"
 
 
 class _AlwaysTimeoutTransport(TransportInterface):
@@ -124,6 +124,28 @@ class _AlwaysCommandNotEnabledTransport(TransportInterface):
         raise TransportCommandNotEnabled("ERR: command not enabled")
 
 
+class _BoolFalseTransport(TransportInterface):
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+        self.calls += 1
+        group = payload[2]
+        rr = payload[4:6]
+        return bytes((0x01, group)) + rr + b"\x00"
+
+
+class _BoolTrueTransport(TransportInterface):
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+        self.calls += 1
+        group = payload[2]
+        rr = payload[4:6]
+        return bytes((0x01, group)) + rr + b"\x01"
+
+
 class _StatusOnlyTransport(TransportInterface):
     def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
         return b"\x00"
@@ -203,22 +225,29 @@ def test_is_instance_present_group_0c_requires_valid_register_response() -> None
     transport = _AlwaysDecodeErrorTransport()
 
     assert is_instance_present(transport, dst=0x15, group=0x0C, instance=0x00) is False
-    assert transport.calls == 4
+    assert transport.calls == 1
 
 
 def test_is_instance_present_group_0c_transport_errors_do_not_count_as_present() -> None:
     transport = _AlwaysTransportErrorTransport()
 
     assert is_instance_present(transport, dst=0x15, group=0x0C, instance=0x00) is False
-    assert transport.calls == 4
+    assert transport.calls == 1
 
 
 def test_is_instance_present_group_0c_true_on_first_valid_register_response() -> None:
-    transport = _FlakyOnceTransport()
+    transport = _BoolTrueTransport()
 
-    # First probe times out, next probe succeeds and marks the instance present.
+    # device_connected=true marks the accessory slot as present.
     assert is_instance_present(transport, dst=0x15, group=0x0C, instance=0x00) is True
-    assert transport.calls == 2
+    assert transport.calls == 1
+
+
+def test_is_instance_present_group_0c_false_when_device_connected_is_false() -> None:
+    transport = _BoolFalseTransport()
+
+    assert is_instance_present(transport, dst=0x15, group=0x0C, instance=0x00) is False
+    assert transport.calls == 1
 
 
 def test_instance_present_cylinder_found(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #155

## What
- tighten BASV2 `GG=0x0C` presence detection to use `RR=0x0001` (`device_connected`) as the presence signal
- stop treating any non-absent remote reply as proof that an accessory slot exists
- add unit coverage for the empty-slot and populated-slot cases

## Why
Live validation showed that empty `0x0C` slots share a stable signature (`0x0001=0`, `0x0002=0`, `0x0003=255`, `0x0004=null`) but were still being enumerated. Using the seeded boolean register aligns the scanner with the actual slot semantics and avoids inflating recommended scans.

## Verification
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/pytest -q tests/test_scanner_register.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/scanner/register.py tests/test_scanner_register.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`
- live smoke: `read_register(... GG=0x0C RR=0x0001 BOOL)` returned `False / True / False` for `II=0x00 / 0x01 / 0x02` via ebusd-tcp on 2026-03-09

## Notes
The occasional false negative observed from repeated `is_instance_present()` probes maps to transient transport behavior on the second send and is tracked separately under #158.