### PR TITLE
transport: add fixed quiet backoff for ebusd retries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -829,6 +829,8 @@ Example: `./out/b524_scan_0x15_2026-02-06T194424Z.json`
 
 **Timeouts / invalid responses during scan:**
 - Errors are recorded inline per-entry (`error` field) and scanning continues (best-effort).
+- On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received`
+  trigger a fixed 5-second quiet backoff before retry so the bus can settle.
 - Partial scans are valid: Ctrl+C results in `meta.incomplete=true` with a reason string.
 
 **Signal handling:**

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If startup fails on default transport (`tcp://127.0.0.1:8888`) in an interactive
 
 Transport note:
 - On shared live `ebusd-tcp` setups, the first B524 directory probe (`GG=0x00`) can transiently return a status-only `00`. The scanner treats this as transient noise and continues discovery instead of declaring B524 unsupported immediately.
+- On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received` now trigger a fixed 5-second quiet backoff before retry so the bus can settle.
 
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.

--- a/src/helianthus_vrc_explorer/transport/ebusd_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/ebusd_tcp.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import io
-import random
 import socket
 import string
 import time
@@ -41,7 +40,9 @@ _SECONDARY_EXTENDED_REGISTER: Final[int] = 0x24
 _EBUSD_COMMAND_TERMINATOR: Final[bytes] = b"\n"
 _HEX_CHARS: Final[set[str]] = set(string.hexdigits)
 _POST_RESPONSE_DRAIN_TIMEOUT_S: Final[float] = 0.01
+_BUS_SETTLE_RETRY_S: Final[float] = 5.0
 _RETRYABLE_TRANSPORT_ERROR_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "arbitration lost",
     "syn received",
     "wrong symbol received",
 )
@@ -376,9 +377,10 @@ class EbusdTcpTransport(TransportInterface):
                 self._trace(
                     "#"
                     f"{seq} RETRY type=timeout "
-                    f"n={timeout_retries}/{self._config.timeout_max_retries}"
+                    f"n={timeout_retries}/{self._config.timeout_max_retries} "
+                    f"sleep_ms={int(_BUS_SETTLE_RETRY_S * 1000)}"
                 )
-                # Immediate retry for ERR: read timeout (no backoff).
+                time.sleep(_BUS_SETTLE_RETRY_S)
                 continue
             except TransportError as exc:
                 if _is_connection_level_error(exc):
@@ -415,15 +417,12 @@ class EbusdTcpTransport(TransportInterface):
                             exc,
                             f"collision retries exhausted ({self._config.collision_max_retries})",
                         ) from exc
-                    min_ms = self._config.collision_backoff_min_ms
-                    max_ms = self._config.collision_backoff_max_ms
-                    sleep_s = random.uniform(min_ms / 1000.0, max_ms / 1000.0)
                     self._trace(
                         f"#{seq} RETRY type=collision "
                         f"n={collision_retries}/{self._config.collision_max_retries} "
-                        f"sleep_ms={int(round(sleep_s * 1000))}"
+                        f"sleep_ms={int(_BUS_SETTLE_RETRY_S * 1000)}"
                     )
-                    time.sleep(sleep_s)
+                    time.sleep(_BUS_SETTLE_RETRY_S)
                     continue
                 raise
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -220,7 +220,7 @@ def test_transport_send_retries_timeout_once_then_succeeds(monkeypatch: pytest.M
 
     assert result == bytes.fromhex("010203")
     assert commands == ["hex 15B52406020002000F00", "hex 15B52406020002000F00"]
-    assert sleep_calls == []
+    assert sleep_calls == [5.0]
 
 
 def test_transport_send_timeout_retries_exhaust_after_five_retries(
@@ -241,10 +241,13 @@ def test_transport_send_timeout_retries_exhaust_after_five_retries(
             transport.send(0x15, payload)
 
     assert commands == ["hex 15B52406020002000F00"] * 6
-    assert sleep_calls == []
+    assert sleep_calls == [5.0] * 5
 
 
-@pytest.mark.parametrize("err_line", ["ERR: SYN received", "ERR: wrong symbol received"])
+@pytest.mark.parametrize(
+    "err_line",
+    ["ERR: arbitration lost", "ERR: SYN received", "ERR: wrong symbol received"],
+)
 def test_transport_send_retries_retryable_transport_errors_once_then_succeeds(
     monkeypatch: pytest.MonkeyPatch,
     err_line: str,
@@ -258,14 +261,13 @@ def test_transport_send_retries_retryable_transport_errors_once_then_succeeds(
         import helianthus_vrc_explorer.transport.ebusd_tcp as ebusd_tcp
 
         monkeypatch.setattr(ebusd_tcp.time, "sleep", _sleep)
-        monkeypatch.setattr(ebusd_tcp.random, "uniform", lambda _a, _b: 0.05)
         transport = EbusdTcpTransport(EbusdTcpConfig(host=host, port=port, timeout_s=0.5))
         payload = bytes.fromhex("020002000F00")
         result = transport.send(0x15, payload)
 
     assert result == bytes.fromhex("010203")
     assert commands == ["hex 15B52406020002000F00", "hex 15B52406020002000F00"]
-    assert sleep_calls == [0.05]
+    assert sleep_calls == [5.0]
 
 
 def test_transport_send_retries_socket_timeout_once_then_succeeds(
@@ -465,14 +467,13 @@ def test_transport_send_collision_retries_exhaust(monkeypatch: pytest.MonkeyPatc
         import helianthus_vrc_explorer.transport.ebusd_tcp as ebusd_tcp
 
         monkeypatch.setattr(ebusd_tcp.time, "sleep", _sleep)
-        monkeypatch.setattr(ebusd_tcp.random, "uniform", lambda _a, _b: 0.03)
         transport = EbusdTcpTransport(EbusdTcpConfig(host=host, port=port, timeout_s=0.5))
         payload = bytes.fromhex("020002000F00")
         with pytest.raises(TransportError, match=r"collision retries exhausted"):
             transport.send(0x15, payload)
 
     assert commands == ["hex 15B52406020002000F00"] * 6
-    assert sleep_calls == [0.03] * 5
+    assert sleep_calls == [5.0] * 5
 
 
 def test_transport_send_respects_max_command_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -516,4 +517,4 @@ def test_transport_send_proto_uses_retry_policy(monkeypatch: pytest.MonkeyPatch)
 
     assert result == bytes.fromhex("00")
     assert commands == ["hex 15070400", "hex 15070400"]
-    assert sleep_calls == []
+    assert sleep_calls == [5.0]


### PR DESCRIPTION
Closes #158

## What
- apply a fixed 5-second quiet backoff before retrying ebusd `ERR: timeout` responses
- apply the same fixed 5-second quiet backoff for `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received`
- document the new bus-settle behavior in `README.md` and `AGENTS.md`
- extend transport tests to cover the fixed cooldown behavior

## Why
Live BASV2 scans were still producing random holes because ebusd-tcp retried too aggressively after bus-contention style failures. A consistent 5-second quiet period lets the bus settle instead of hammering the same unsettled state with immediate retries or short jitter.

## Verification
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/pytest -q tests/test_transport.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/transport/ebusd_tcp.py tests/test_transport.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`
- live smoke on 2026-03-09 with trace `/tmp/vrc-158-live.trace`: repeated `GG=0x0C II=0x01 RR=0x0001` reads hit `ERR: SYN received`, `ERR: SYN received`, `ERR: arbitration lost`, and retried with `sleep_ms=5000` before succeeding

## Notes
Connection-level socket timeouts remain on the existing reconnect path; the fixed 5-second quiet backoff is for bus-level contention/sync/ERR timeout conditions.