### PR TITLE
scanner: add read-only B516 dump path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -608,6 +608,10 @@ CI enforces this via `python scripts/check_docs_sync.py`.
 │                                                               by default to keep the standard B524/B509 scan path    │
 │                                                               unchanged.                                             │
 │                                                               [default: no-b555-dump]                                │
+│ --b516-dump                --no-b516-dump                     Opt-in read-only B516 energy dump (active              │
+│                                                               request/response only). Disabled by default to keep    │
+│                                                               the standard B524/B555/B509 scan path unchanged.       │
+│                                                               [default: no-b516-dump]                                │
 │ --planner-ui                                         TEXT     Interactive planner mode: disabled, auto, textual, or  │
 │                                                               classic.                                               │
 │                                                               [default: disabled]                                    │

--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -614,6 +614,14 @@ def scan(
             "the standard B524/B509 scan path unchanged."
         ),
     ),
+    b516_dump: bool = typer.Option(  # noqa: B008
+        False,
+        "--b516-dump/--no-b516-dump",
+        help=(
+            "Opt-in read-only B516 energy dump (active request/response only). Disabled "
+            "by default to keep the standard B524/B555/B509 scan path unchanged."
+        ),
+    ),
     planner_ui: str = typer.Option(  # noqa: B008
         "disabled",
         "--planner-ui",
@@ -764,6 +772,7 @@ def scan(
                             dst=dst_u8,
                             b509_ranges=b509_ranges,
                             b555_dump=b555_dump,
+                            b516_dump=b516_dump,
                             ebusd_host=transport_settings.host,
                             ebusd_port=transport_settings.port,
                             ebusd_schema=ebusd_schema,

--- a/src/helianthus_vrc_explorer/protocol/b516.py
+++ b/src/helianthus_vrc_explorer/protocol/b516.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from struct import unpack as _unpack
+
+
+def _validate_nibble(name: str, value: int) -> int:
+    if not (0x0 <= value <= 0xF):
+        raise ValueError(f"{name} out of range 0x0..0xF: 0x{value:X}")
+    return value
+
+
+def build_b516_payload(*, period: int, source: int, usage: int, w: int, v: int, q: int) -> bytes:
+    return bytes(
+        (
+            0x10,
+            _validate_nibble("period", period),
+            0xFF,
+            0xFF,
+            _validate_nibble("source", source),
+            _validate_nibble("usage", usage),
+            (_validate_nibble("w", w) << 4) | _validate_nibble("v", v),
+            0x30 | _validate_nibble("q", q),
+        )
+    )
+
+
+def build_b516_system_payload(*, source: int, usage: int) -> bytes:
+    return build_b516_payload(period=0x0, source=source, usage=usage, w=0x0, v=0x0, q=0x0)
+
+
+def build_b516_year_payload(*, source: int, usage: int, current: bool) -> bytes:
+    return build_b516_payload(
+        period=0x3,
+        source=source,
+        usage=usage,
+        w=0x0,
+        v=0x0,
+        q=0x2 if current else 0x0,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class B516Response:
+    period: int
+    source: int
+    usage: int
+    packed_window: int
+    qualifier: int
+    value_wh: float
+
+    @property
+    def value_kwh(self) -> float:
+        return self.value_wh / 1000.0
+
+
+def parse_b516_response(payload: bytes) -> B516Response:
+    blob = bytes(payload)
+    if len(blob) < 11:
+        raise ValueError(f"B516 response must be at least 11 bytes, got {len(blob)}")
+    return B516Response(
+        period=blob[0] & 0x0F,
+        source=blob[3] & 0x0F,
+        usage=blob[4] & 0x0F,
+        packed_window=blob[5],
+        qualifier=blob[6] & 0x0F,
+        value_wh=float(_unpack("<f", blob[-4:])[0]),
+    )

--- a/src/helianthus_vrc_explorer/scanner/b516.py
+++ b/src/helianthus_vrc_explorer/scanner/b516.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from ..protocol.b516 import (
+    B516Response,
+    build_b516_system_payload,
+    build_b516_year_payload,
+    parse_b516_response,
+)
+from ..transport.base import TransportCommandNotEnabled, TransportError, TransportTimeout
+from .observer import ScanObserver
+
+_B516_PRIMARY = 0xB5
+_B516_SECONDARY = 0x16
+
+
+class _B516Transport(Protocol):
+    def send_proto(
+        self,
+        dst: int,
+        primary: int,
+        secondary: int,
+        payload: bytes,
+        *,
+        expect_response: bool = True,
+    ) -> bytes: ...
+
+
+@dataclass(frozen=True, slots=True)
+class B516SelectorSpec:
+    key: str
+    label: str
+    period: str
+    source: str
+    usage: str
+    payload: bytes
+
+
+DEFAULT_B516_SELECTORS: tuple[B516SelectorSpec, ...] = (
+    B516SelectorSpec(
+        "system.gas.heating",
+        "System Gas Heating",
+        "system",
+        "gas",
+        "heating",
+        build_b516_system_payload(source=0x4, usage=0x3),
+    ),
+    B516SelectorSpec(
+        "system.gas.hot_water",
+        "System Gas Hot Water",
+        "system",
+        "gas",
+        "hot_water",
+        build_b516_system_payload(source=0x4, usage=0x4),
+    ),
+    B516SelectorSpec(
+        "system.electricity.heating",
+        "System Electricity Heating",
+        "system",
+        "electricity",
+        "heating",
+        build_b516_system_payload(source=0x3, usage=0x3),
+    ),
+    B516SelectorSpec(
+        "system.electricity.hot_water",
+        "System Electricity Hot Water",
+        "system",
+        "electricity",
+        "hot_water",
+        build_b516_system_payload(source=0x3, usage=0x4),
+    ),
+    B516SelectorSpec(
+        "year.current.gas.heating",
+        "Current Year Gas Heating",
+        "year_current",
+        "gas",
+        "heating",
+        build_b516_year_payload(source=0x4, usage=0x3, current=True),
+    ),
+    B516SelectorSpec(
+        "year.current.gas.hot_water",
+        "Current Year Gas Hot Water",
+        "year_current",
+        "gas",
+        "hot_water",
+        build_b516_year_payload(source=0x4, usage=0x4, current=True),
+    ),
+    B516SelectorSpec(
+        "year.current.electricity.heating",
+        "Current Year Electricity Heating",
+        "year_current",
+        "electricity",
+        "heating",
+        build_b516_year_payload(source=0x3, usage=0x3, current=True),
+    ),
+    B516SelectorSpec(
+        "year.current.electricity.hot_water",
+        "Current Year Electricity Hot Water",
+        "year_current",
+        "electricity",
+        "hot_water",
+        build_b516_year_payload(source=0x3, usage=0x4, current=True),
+    ),
+    B516SelectorSpec(
+        "year.previous.gas.heating",
+        "Previous Year Gas Heating",
+        "year_previous",
+        "gas",
+        "heating",
+        build_b516_year_payload(source=0x4, usage=0x3, current=False),
+    ),
+    B516SelectorSpec(
+        "year.previous.gas.hot_water",
+        "Previous Year Gas Hot Water",
+        "year_previous",
+        "gas",
+        "hot_water",
+        build_b516_year_payload(source=0x4, usage=0x4, current=False),
+    ),
+    B516SelectorSpec(
+        "year.previous.electricity.heating",
+        "Previous Year Electricity Heating",
+        "year_previous",
+        "electricity",
+        "heating",
+        build_b516_year_payload(source=0x3, usage=0x3, current=False),
+    ),
+    B516SelectorSpec(
+        "year.previous.electricity.hot_water",
+        "Previous Year Electricity Hot Water",
+        "year_previous",
+        "electricity",
+        "hot_water",
+        build_b516_year_payload(source=0x3, usage=0x4, current=False),
+    ),
+)
+
+
+def _emit_trace_label(transport: _B516Transport, label: str) -> None:
+    trace_fn = getattr(transport, "trace_label", None)
+    if callable(trace_fn):
+        trace_fn(label)
+
+
+def _entry_from_result(
+    spec: B516SelectorSpec,
+    *,
+    response: bytes | None,
+    parsed: B516Response | None,
+    error: str | None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "label": spec.label,
+        "period": spec.period,
+        "source": spec.source,
+        "usage": spec.usage,
+        "request_hex": spec.payload.hex(),
+        "reply_hex": response.hex() if response is not None else None,
+        "error": error,
+    }
+    if parsed is None:
+        return entry
+    entry.update(
+        {
+            "echo_period": f"0x{parsed.period:01x}",
+            "echo_source": f"0x{parsed.source:01x}",
+            "echo_usage": f"0x{parsed.usage:01x}",
+            "echo_window": f"0x{parsed.packed_window:02x}",
+            "echo_qualifier": f"0x{parsed.qualifier:01x}",
+            "value_wh": parsed.value_wh,
+            "value_kwh": parsed.value_kwh,
+        }
+    )
+    return entry
+
+
+def scan_b516(
+    transport: _B516Transport,
+    *,
+    dst: int,
+    observer: ScanObserver | None = None,
+) -> dict[str, Any]:
+    start_perf = time.perf_counter()
+    read_count = 0
+    error_count = 0
+    incomplete = False
+    incomplete_reason: str | None = None
+
+    artifact: dict[str, Any] = {
+        "meta": {
+            "scan_timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "scan_duration_seconds": 0.0,
+            "destination_address": f"0x{dst:02x}",
+            "read_count": 0,
+            "error_count": 0,
+            "selector_count": len(DEFAULT_B516_SELECTORS),
+            "incomplete": False,
+        },
+        "entries": {},
+    }
+    entries = artifact["entries"]
+
+    try:
+        if observer is not None:
+            observer.phase_start("b516_dump", total=len(DEFAULT_B516_SELECTORS) or 1)
+        _emit_trace_label(transport, "B516 Energy Dump")
+
+        for spec in DEFAULT_B516_SELECTORS:
+            if observer is not None:
+                observer.status(f"B516 {spec.label}")
+            response: bytes | None = None
+            parsed: B516Response | None = None
+            error: str | None = None
+            try:
+                response = transport.send_proto(dst, _B516_PRIMARY, _B516_SECONDARY, spec.payload)
+                parsed = parse_b516_response(response)
+            except TransportTimeout:
+                error = "timeout"
+            except TransportError as exc:
+                if isinstance(exc, TransportCommandNotEnabled):
+                    raise
+                error = f"transport_error: {exc}"
+            except Exception as exc:
+                error = f"parse_error: {exc}"
+
+            read_count += 1
+            if error is not None:
+                error_count += 1
+
+            entries[spec.key] = _entry_from_result(
+                spec,
+                response=response,
+                parsed=parsed,
+                error=error,
+            )
+            if observer is not None:
+                observer.phase_advance("b516_dump", advance=1)
+
+    except KeyboardInterrupt:
+        incomplete = True
+        incomplete_reason = "user_interrupt"
+    finally:
+        if observer is not None:
+            observer.phase_finish("b516_dump")
+
+    artifact["meta"]["scan_duration_seconds"] = round(time.perf_counter() - start_perf, 4)
+    artifact["meta"]["read_count"] = read_count
+    artifact["meta"]["error_count"] = error_count
+    artifact["meta"]["incomplete"] = incomplete
+    if incomplete_reason is not None:
+        artifact["meta"]["incomplete_reason"] = incomplete_reason
+    return artifact

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -31,6 +31,7 @@ from ..transport.base import (
 from ..transport.instrumented import CountingTransport
 from ..ui.planner import PlannerGroup, PlannerPreset, build_plan_from_preset, prompt_scan_plan
 from .b509 import scan_b509
+from .b516 import scan_b516
 from .b555 import scan_b555
 from .director import GROUP_CONFIG, classify_groups, discover_groups
 from .observer import ScanObserver
@@ -1509,6 +1510,7 @@ def scan_vrc(
     dst: int,
     b509_ranges: list[tuple[int, int]],
     b555_dump: bool = False,
+    b516_dump: bool = False,
     ebusd_host: str | None = None,
     ebusd_port: int | None = None,
     ebusd_schema: EbusdCsvSchema | None = None,
@@ -1519,7 +1521,7 @@ def scan_vrc(
     planner_preset: PlannerPreset = "recommended",
     probe_constraints: bool = False,
 ) -> dict[str, Any]:
-    """Run the full VRC scan flow: B524 primary scan, optional B555 dump, then B509."""
+    """Run the full VRC scan flow: B524 primary scan, optional B555/B516 dumps, then B509."""
 
     artifact = scan_b524(
         transport,
@@ -1561,6 +1563,27 @@ def scan_vrc(
                 reason = b555_meta.get("incomplete_reason")
                 if isinstance(reason, str):
                     meta["incomplete_reason"] = f"b555_{reason}"
+            return artifact
+
+    if b516_dump:
+        b516_artifact = scan_b516(
+            transport,  # type: ignore[arg-type]
+            dst=dst,
+            observer=observer,
+        )
+        artifact["b516_dump"] = b516_artifact
+
+        b516_meta = b516_artifact.get("meta", {})
+        if (
+            isinstance(b516_meta, dict)
+            and bool(b516_meta.get("incomplete"))
+            and isinstance(meta, dict)
+        ):
+            meta["incomplete"] = True
+            if "incomplete_reason" not in meta:
+                reason = b516_meta.get("incomplete_reason")
+                if isinstance(reason, str):
+                    meta["incomplete_reason"] = f"b516_{reason}"
             return artifact
 
     b509_dump = scan_b509(

--- a/src/helianthus_vrc_explorer/ui/live.py
+++ b/src/helianthus_vrc_explorer/ui/live.py
@@ -28,6 +28,7 @@ _PHASE_LABELS: dict[str, str] = {
     "instance_discovery": "Instance Discovery",
     "register_scan": "Register Scan",
     "b555_dump": "B555 Dump",
+    "b516_dump": "B516 Dump",
     "b509_dump": "B509 Dump",
 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,7 @@ def test_scan_cli_defaults_planner_ui_to_disabled(monkeypatch, tmp_path: Path) -
     def _fake_scan_vrc(*_args, **kwargs):
         captured["planner_ui"] = kwargs["planner_ui"]
         captured["b555_dump"] = kwargs["b555_dump"]
+        captured["b516_dump"] = kwargs["b516_dump"]
         return {
             "meta": {
                 "scan_timestamp": "2026-02-13T00:00:00Z",
@@ -251,6 +252,7 @@ def test_scan_cli_defaults_planner_ui_to_disabled(monkeypatch, tmp_path: Path) -
     assert result.exit_code == 0
     assert captured["planner_ui"] == "disabled"
     assert captured["b555_dump"] is False
+    assert captured["b516_dump"] is False
 
 
 def test_scan_cli_passes_explicit_planner_ui(monkeypatch, tmp_path: Path) -> None:
@@ -356,6 +358,58 @@ def test_scan_cli_passes_b555_dump_flag(monkeypatch, tmp_path: Path) -> None:
     )
     assert result.exit_code == 0
     assert captured["b555_dump"] is True
+
+
+def test_scan_cli_passes_b516_dump_flag(monkeypatch, tmp_path: Path) -> None:
+    import helianthus_vrc_explorer.cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    class _OkTransport:
+        @contextmanager
+        def session(self):
+            yield self
+
+    def _fake_build_transport(settings, *, trace_file):  # noqa: ANN001
+        _ = settings
+        _ = trace_file
+        return _OkTransport()
+
+    @contextmanager
+    def _fake_observer(*_args, **_kwargs):
+        yield None
+
+    def _fake_scan_vrc(*_args, **kwargs):
+        captured["b516_dump"] = kwargs["b516_dump"]
+        return {
+            "meta": {
+                "scan_timestamp": "2026-02-13T00:00:00Z",
+                "destination_address": "0x15",
+                "incomplete": False,
+                "schema_sources": [],
+            },
+            "groups": {},
+        }
+
+    monkeypatch.setattr(cli_mod, "_build_transport", _fake_build_transport)
+    monkeypatch.setattr(cli_mod, "_probe_scan_identity", lambda _transport, *, dst: {})
+    monkeypatch.setattr(cli_mod, "make_scan_observer", _fake_observer)
+    monkeypatch.setattr(cli_mod, "scan_vrc", _fake_scan_vrc)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--dst",
+            "0x15",
+            "--b516-dump",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured["b516_dump"] is True
 
 
 def test_scan_cli_missing_textual_browse_falls_back_to_html_and_summary(

--- a/tests/test_protocol_b516.py
+++ b/tests/test_protocol_b516.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from helianthus_vrc_explorer.protocol.b516 import (
+    build_b516_system_payload,
+    build_b516_year_payload,
+    parse_b516_response,
+)
+
+
+def test_build_b516_payloads() -> None:
+    assert build_b516_system_payload(source=0x4, usage=0x3) == bytes.fromhex("1000ffff04030030")
+    assert build_b516_year_payload(source=0x3, usage=0x4, current=True) == bytes.fromhex(
+        "1003ffff03040032"
+    )
+    assert build_b516_year_payload(source=0x3, usage=0x4, current=False) == bytes.fromhex(
+        "1003ffff03040030"
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "usage"),
+    [
+        (0x10, 0x3),
+        (0x4, 0x10),
+    ],
+)
+def test_build_b516_payloads_validate_nibbles(source: int, usage: int) -> None:
+    with pytest.raises(ValueError):
+        build_b516_system_payload(source=source, usage=usage)
+
+
+def test_parse_b516_response() -> None:
+    parsed = parse_b516_response(bytes.fromhex("03aabb0403003200004842"))
+    assert parsed.period == 0x3
+    assert parsed.source == 0x4
+    assert parsed.usage == 0x3
+    assert parsed.packed_window == 0x00
+    assert parsed.qualifier == 0x2
+    assert parsed.value_wh == 50.0
+    assert parsed.value_kwh == 0.05
+
+
+def test_parse_b516_response_requires_min_length() -> None:
+    with pytest.raises(ValueError):
+        parse_b516_response(bytes.fromhex("03aabb0403"))

--- a/tests/test_scanner_b516.py
+++ b/tests/test_scanner_b516.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from helianthus_vrc_explorer.scanner.b516 import scan_b516
+from helianthus_vrc_explorer.scanner.scan import scan_vrc
+from helianthus_vrc_explorer.transport.base import TransportError, TransportTimeout
+
+
+class _ProtoOnlyTransport:
+    def __init__(self, responses: dict[bytes, bytes | Exception]) -> None:
+        self._responses = responses
+        self.calls: list[bytes] = []
+
+    def send_proto(
+        self,
+        dst: int,
+        primary: int,
+        secondary: int,
+        payload: bytes,
+        *,
+        expect_response: bool = True,
+    ) -> bytes:
+        _ = dst
+        _ = expect_response
+        assert (primary, secondary) == (0xB5, 0x16)
+        self.calls.append(payload)
+        response = self._responses.get(payload)
+        if response is None:
+            raise TransportError(f"unmapped payload: {payload.hex()}")
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class _NoopTransport:
+    def send(self, dst: int, payload: bytes) -> bytes:
+        _ = dst
+        _ = payload
+        raise AssertionError("send should not be called")
+
+    def send_proto(
+        self,
+        dst: int,
+        primary: int,
+        secondary: int,
+        payload: bytes,
+        *,
+        expect_response: bool = True,
+    ) -> bytes:
+        _ = dst
+        _ = primary
+        _ = secondary
+        _ = payload
+        _ = expect_response
+        raise AssertionError("send_proto should not be called")
+
+
+def test_scan_b516_collects_entries_and_preserves_errors() -> None:
+    responses = {
+        bytes.fromhex("1000ffff04030030"): bytes.fromhex("00aabb0403003000004842"),
+        bytes.fromhex("1000ffff04040030"): TransportTimeout("timeout"),
+        bytes.fromhex("1000ffff03030030"): bytes.fromhex("00aabb0303003000002041"),
+        bytes.fromhex("1000ffff03040030"): bytes.fromhex("00aabb030400300000a040"),
+        bytes.fromhex("1003ffff04030032"): bytes.fromhex("03aabb0403003200002041"),
+        bytes.fromhex("1003ffff04040032"): bytes.fromhex("03aabb040400320000a040"),
+        bytes.fromhex("1003ffff03030032"): bytes.fromhex("03aabb030300320000f041"),
+        bytes.fromhex("1003ffff03040032"): bytes.fromhex("03aabb0304003200002042"),
+        bytes.fromhex("1003ffff04030030"): bytes.fromhex("03aabb0403003000002041"),
+        bytes.fromhex("1003ffff04040030"): bytes.fromhex("03aabb040400300000a040"),
+        bytes.fromhex("1003ffff03030030"): bytes.fromhex("03aabb030300300000f041"),
+        bytes.fromhex("1003ffff03040030"): bytes.fromhex("03aabb0304003000002042"),
+    }
+    transport = _ProtoOnlyTransport(responses)
+
+    artifact = scan_b516(transport, dst=0x15)
+
+    meta = artifact["meta"]
+    assert meta["destination_address"] == "0x15"
+    assert meta["selector_count"] == 12
+    assert meta["read_count"] == 12
+    assert meta["error_count"] == 1
+    assert meta["incomplete"] is False
+
+    entries = artifact["entries"]
+    assert entries["system.gas.heating"]["value_wh"] == 50.0
+    assert entries["system.gas.hot_water"]["error"] == "timeout"
+    assert entries["year.current.gas.heating"]["echo_period"] == "0x3"
+    assert entries["year.previous.electricity.hot_water"]["value_kwh"] == 0.04
+
+
+def test_scan_vrc_adds_b516_dump_when_opted_in(monkeypatch) -> None:
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    def _fake_scan_b524(*_args, **_kwargs):
+        return {"meta": {"incomplete": False}, "groups": {}}
+
+    def _fake_scan_b516(*_args, **_kwargs):
+        return {"meta": {"incomplete": False, "read_count": 12}, "entries": {}}
+
+    def _fake_scan_b509(*_args, **_kwargs):
+        return {"meta": {"incomplete": False, "read_count": 0}, "devices": {}}
+
+    monkeypatch.setattr(scan_mod, "scan_b524", _fake_scan_b524)
+    monkeypatch.setattr(scan_mod, "scan_b516", _fake_scan_b516)
+    monkeypatch.setattr(scan_mod, "scan_b509", _fake_scan_b509)
+
+    artifact = scan_vrc(
+        _NoopTransport(),
+        dst=0x15,
+        b509_ranges=[],
+        b516_dump=True,
+    )
+
+    assert artifact["b516_dump"]["meta"]["read_count"] == 12
+    assert artifact["b509_dump"]["meta"]["read_count"] == 0
+
+
+def test_scan_vrc_propagates_incomplete_b516_and_skips_b509(monkeypatch) -> None:
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    def _fake_scan_b524(*_args, **_kwargs):
+        return {"meta": {"incomplete": False}, "groups": {}}
+
+    def _fake_scan_b516(*_args, **_kwargs):
+        return {
+            "meta": {
+                "incomplete": True,
+                "incomplete_reason": "user_interrupt",
+                "read_count": 7,
+            },
+            "entries": {},
+        }
+
+    def _unexpected_scan_b509(*_args, **_kwargs):
+        raise AssertionError("B509 should be skipped after incomplete B516 dump")
+
+    monkeypatch.setattr(scan_mod, "scan_b524", _fake_scan_b524)
+    monkeypatch.setattr(scan_mod, "scan_b516", _fake_scan_b516)
+    monkeypatch.setattr(scan_mod, "scan_b509", _unexpected_scan_b509)
+
+    artifact = scan_vrc(
+        _NoopTransport(),
+        dst=0x15,
+        b509_ranges=[],
+        b516_dump=True,
+    )
+
+    assert artifact["meta"]["incomplete"] is True
+    assert artifact["meta"]["incomplete_reason"] == "b516_user_interrupt"
+    assert artifact["b516_dump"]["meta"]["read_count"] == 7
+    assert "b509_dump" not in artifact


### PR DESCRIPTION
## Summary
- add an opt-in, read-only B516 energy dump path using active request/response selectors
- persist B516 results under a dedicated `b516_dump` artifact subtree with raw request/reply evidence
- wire the feature into `scan_vrc` and CLI behind `--b516-dump`

## Testing
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m pytest -q tests/test_protocol_b516.py tests/test_scanner_b516.py tests/test_cli.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/protocol/b516.py src/helianthus_vrc_explorer/scanner/b516.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/cli.py src/helianthus_vrc_explorer/ui/live.py tests/test_protocol_b516.py tests/test_scanner_b516.py tests/test_cli.py`
- `../helianthus-vrc-explorer/venv/bin/python -m ruff format --check src/helianthus_vrc_explorer/protocol/b516.py src/helianthus_vrc_explorer/scanner/b516.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/cli.py src/helianthus_vrc_explorer/ui/live.py tests/test_protocol_b516.py tests/test_scanner_b516.py tests/test_cli.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`
