### PR TITLE
ui: expose b555 dump in reports

### DIFF
--- a/src/helianthus_vrc_explorer/ui/browse_models.py
+++ b/src/helianthus_vrc_explorer/ui/browse_models.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 BrowseTab = Literal["config", "config_limits", "state"]
-ProtocolKey = Literal["b524", "b509"]
+ProtocolKey = Literal["b524", "b555", "b509"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,6 +22,9 @@ class RegisterAddress:
         suffix = f" {self.read_opcode}" if self.read_opcode else ""
         if self.protocol == "b509":
             return f"B509 RR={self.register_key}{suffix}"
+        if self.protocol == "b555":
+            group_key = self.group_key or "program"
+            return f"B555 {group_key} {self.register_key}{suffix}".strip()
         group_key = self.group_key or "0x??"
         instance_key = self.instance_key or "0x??"
         return f"GG={group_key} II={instance_key} RR={self.register_key}{suffix}"

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -94,7 +94,8 @@ def _instance_label(
 
 
 def _row_sort_key(row: RegisterRow) -> tuple[int, int, int, int, int]:
-    proto_weight = 0 if row.protocol == "b524" else 1
+    proto_weight_map = {"b524": 0, "b555": 1, "b509": 2}
+    proto_weight = proto_weight_map.get(row.protocol, 99)
     if row.protocol == "b524":
         return (
             proto_weight,
@@ -102,6 +103,14 @@ def _row_sort_key(row: RegisterRow) -> tuple[int, int, int, int, int]:
             _safe_int_hex(row.namespace_key or "0"),
             _safe_int_hex(row.instance_key or "0"),
             _safe_int_hex(row.register_key),
+        )
+    if row.protocol == "b555":
+        return (
+            proto_weight,
+            _safe_int_hex(row.group_key or "0"),
+            0,
+            0,
+            _safe_int_hex(row.register_key.split(":", 1)[-1] if ":" in row.register_key else "0"),
         )
     return (proto_weight, 0, 0, 0, _safe_int_hex(row.register_key))
 
@@ -162,6 +171,38 @@ def _parse_range_key(range_key: str) -> tuple[int, int] | None:
     return (start, end)
 
 
+def _format_b555_value(entry: dict[str, Any]) -> str:
+    error = entry.get("error")
+    if isinstance(error, str) and error:
+        return error
+    status_label = str(entry.get("status_label") or "").strip()
+    if status_label and status_label != "available":
+        return status_label
+    op = str(entry.get("op") or "").strip().lower()
+    if op == "0xa3":
+        parts: list[str] = []
+        if isinstance(entry.get("max_slots"), int):
+            parts.append(f"max_slots={entry['max_slots']}")
+        if isinstance(entry.get("temp_slots"), int):
+            parts.append(f"temp_slots={entry['temp_slots']}")
+        if isinstance(entry.get("time_resolution_min"), int):
+            parts.append(f"resolution={entry['time_resolution_min']}m")
+        return ", ".join(parts) or "config"
+    if op == "0xa4":
+        days = entry.get("days")
+        if isinstance(days, dict):
+            return ", ".join(f"{day[:3]}={value}" for day, value in days.items())
+        return "slots/weekday"
+    start_text = entry.get("start_text")
+    end_text = entry.get("end_text")
+    temp = entry.get("temperature_c")
+    if isinstance(start_text, str) and isinstance(end_text, str):
+        if isinstance(temp, (int, float)) and not isinstance(temp, bool):
+            return f"{start_text}-{end_text} @ {float(temp):g}C"
+        return f"{start_text}-{end_text}"
+    return "entry"
+
+
 @dataclass(slots=True)
 class BrowseStore:
     device_label: str
@@ -194,12 +235,7 @@ class BrowseStore:
         row_by_id: dict[str, RegisterRow] = {}
         groups = artifact.get("groups")
         if not isinstance(groups, dict):
-            return cls(
-                device_label=device_label,
-                rows=[],
-                tree_nodes=tree_nodes,
-                _row_by_id={},
-            )
+            groups = {}
 
         group_keys = sorted((k for k in groups if isinstance(k, str)), key=_safe_int_hex)
         if group_keys:
@@ -471,6 +507,174 @@ class BrowseStore:
                             rows.append(row)
                             row_by_id[row_id] = row
 
+        b555_dump = artifact.get("b555_dump")
+        if isinstance(b555_dump, dict):
+            tree_nodes.append(
+                TreeNodeRef(
+                    node_id="proto:b555",
+                    label="B555",
+                    level="protocol",
+                    protocol="b555",
+                )
+            )
+            programs = b555_dump.get("programs")
+            if isinstance(programs, dict):
+                for program_key in sorted(
+                    (key for key in programs if isinstance(key, str)),
+                    key=str,
+                ):
+                    program_obj = programs.get(program_key)
+                    if not isinstance(program_obj, dict):
+                        continue
+                    label = str(program_obj.get("label") or program_key)
+                    tree_nodes.append(
+                        TreeNodeRef(
+                            node_id=f"b555:program:{program_key}",
+                            label=label,
+                            level="group",
+                            protocol="b555",
+                            group_key=program_key,
+                        )
+                    )
+
+                    selector_obj = program_obj.get("selector")
+                    selector_text = ""
+                    if isinstance(selector_obj, dict):
+                        zone = selector_obj.get("zone")
+                        hc = selector_obj.get("hc")
+                        if isinstance(zone, str) and isinstance(hc, str):
+                            selector_text = f"zone={zone} hc={hc}"
+
+                    for entry_key, tab in (("config", "config"), ("slots_per_weekday", "config")):
+                        entry = program_obj.get(entry_key)
+                        if not isinstance(entry, dict):
+                            continue
+                        register_key = "0xa3" if entry_key == "config" else "0xa4"
+                        name = f"{label} {entry_key.replace('_', ' ')}"
+                        value_text = _format_b555_value(entry)
+                        raw_hex = str(entry.get("reply_hex") or "")
+                        access_flags = str(entry.get("status_label") or "—")
+                        path = f"B555/{label}/{entry_key}"
+                        row_id = f"b555:{program_key}:{entry_key}"
+                        address = RegisterAddress(
+                            protocol="b555",
+                            group_key=program_key,
+                            namespace_key=None,
+                            namespace_label=None,
+                            instance_key=None,
+                            register_key=register_key,
+                            read_opcode=register_key,
+                        )
+                        search_blob = " ".join(
+                            [
+                                path.lower(),
+                                name.lower(),
+                                selector_text.lower(),
+                                value_text.lower(),
+                                raw_hex.lower(),
+                                access_flags.lower(),
+                            ]
+                        )
+                        row = RegisterRow(
+                            row_id=row_id,
+                            protocol="b555",
+                            group_key=program_key,
+                            namespace_key=None,
+                            namespace_label=None,
+                            group_name=label,
+                            instance_key=None,
+                            register_key=register_key,
+                            name=name,
+                            myvaillant_name="",
+                            ebusd_name="",
+                            path=path,
+                            tab=tab,
+                            address=address,
+                            value_text=value_text,
+                            raw_hex=raw_hex,
+                            unit="n/a",
+                            access_flags=access_flags,
+                            last_update_text=last_update_text,
+                            age_text=age_text,
+                            change_indicator="-",
+                            search_blob=search_blob,
+                        )
+                        rows.append(row)
+                        row_by_id[row_id] = row
+
+                    weekdays = program_obj.get("weekdays")
+                    if not isinstance(weekdays, dict):
+                        continue
+                    for day_name in sorted(
+                        (key for key in weekdays if isinstance(key, str)),
+                        key=str,
+                    ):
+                        day_obj = weekdays.get(day_name)
+                        if not isinstance(day_obj, dict):
+                            continue
+                        slots = day_obj.get("slots")
+                        if not isinstance(slots, dict):
+                            continue
+                        for slot_key in sorted(
+                            (key for key in slots if isinstance(key, str)),
+                            key=_safe_int_hex,
+                        ):
+                            entry = slots.get(slot_key)
+                            if not isinstance(entry, dict):
+                                continue
+                            register_key = f"{day_name}:{slot_key}"
+                            name = f"{label} {day_name} slot {slot_key}"
+                            value_text = _format_b555_value(entry)
+                            raw_hex = str(entry.get("reply_hex") or "")
+                            access_flags = str(entry.get("status_label") or "—")
+                            path = f"B555/{label}/{day_name}/{slot_key}"
+                            row_id = f"b555:{program_key}:{day_name}:{slot_key}"
+                            address = RegisterAddress(
+                                protocol="b555",
+                                group_key=program_key,
+                                namespace_key=None,
+                                namespace_label=None,
+                                instance_key=None,
+                                register_key=register_key,
+                                read_opcode=str(entry.get("op") or "0xa5"),
+                            )
+                            search_blob = " ".join(
+                                [
+                                    path.lower(),
+                                    name.lower(),
+                                    selector_text.lower(),
+                                    value_text.lower(),
+                                    raw_hex.lower(),
+                                    access_flags.lower(),
+                                ]
+                            )
+                            row = RegisterRow(
+                                row_id=row_id,
+                                protocol="b555",
+                                group_key=program_key,
+                                namespace_key=None,
+                                namespace_label=None,
+                                group_name=label,
+                                instance_key=None,
+                                register_key=register_key,
+                                name=name,
+                                myvaillant_name="",
+                                ebusd_name="",
+                                path=path,
+                                tab="state",
+                                address=address,
+                                value_text=value_text,
+                                raw_hex=raw_hex,
+                                unit="n/a",
+                                access_flags=access_flags,
+                                last_update_text=last_update_text,
+                                age_text=age_text,
+                                change_indicator="-",
+                                search_blob=search_blob,
+                            )
+                            rows.append(row)
+                            row_by_id[row_id] = row
+
         rows.sort(key=_row_sort_key)
         return cls(
             device_label=device_label,
@@ -488,11 +692,15 @@ class BrowseStore:
             return selected
         if node.level == "protocol" and node.protocol is not None:
             return [row for row in selected if row.protocol == node.protocol]
-        if node.level == "group" and node.protocol == "b524" and node.group_key is not None:
+        if (
+            node.level == "group"
+            and node.protocol in {"b524", "b555"}
+            and node.group_key is not None
+        ):
             return [
                 row
                 for row in selected
-                if row.protocol == "b524" and row.group_key == node.group_key
+                if row.protocol == node.protocol and row.group_key == node.group_key
             ]
         if (
             node.level == "namespace"

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -909,6 +909,10 @@ __ARTIFACT_JSON__
         return tabId === "b509";
       }
 
+      function _isB555Tab(tabId) {
+        return tabId === "b555";
+      }
+
       function _isB524Tab(tabId) {
         return typeof tabId === "string" && tabId.startsWith("b524:");
       }
@@ -925,10 +929,24 @@ __ARTIFACT_JSON__
         }
       }
 
-      function buildTabs(groupKeys, hasB509) {
+      function buildTabs(groupKeys, hasB555, hasB509) {
         tabsEl.innerHTML = "";
         const groupsRoot = artifact && typeof artifact === "object" ? artifact.groups || {} : {};
         const orderedTabIds = [];
+
+        if (hasB555) {
+          const btn = document.createElement("div");
+          btn.className = "tab";
+          btn.textContent = "B555 Dump";
+          btn.dataset.tabId = "b555";
+          btn.addEventListener("click", () => {
+            state.activeTab = "b555";
+            _syncActiveTabClasses();
+            renderActiveTab();
+          });
+          tabsEl.appendChild(btn);
+          orderedTabIds.push("b555");
+        }
 
         if (hasB509) {
           const btn = document.createElement("div");
@@ -965,6 +983,128 @@ __ARTIFACT_JSON__
           state.activeTab = orderedTabIds[0] || null;
         }
         _syncActiveTabClasses();
+      }
+
+      function renderB555Tab() {
+        const b555 = artifact && typeof artifact === "object" ? artifact.b555_dump : null;
+        if (!b555 || typeof b555 !== "object") {
+          sheetArea.innerHTML = "<div class='subtitle'>No B555 dump in artifact.</div>";
+          return;
+        }
+
+        const programs = b555.programs && typeof b555.programs === "object" ? b555.programs : {};
+        const rows = [];
+
+        for (const programKey of Object.keys(programs).sort()) {
+          const program = programs[programKey];
+          if (!program || typeof program !== "object") continue;
+          const label = typeof program.label === "string" && program.label ? program.label : programKey;
+          const selector = program.selector && typeof program.selector === "object" ? program.selector : {};
+          const zone = typeof selector.zone === "string" ? selector.zone : "n/a";
+          const hc = typeof selector.hc === "string" ? selector.hc : "n/a";
+
+          function pushRow(kind, key, entry, valueText) {
+            if (!entry || typeof entry !== "object") return;
+            rows.push({
+              programKey,
+              label,
+              selector: `zone=${zone} hc=${hc}`,
+              kind,
+              key,
+              valueText,
+              requestHex: typeof entry.request_hex === "string" ? entry.request_hex : "",
+              replyHex: typeof entry.reply_hex === "string" ? entry.reply_hex : "",
+              error: typeof entry.error === "string" ? entry.error : "",
+              status: typeof entry.status_label === "string" ? entry.status_label : (typeof entry.status === "string" ? entry.status : ""),
+            });
+          }
+
+          const config = program.config;
+          if (config && typeof config === "object") {
+            const parts = [];
+            if (typeof config.max_slots === "number") parts.push(`max_slots=${config.max_slots}`);
+            if (typeof config.temp_slots === "number") parts.push(`temp_slots=${config.temp_slots}`);
+            if (typeof config.time_resolution_min === "number") parts.push(`resolution=${config.time_resolution_min}m`);
+            pushRow("A3", "config", config, parts.join(", ") || "config");
+          }
+
+          const slots = program.slots_per_weekday;
+          if (slots && typeof slots === "object") {
+            const dayMap = slots.days && typeof slots.days === "object" ? slots.days : {};
+            const valueText = Object.entries(dayMap).map(([day, count]) => `${day.slice(0, 3)}=${count}`).join(", ") || "slots/weekday";
+            pushRow("A4", "slots_per_weekday", slots, valueText);
+          }
+
+          const weekdays = program.weekdays && typeof program.weekdays === "object" ? program.weekdays : {};
+          for (const dayName of Object.keys(weekdays).sort()) {
+            const dayObj = weekdays[dayName];
+            if (!dayObj || typeof dayObj !== "object") continue;
+            const slotMap = dayObj.slots && typeof dayObj.slots === "object" ? dayObj.slots : {};
+            for (const slotKey of sortedHexKeys(Object.keys(slotMap))) {
+              const entry = slotMap[slotKey];
+              if (!entry || typeof entry !== "object") continue;
+              let valueText = typeof entry.status_label === "string" && entry.status_label && entry.status_label !== "available"
+                ? entry.status_label
+                : "entry";
+              if (typeof entry.start_text === "string" && typeof entry.end_text === "string") {
+                valueText = `${entry.start_text}-${entry.end_text}`;
+                if (typeof entry.temperature_c === "number") valueText += ` @ ${formatValue(entry.temperature_c)}C`;
+              }
+              pushRow("A5", `${dayName}:${slotKey}`, entry, valueText);
+            }
+          }
+        }
+
+        const card = document.createElement("div");
+        if (!rows.length) {
+          const msg = document.createElement("div");
+          msg.className = "subtitle";
+          msg.textContent = "No B555 rows in artifact.";
+          card.appendChild(msg);
+          sheetArea.innerHTML = "";
+          sheetArea.appendChild(card);
+          return;
+        }
+
+        const wrap = document.createElement("div");
+        wrap.className = "table-wrap";
+        const table = document.createElement("table");
+        const thead = document.createElement("thead");
+        const trHead = document.createElement("tr");
+        for (const col of ["Program", "Selector", "Entry", "Value", "Reply", "Error"]) {
+          const th = document.createElement("th");
+          th.textContent = col;
+          trHead.appendChild(th);
+        }
+        thead.appendChild(trHead);
+        table.appendChild(thead);
+
+        const tbody = document.createElement("tbody");
+        for (const row of rows) {
+          const tr = document.createElement("tr");
+          for (const value of [
+            row.label,
+            row.selector,
+            `${row.kind} ${row.key}`,
+            row.status ? `${row.valueText} (${row.status})` : row.valueText,
+            row.replyHex || "—",
+            row.error || "—",
+          ]) {
+            const td = document.createElement("td");
+            td.textContent = value;
+            tr.appendChild(td);
+          }
+          if (row.requestHex) {
+            tr.title = `request_hex=${row.requestHex}${row.replyHex ? `\\nreply_hex=${row.replyHex}` : ""}`;
+          }
+          tbody.appendChild(tr);
+        }
+
+        table.appendChild(tbody);
+        wrap.appendChild(table);
+        card.appendChild(wrap);
+        sheetArea.innerHTML = "";
+        sheetArea.appendChild(card);
       }
 
       function renderB509Tab() {
@@ -1416,6 +1556,10 @@ __ARTIFACT_JSON__
       }
 
       function renderActiveTab() {
+        if (_isB555Tab(state.activeTab)) {
+          renderB555Tab();
+          return;
+        }
         if (_isB509Tab(state.activeTab)) {
           renderB509Tab();
           return;
@@ -1426,9 +1570,10 @@ __ARTIFACT_JSON__
 
       const groupsRoot = artifact && typeof artifact === "object" ? artifact.groups || {} : {};
       const groupKeys = sortedHexKeys(Object.keys(groupsRoot));
+      const hasB555 = !!(artifact && typeof artifact === "object" && artifact.b555_dump && typeof artifact.b555_dump === "object");
       const hasB509 = !!(artifact && typeof artifact === "object" && artifact.b509_dump && typeof artifact.b509_dump === "object");
       renderSummaryChips(groupsRoot);
-      buildTabs(groupKeys, hasB509);
+      buildTabs(groupKeys, hasB555, hasB509);
       renderActiveTab();
     </script>
   </body>

--- a/src/helianthus_vrc_explorer/ui/live.py
+++ b/src/helianthus_vrc_explorer/ui/live.py
@@ -27,6 +27,7 @@ _PHASE_LABELS: dict[str, str] = {
     "constraint_probe": "Constraint Probe",
     "instance_discovery": "Instance Discovery",
     "register_scan": "Register Scan",
+    "b555_dump": "B555 Dump",
     "b509_dump": "B509 Dump",
 }
 

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -253,6 +253,25 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
                 b509_txt += " incomplete=true"
             console.print(b509_txt, style="dim")
 
+    b555_dump = artifact.get("b555_dump")
+    if isinstance(b555_dump, dict):
+        b555_meta = b555_dump.get("meta")
+        if isinstance(b555_meta, dict):
+            b555_reads = b555_meta.get("read_count")
+            b555_errors = b555_meta.get("error_count")
+            b555_incomplete = bool(b555_meta.get("incomplete", False))
+            programs = b555_dump.get("programs")
+            b555_txt = "b555"
+            if isinstance(b555_reads, int):
+                b555_txt += f" reads={b555_reads}"
+            if isinstance(b555_errors, int):
+                b555_txt += f" errors={b555_errors}"
+            if isinstance(programs, dict):
+                b555_txt += f" programs={len(programs)}"
+            if b555_incomplete:
+                b555_txt += " incomplete=true"
+            console.print(b555_txt, style="dim")
+
     table = Table(show_header=True, header_style="bold", box=None)
     table.add_column("Group", style="cyan", no_wrap=True)
     table.add_column("Name", style="white")

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -224,6 +224,79 @@ def test_browse_store_hides_b524_protocol_when_no_groups_present() -> None:
     assert "proto:b509" in node_ids
 
 
+def test_browse_store_adds_b555_protocol_and_program_rows() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {},
+        "b555_dump": {
+            "meta": {"read_count": 3, "error_count": 0, "incomplete": False},
+            "programs": {
+                "z1_heating": {
+                    "label": "Z1 Heating",
+                    "selector": {"zone": "0x00", "hc": "0x00"},
+                    "config": {
+                        "op": "0xa3",
+                        "reply_hex": "000c0a05010c051e00",
+                        "status": "0x00",
+                        "status_label": "available",
+                        "max_slots": 12,
+                        "temp_slots": 12,
+                        "time_resolution_min": 10,
+                    },
+                    "slots_per_weekday": {
+                        "op": "0xa4",
+                        "reply_hex": "000100000000000000",
+                        "status": "0x00",
+                        "status_label": "available",
+                        "days": {
+                            "monday": 1,
+                            "tuesday": 0,
+                            "wednesday": 0,
+                            "thursday": 0,
+                            "friday": 0,
+                            "saturday": 0,
+                            "sunday": 0,
+                        },
+                    },
+                    "weekdays": {
+                        "monday": {
+                            "slots": {
+                                "0x00": {
+                                    "op": "0xa5",
+                                    "reply_hex": "0000001800e100",
+                                    "status": "0x00",
+                                    "status_label": "available",
+                                    "start_text": "00:00",
+                                    "end_text": "24:00",
+                                    "temperature_c": 22.5,
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    node_ids = {node.node_id for node in store.tree_nodes}
+    assert "proto:b555" in node_ids
+    assert "b555:program:z1_heating" in node_ids
+
+    b555_rows = [row for row in store.rows if row.protocol == "b555"]
+    assert len(b555_rows) == 3
+    assert any(row.name == "Z1 Heating config" for row in b555_rows)
+    assert any(row.name == "Z1 Heating slots per weekday" for row in b555_rows)
+    slot_row = next(row for row in b555_rows if row.register_key == "monday:0x00")
+    assert slot_row.value_text == "00:00-24:00 @ 22.5C"
+
+    program_node = next(
+        node for node in store.tree_nodes if node.node_id == "b555:program:z1_heating"
+    )
+    selected = store.rows_for_selection(program_node, tab="state")
+    assert [row.register_key for row in selected] == ["monday:0x00"]
+
+
 def test_browse_store_treats_unknown_singleton_group_as_singleton() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -41,6 +41,62 @@ def test_html_report_supports_b509_tab_and_dual_naming() -> None:
     assert "ebusd: " in html
 
 
+def test_html_report_supports_b555_tab() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {},
+        "b555_dump": {
+            "meta": {"read_count": 3, "error_count": 0, "incomplete": False},
+            "programs": {
+                "z1_heating": {
+                    "label": "Z1 Heating",
+                    "selector": {"zone": "0x00", "hc": "0x00"},
+                    "config": {
+                        "request_hex": "a30000",
+                        "reply_hex": "000c0a05010c051e00",
+                        "status": "0x00",
+                        "status_label": "available",
+                        "max_slots": 12,
+                        "temp_slots": 12,
+                        "time_resolution_min": 10,
+                    },
+                    "slots_per_weekday": {
+                        "request_hex": "a40000",
+                        "reply_hex": "000100000000000000",
+                        "status": "0x00",
+                        "status_label": "available",
+                        "days": {"monday": 1},
+                    },
+                    "weekdays": {
+                        "monday": {
+                            "slots": {
+                                "0x00": {
+                                    "op": "0xa5",
+                                    "request_hex": "a500000000",
+                                    "reply_hex": "0000001800e100",
+                                    "status": "0x00",
+                                    "status_label": "available",
+                                    "start_text": "00:00",
+                                    "end_text": "24:00",
+                                    "temperature_c": 22.5,
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert "B555 Dump" in html
+    assert "No B555 dump in artifact." in html
+    assert "request_hex=" in html
+    assert '"zone":"0x00"' in html
+    assert '"hc":"0x00"' in html
+
+
 def test_html_report_renders_namespace_totals_and_flags_access_for_dual_namespace_groups() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -72,6 +72,10 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
                 },
             },
         },
+        "b555_dump": {
+            "meta": {"read_count": 4, "error_count": 1, "incomplete": False},
+            "programs": {"z1_heating": {}, "dhw": {}},
+        },
     }
 
     console = Console(record=True, width=140)
@@ -81,6 +85,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     text = console.export_text()
     assert "namespaces local=2, remote=1" in text
     assert "flags_access volatile_ro=0, stable_ro=2, technical_rw=0, user_rw=1" in text
+    assert "b555 reads=4 errors=1 programs=2" in text
     assert "local=1, remote=1" in text
     assert "Radio Sensors VRC7xx" in text
     assert "2/2" not in text


### PR DESCRIPTION
## Summary
- expose `b555_dump` in CLI summary as a distinct protocol line
- add a separate `proto:b555` browse section without flattening B555 into B524 groups
- add a dedicated B555 tab in the HTML report with raw request/reply evidence

## Testing
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m pytest -q tests/test_summary.py tests/test_browse_store.py tests/test_html_report.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/ui/summary.py src/helianthus_vrc_explorer/ui/browse_models.py src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/html_report.py src/helianthus_vrc_explorer/ui/live.py tests/test_summary.py tests/test_browse_store.py tests/test_html_report.py`
- `../helianthus-vrc-explorer/venv/bin/python -m ruff format --check src/helianthus_vrc_explorer/ui/summary.py src/helianthus_vrc_explorer/ui/browse_models.py src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/html_report.py src/helianthus_vrc_explorer/ui/live.py tests/test_summary.py tests/test_browse_store.py tests/test_html_report.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`
