### PR TITLE
transport: add 15s backoff after ebusd no-signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -831,6 +831,8 @@ Example: `./out/b524_scan_0x15_2026-02-06T194424Z.json`
 - Errors are recorded inline per-entry (`error` field) and scanning continues (best-effort).
 - On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received`
   trigger a fixed 5-second quiet backoff before retry so the bus can settle.
+- On `ebusd-tcp`, `ERR: no signal` triggers a fixed 15-second quiet backoff before retry so the
+  eBUS side can recover instead of being polled aggressively.
 - Partial scans are valid: Ctrl+C results in `meta.incomplete=true` with a reason string.
 
 **Signal handling:**

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If startup fails on default transport (`tcp://127.0.0.1:8888`) in an interactive
 Transport note:
 - On shared live `ebusd-tcp` setups, the first B524 directory probe (`GG=0x00`) can transiently return a status-only `00`. The scanner treats this as transient noise and continues discovery instead of declaring B524 unsupported immediately.
 - On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received` now trigger a fixed 5-second quiet backoff before retry so the bus can settle.
+- On `ebusd-tcp`, `ERR: no signal` now triggers a fixed 15-second quiet backoff before retry so the eBUS side can recover instead of being polled aggressively.
 
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.

--- a/src/helianthus_vrc_explorer/transport/ebusd_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/ebusd_tcp.py
@@ -41,6 +41,7 @@ _EBUSD_COMMAND_TERMINATOR: Final[bytes] = b"\n"
 _HEX_CHARS: Final[set[str]] = set(string.hexdigits)
 _POST_RESPONSE_DRAIN_TIMEOUT_S: Final[float] = 0.01
 _BUS_SETTLE_RETRY_S: Final[float] = 5.0
+_BUS_LOST_RETRY_S: Final[float] = 15.0
 _RETRYABLE_TRANSPORT_ERROR_SUBSTRINGS: Final[tuple[str, ...]] = (
     "arbitration lost",
     "syn received",
@@ -401,12 +402,11 @@ class EbusdTcpTransport(TransportInterface):
                             exc,
                             f"no-signal polling exceeded {self._config.no_signal_max_s:.1f}s",
                         ) from exc
-                    sleep_s = self._config.no_signal_poll_ms / 1000.0
                     self._trace(
                         f"#{seq} RETRY type=no_signal elapsed_ms={int(elapsed_s * 1000)} "
-                        f"sleep_ms={self._config.no_signal_poll_ms}"
+                        f"sleep_ms={int(_BUS_LOST_RETRY_S * 1000)}"
                     )
-                    time.sleep(sleep_s)
+                    time.sleep(_BUS_LOST_RETRY_S)
                     continue
 
                 no_signal_start_monotonic = None

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -313,13 +313,13 @@ def test_transport_send_polls_no_signal_then_recovers(
 
     assert result == bytes.fromhex("010203")
     assert commands == ["hex 15B52406020002000F00", "hex 15B52406020002000F00"]
-    assert sleep_calls == [0.2]
+    assert sleep_calls == [15.0]
 
 
-def test_transport_send_no_signal_polling_exhausts(
+def test_transport_send_no_signal_backoff_exhausts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with _run_ebusd_test_server([["ERR: no signal"]] * 4) as (host, port, commands):
+    with _run_ebusd_test_server([["ERR: no signal"]] * 2) as (host, port, commands):
         sleep_calls: list[float] = []
         now = {"t": 0.0}
 
@@ -336,16 +336,16 @@ def test_transport_send_no_signal_polling_exhausts(
                 host=host,
                 port=port,
                 timeout_s=0.5,
-                no_signal_max_s=0.6,
+                no_signal_max_s=15.0,
                 no_signal_poll_ms=200,
             )
         )
         payload = bytes.fromhex("020002000F00")
-        with pytest.raises(TransportError, match=r"no-signal polling exceeded 0.6s"):
+        with pytest.raises(TransportError, match=r"no-signal polling exceeded 15.0s"):
             transport.send(0x15, payload)
 
-    assert commands == ["hex 15B52406020002000F00"] * 4
-    assert sleep_calls == [0.2, 0.2, 0.2]
+    assert commands == ["hex 15B52406020002000F00"] * 2
+    assert sleep_calls == [15.0]
 
 
 def test_parse_ebusd_info_lines_scans_all_lines_for_errors() -> None:


### PR DESCRIPTION
Closes #167

## What
- change ebusd-tcp `ERR: no signal` handling from short polling to a fixed 15-second quiet backoff
- keep the existing 5-second backoff for arbitration/sync/ERR timeout conditions unchanged
- document the new bus-loss retry behavior in `README.md` and `AGENTS.md`
- update transport tests to cover the fixed 15-second cooldown

## Why
When ebusd reports that the eBUS side has lost signal, short polling just keeps hammering the same broken state. A longer quiet period gives the adapter/bus chain time to recover and matches the operator guidance from live use.

## Verification
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/pytest -q tests/test_transport.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/transport/ebusd_tcp.py tests/test_transport.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`

## Notes
I did not force a live `ERR: no signal` on the real bus just to verify this path, because reproducing it intentionally would require destabilizing the active eBUS chain.