### PR TITLE
ui: expose B516 dump in summary, browse, and HTML report

### DIFF
--- a/src/helianthus_vrc_explorer/ui/browse_models.py
+++ b/src/helianthus_vrc_explorer/ui/browse_models.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 BrowseTab = Literal["config", "config_limits", "state"]
-ProtocolKey = Literal["b524", "b555", "b509"]
+ProtocolKey = Literal["b524", "b555", "b516", "b509"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +25,8 @@ class RegisterAddress:
         if self.protocol == "b555":
             group_key = self.group_key or "program"
             return f"B555 {group_key} {self.register_key}{suffix}".strip()
+        if self.protocol == "b516":
+            return f"B516 {self.register_key}{suffix}".strip()
         group_key = self.group_key or "0x??"
         instance_key = self.instance_key or "0x??"
         return f"GG={group_key} II={instance_key} RR={self.register_key}{suffix}"

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -94,7 +94,7 @@ def _instance_label(
 
 
 def _row_sort_key(row: RegisterRow) -> tuple[int, int, int, int, int]:
-    proto_weight_map = {"b524": 0, "b555": 1, "b509": 2}
+    proto_weight_map = {"b524": 0, "b555": 1, "b516": 2, "b509": 3}
     proto_weight = proto_weight_map.get(row.protocol, 99)
     if row.protocol == "b524":
         return (
@@ -111,6 +111,21 @@ def _row_sort_key(row: RegisterRow) -> tuple[int, int, int, int, int]:
             0,
             0,
             _safe_int_hex(row.register_key.split(":", 1)[-1] if ":" in row.register_key else "0"),
+        )
+    if row.protocol == "b516":
+        period_weight_map = {
+            "system": 0,
+            "year_current": 1,
+            "year_previous": 2,
+        }
+        source_weight_map = {"gas": 0, "electricity": 1}
+        usage_weight_map = {"heating": 0, "hot_water": 1}
+        return (
+            proto_weight,
+            period_weight_map.get(row.group_key or "", 99),
+            source_weight_map.get(row.namespace_key or "", 99),
+            usage_weight_map.get(row.namespace_label or "", 99),
+            0,
         )
     return (proto_weight, 0, 0, 0, _safe_int_hex(row.register_key))
 
@@ -200,6 +215,22 @@ def _format_b555_value(entry: dict[str, Any]) -> str:
         if isinstance(temp, (int, float)) and not isinstance(temp, bool):
             return f"{start_text}-{end_text} @ {float(temp):g}C"
         return f"{start_text}-{end_text}"
+    return "entry"
+
+
+def _format_b516_value(entry: dict[str, Any]) -> str:
+    error = entry.get("error")
+    if isinstance(error, str) and error:
+        return error
+    value_kwh = entry.get("value_kwh")
+    value_wh = entry.get("value_wh")
+    if isinstance(value_kwh, (int, float)) and not isinstance(value_kwh, bool):
+        value_txt = f"{float(value_kwh):g} kWh"
+        if isinstance(value_wh, (int, float)) and not isinstance(value_wh, bool):
+            value_txt += f" ({float(value_wh):g} Wh)"
+        return value_txt
+    if isinstance(value_wh, (int, float)) and not isinstance(value_wh, bool):
+        return f"{float(value_wh):g} Wh"
     return "entry"
 
 
@@ -675,6 +706,115 @@ class BrowseStore:
                             rows.append(row)
                             row_by_id[row_id] = row
 
+        b516_dump = artifact.get("b516_dump")
+        if isinstance(b516_dump, dict):
+            tree_nodes.append(
+                TreeNodeRef(
+                    node_id="proto:b516",
+                    label="B516",
+                    level="protocol",
+                    protocol="b516",
+                )
+            )
+            entries = b516_dump.get("entries")
+            if isinstance(entries, dict):
+                period_labels = {
+                    "system": "System",
+                    "year_current": "Current Year",
+                    "year_previous": "Previous Year",
+                }
+                seen_periods: set[str] = set()
+                for entry_key in sorted(
+                    (key for key in entries if isinstance(key, str)),
+                    key=str,
+                ):
+                    entry = entries.get(entry_key)
+                    if not isinstance(entry, dict):
+                        continue
+                    period = str(entry.get("period") or "").strip()
+                    source = str(entry.get("source") or "").strip()
+                    usage = str(entry.get("usage") or "").strip()
+                    label = str(entry.get("label") or entry_key).strip() or entry_key
+                    if period and period not in seen_periods:
+                        tree_nodes.append(
+                            TreeNodeRef(
+                                node_id=f"b516:group:{period}",
+                                label=period_labels.get(period, period),
+                                level="group",
+                                protocol="b516",
+                                group_key=period,
+                            )
+                        )
+                        seen_periods.add(period)
+                    request_hex = str(entry.get("request_hex") or "")
+                    reply_hex = str(entry.get("reply_hex") or "")
+                    error = str(entry.get("error") or "")
+                    value_text = _format_b516_value(entry)
+                    path_parts = ["B516"]
+                    if period:
+                        path_parts.append(period_labels.get(period, period))
+                    if source:
+                        path_parts.append(source)
+                    if usage:
+                        path_parts.append(usage)
+                    path = "/".join(path_parts + [label])
+                    address = RegisterAddress(
+                        protocol="b516",
+                        group_key=period or None,
+                        namespace_key=source or None,
+                        namespace_label=usage or None,
+                        instance_key=None,
+                        register_key=entry_key,
+                        read_opcode=None,
+                    )
+                    search_blob = " ".join(
+                        [
+                            path.lower(),
+                            label.lower(),
+                            entry_key.lower(),
+                            period.lower(),
+                            source.lower(),
+                            usage.lower(),
+                            value_text.lower(),
+                            request_hex.lower(),
+                            reply_hex.lower(),
+                            error.lower(),
+                            str(entry.get("echo_period") or "").lower(),
+                            str(entry.get("echo_source") or "").lower(),
+                            str(entry.get("echo_usage") or "").lower(),
+                            str(entry.get("echo_window") or "").lower(),
+                            str(entry.get("echo_qualifier") or "").lower(),
+                            "state",
+                        ]
+                    )
+                    row_id = f"b516:{entry_key}"
+                    row = RegisterRow(
+                        row_id=row_id,
+                        protocol="b516",
+                        group_key=period or None,
+                        namespace_key=source or None,
+                        namespace_label=usage or None,
+                        group_name="B516",
+                        instance_key=None,
+                        register_key=entry_key,
+                        name=label,
+                        myvaillant_name="",
+                        ebusd_name="",
+                        path=path,
+                        tab="state",
+                        address=address,
+                        value_text=value_text,
+                        raw_hex=reply_hex,
+                        unit="kWh",
+                        access_flags="read-only",
+                        last_update_text=last_update_text,
+                        age_text=age_text,
+                        change_indicator="-",
+                        search_blob=search_blob,
+                    )
+                    rows.append(row)
+                    row_by_id[row_id] = row
+
         rows.sort(key=_row_sort_key)
         return cls(
             device_label=device_label,
@@ -694,7 +834,7 @@ class BrowseStore:
             return [row for row in selected if row.protocol == node.protocol]
         if (
             node.level == "group"
-            and node.protocol in {"b524", "b555"}
+            and node.protocol in {"b524", "b555", "b516"}
             and node.group_key is not None
         ):
             return [

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -913,6 +913,10 @@ __ARTIFACT_JSON__
         return tabId === "b555";
       }
 
+      function _isB516Tab(tabId) {
+        return tabId === "b516";
+      }
+
       function _isB524Tab(tabId) {
         return typeof tabId === "string" && tabId.startsWith("b524:");
       }
@@ -929,7 +933,7 @@ __ARTIFACT_JSON__
         }
       }
 
-      function buildTabs(groupKeys, hasB555, hasB509) {
+      function buildTabs(groupKeys, hasB555, hasB516, hasB509) {
         tabsEl.innerHTML = "";
         const groupsRoot = artifact && typeof artifact === "object" ? artifact.groups || {} : {};
         const orderedTabIds = [];
@@ -946,6 +950,20 @@ __ARTIFACT_JSON__
           });
           tabsEl.appendChild(btn);
           orderedTabIds.push("b555");
+        }
+
+        if (hasB516) {
+          const btn = document.createElement("div");
+          btn.className = "tab";
+          btn.textContent = "B516 Dump";
+          btn.dataset.tabId = "b516";
+          btn.addEventListener("click", () => {
+            state.activeTab = "b516";
+            _syncActiveTabClasses();
+            renderActiveTab();
+          });
+          tabsEl.appendChild(btn);
+          orderedTabIds.push("b516");
         }
 
         if (hasB509) {
@@ -1097,6 +1115,104 @@ __ARTIFACT_JSON__
           if (row.requestHex) {
             tr.title = `request_hex=${row.requestHex}${row.replyHex ? `\\nreply_hex=${row.replyHex}` : ""}`;
           }
+          tbody.appendChild(tr);
+        }
+
+        table.appendChild(tbody);
+        wrap.appendChild(table);
+        card.appendChild(wrap);
+        sheetArea.innerHTML = "";
+        sheetArea.appendChild(card);
+      }
+
+      function renderB516Tab() {
+        const b516 = artifact && typeof artifact === "object" ? artifact.b516_dump : null;
+        if (!b516 || typeof b516 !== "object") {
+          sheetArea.innerHTML = "<div class='subtitle'>No B516 dump in artifact.</div>";
+          return;
+        }
+
+        const entries = b516.entries && typeof b516.entries === "object" ? b516.entries : {};
+        const rows = [];
+        for (const entryKey of Object.keys(entries).sort()) {
+          const entry = entries[entryKey];
+          if (!entry || typeof entry !== "object") continue;
+          rows.push({ entryKey, entry });
+        }
+
+        const card = document.createElement("div");
+        if (!rows.length) {
+          const msg = document.createElement("div");
+          msg.className = "subtitle";
+          msg.textContent = "No B516 entries in artifact.";
+          card.appendChild(msg);
+          sheetArea.innerHTML = "";
+          sheetArea.appendChild(card);
+          return;
+        }
+
+        const wrap = document.createElement("div");
+        wrap.className = "table-wrap";
+        const table = document.createElement("table");
+        const thead = document.createElement("thead");
+        const trHead = document.createElement("tr");
+        for (const col of ["Label", "Selector", "kWh", "Wh", "Request", "Reply", "Error"]) {
+          const th = document.createElement("th");
+          th.textContent = col;
+          trHead.appendChild(th);
+        }
+        thead.appendChild(trHead);
+        table.appendChild(thead);
+
+        const tbody = document.createElement("tbody");
+        for (const row of rows) {
+          const tr = document.createElement("tr");
+          const entry = row.entry;
+          const label = typeof entry.label === "string" && entry.label ? entry.label : row.entryKey;
+          const period = typeof entry.period === "string" ? entry.period : "n/a";
+          const source = typeof entry.source === "string" ? entry.source : "n/a";
+          const usage = typeof entry.usage === "string" ? entry.usage : "n/a";
+          const requestHex = typeof entry.request_hex === "string" ? entry.request_hex : "";
+          const replyHex = typeof entry.reply_hex === "string" ? entry.reply_hex : "";
+          const error = typeof entry.error === "string" ? entry.error : "";
+          const valueKwh = typeof entry.value_kwh === "number" ? formatValue(entry.value_kwh) : "—";
+          const valueWh = typeof entry.value_wh === "number" ? formatValue(entry.value_wh) : "—";
+
+          const labelTd = document.createElement("td");
+          const nameEl = document.createElement("div");
+          nameEl.className = "offset-name";
+          nameEl.textContent = label;
+          labelTd.appendChild(nameEl);
+          const keyEl = document.createElement("div");
+          keyEl.className = "offset-name-secondary";
+          keyEl.textContent = row.entryKey;
+          labelTd.appendChild(keyEl);
+          tr.appendChild(labelTd);
+
+          const selectorTd = document.createElement("td");
+          selectorTd.textContent = `${period} / ${source} / ${usage}`;
+          const echoParts = [];
+          if (typeof entry.echo_period === "string") echoParts.push(`p=${entry.echo_period}`);
+          if (typeof entry.echo_source === "string") echoParts.push(`s=${entry.echo_source}`);
+          if (typeof entry.echo_usage === "string") echoParts.push(`u=${entry.echo_usage}`);
+          if (typeof entry.echo_window === "string") echoParts.push(`w=${entry.echo_window}`);
+          if (typeof entry.echo_qualifier === "string") echoParts.push(`q=${entry.echo_qualifier}`);
+          if (echoParts.length) {
+            const echoEl = document.createElement("div");
+            echoEl.className = "offset-name-secondary";
+            echoEl.textContent = `echo ${echoParts.join(" ")}`;
+            selectorTd.appendChild(echoEl);
+          }
+          tr.appendChild(selectorTd);
+
+          for (const value of [valueKwh, valueWh, requestHex || "—", replyHex || "—", error || "—"]) {
+            const td = document.createElement("td");
+            td.textContent = value;
+            if (value === requestHex || value === replyHex) td.className = "cell-raw";
+            if (value === error && error) td.className = "cell-error";
+            tr.appendChild(td);
+          }
+
           tbody.appendChild(tr);
         }
 
@@ -1560,6 +1676,10 @@ __ARTIFACT_JSON__
           renderB555Tab();
           return;
         }
+        if (_isB516Tab(state.activeTab)) {
+          renderB516Tab();
+          return;
+        }
         if (_isB509Tab(state.activeTab)) {
           renderB509Tab();
           return;
@@ -1571,9 +1691,10 @@ __ARTIFACT_JSON__
       const groupsRoot = artifact && typeof artifact === "object" ? artifact.groups || {} : {};
       const groupKeys = sortedHexKeys(Object.keys(groupsRoot));
       const hasB555 = !!(artifact && typeof artifact === "object" && artifact.b555_dump && typeof artifact.b555_dump === "object");
+      const hasB516 = !!(artifact && typeof artifact === "object" && artifact.b516_dump && typeof artifact.b516_dump === "object");
       const hasB509 = !!(artifact && typeof artifact === "object" && artifact.b509_dump && typeof artifact.b509_dump === "object");
       renderSummaryChips(groupsRoot);
-      buildTabs(groupKeys, hasB555, hasB509);
+      buildTabs(groupKeys, hasB555, hasB516, hasB509);
       renderActiveTab();
     </script>
   </body>

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -272,6 +272,25 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
                 b555_txt += " incomplete=true"
             console.print(b555_txt, style="dim")
 
+    b516_dump = artifact.get("b516_dump")
+    if isinstance(b516_dump, dict):
+        b516_meta = b516_dump.get("meta")
+        if isinstance(b516_meta, dict):
+            b516_reads = b516_meta.get("read_count")
+            b516_errors = b516_meta.get("error_count")
+            b516_incomplete = bool(b516_meta.get("incomplete", False))
+            entries = b516_dump.get("entries")
+            b516_txt = "b516"
+            if isinstance(b516_reads, int):
+                b516_txt += f" reads={b516_reads}"
+            if isinstance(b516_errors, int):
+                b516_txt += f" errors={b516_errors}"
+            if isinstance(entries, dict):
+                b516_txt += f" entries={len(entries)}"
+            if b516_incomplete:
+                b516_txt += " incomplete=true"
+            console.print(b516_txt, style="dim")
+
     table = Table(show_header=True, header_style="bold", box=None)
     table.add_column("Group", style="cyan", no_wrap=True)
     table.add_column("Name", style="white")

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -297,6 +297,60 @@ def test_browse_store_adds_b555_protocol_and_program_rows() -> None:
     assert [row.register_key for row in selected] == ["monday:0x00"]
 
 
+def test_browse_store_adds_b516_protocol_and_entry_rows() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {},
+        "b516_dump": {
+            "meta": {"read_count": 2, "error_count": 1, "incomplete": False},
+            "entries": {
+                "system.gas.heating": {
+                    "label": "System Gas Heating",
+                    "period": "system",
+                    "source": "gas",
+                    "usage": "heating",
+                    "request_hex": "1000ffff04030030",
+                    "reply_hex": "00aabb040300300000c842",
+                    "value_wh": 100.0,
+                    "value_kwh": 0.1,
+                    "error": None,
+                },
+                "year.previous.electricity.hot_water": {
+                    "label": "Previous Year Electricity Hot Water",
+                    "period": "year_previous",
+                    "source": "electricity",
+                    "usage": "hot_water",
+                    "request_hex": "1030ffff03043131",
+                    "reply_hex": "03aabb030400",
+                    "error": "parse_error: B516 response must be at least 11 bytes",
+                },
+            },
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    node_ids = {node.node_id for node in store.tree_nodes}
+    assert "proto:b516" in node_ids
+    assert "b516:group:system" in node_ids
+    assert "b516:group:year_previous" in node_ids
+
+    b516_rows = [row for row in store.rows if row.protocol == "b516"]
+    assert len(b516_rows) == 2
+
+    heating_row = next(row for row in b516_rows if row.register_key == "system.gas.heating")
+    assert heating_row.name == "System Gas Heating"
+    assert heating_row.value_text == "0.1 kWh (100 Wh)"
+    assert heating_row.raw_hex == "00aabb040300300000c842"
+    assert heating_row.path == "B516/System/gas/heating/System Gas Heating"
+    assert heating_row.access_flags == "read-only"
+
+    group_node = next(
+        node for node in store.tree_nodes if node.node_id == "b516:group:year_previous"
+    )
+    selected = store.rows_for_selection(group_node, tab="state")
+    assert [row.row_id for row in selected] == ["b516:year.previous.electricity.hot_water"]
+
+
 def test_browse_store_treats_unknown_singleton_group_as_singleton() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -97,6 +97,95 @@ def test_html_report_supports_b555_tab() -> None:
     assert '"hc":"0x00"' in html
 
 
+def test_html_report_supports_b516_tab() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {},
+        "b516_dump": {
+            "meta": {"read_count": 1, "error_count": 0, "incomplete": False},
+            "entries": {
+                "system.gas.heating": {
+                    "label": "System Gas Heating",
+                    "period": "system",
+                    "source": "gas",
+                    "usage": "heating",
+                    "request_hex": "1000ffff04030030",
+                    "reply_hex": "00aabb0403003000004842",
+                    "echo_period": "0x0",
+                    "echo_source": "0x4",
+                    "echo_usage": "0x3",
+                    "echo_window": "0x00",
+                    "echo_qualifier": "0x0",
+                    "value_wh": 50.0,
+                    "value_kwh": 0.05,
+                    "error": None,
+                }
+            },
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert "B516 Dump" in html
+    assert "No B516 dump in artifact." in html
+    assert "System Gas Heating" in html
+    assert '"period":"system"' in html
+    assert '"source":"gas"' in html
+    assert '"usage":"heating"' in html
+    assert "1000ffff04030030" in html
+    assert "00aabb0403003000004842" in html
+    assert '"echo_period":"0x0"' in html
+
+
+def test_html_report_supports_b516_tab_with_raw_evidence() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {},
+        "b516_dump": {
+            "meta": {"read_count": 2, "error_count": 1, "incomplete": False},
+            "entries": {
+                "system.gas.heating": {
+                    "label": "System Gas Heating",
+                    "period": "system",
+                    "source": "gas",
+                    "usage": "heating",
+                    "request_hex": "1000ffff04030030",
+                    "reply_hex": "00aabb040300300000c842",
+                    "echo_period": "0x0",
+                    "echo_source": "0x4",
+                    "echo_usage": "0x3",
+                    "echo_window": "0x00",
+                    "echo_qualifier": "0x0",
+                    "value_wh": 100.0,
+                    "value_kwh": 0.1,
+                    "error": None,
+                },
+                "year.previous.electricity.hot_water": {
+                    "label": "Previous Year Electricity Hot Water",
+                    "period": "year_previous",
+                    "source": "electricity",
+                    "usage": "hot_water",
+                    "request_hex": "1030ffff03043131",
+                    "reply_hex": "03aabb030400",
+                    "error": "parse_error: B516 response must be at least 11 bytes",
+                },
+            },
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert "B516 Dump" in html
+    assert "No B516 dump in artifact." in html
+    assert "No B516 entries in artifact." in html
+    assert '"system.gas.heating"' in html
+    assert '"request_hex":"1000ffff04030030"' in html
+    assert '"reply_hex":"00aabb040300300000c842"' in html
+    assert '"value_kwh":0.1' in html
+    assert '"value_wh":100.0' in html
+    assert '"echo_period":"0x0"' in html
+
+
 def test_html_report_renders_namespace_totals_and_flags_access_for_dual_namespace_groups() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -89,3 +89,46 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     assert "local=1, remote=1" in text
     assert "Radio Sensors VRC7xx" in text
     assert "2/2" not in text
+
+
+def test_render_summary_shows_b516_stats(tmp_path: Path) -> None:
+    artifact = {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+            "scan_duration_seconds": 0.75,
+        },
+        "groups": {},
+        "b516_dump": {
+            "meta": {"read_count": 12, "error_count": 2, "incomplete": True},
+            "entries": {
+                "system.gas.heating": {
+                    "label": "System Gas Heating",
+                    "period": "system",
+                    "source": "gas",
+                    "usage": "heating",
+                    "request_hex": "1000ffff04030030",
+                    "reply_hex": "00",
+                    "value_wh": 100.0,
+                    "value_kwh": 0.1,
+                    "error": None,
+                },
+                "year.previous.electricity.hot_water": {
+                    "label": "Previous Year Electricity Hot Water",
+                    "period": "year_previous",
+                    "source": "electricity",
+                    "usage": "hot_water",
+                    "request_hex": "1030ffff03043231",
+                    "reply_hex": None,
+                    "error": "timeout",
+                },
+            },
+        },
+    }
+
+    console = Console(record=True, width=140)
+
+    render_summary(console, artifact, output_path=tmp_path / "artifact.json")
+
+    text = console.export_text()
+    assert "b516 reads=12 errors=2 entries=2 incomplete=true" in text


### PR DESCRIPTION
Closes #177

## What
- surface `b516_dump` in the CLI summary
- expose `B516` as a separate browse protocol section with read-only rows
- render a dedicated `B516 Dump` tab in the HTML report

## Why
The B516 acquisition path already lands a separate artifact subtree. The UI still hid it, which made the reverse-engineering workflow incomplete unless you opened the raw JSON.

## Validation
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m pytest -q tests/test_summary.py tests/test_browse_store.py tests/test_html_report.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff check src/helianthus_vrc_explorer/ui/browse_models.py src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/html_report.py src/helianthus_vrc_explorer/ui/summary.py tests/test_summary.py tests/test_browse_store.py tests/test_html_report.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python -m ruff format --check src/helianthus_vrc_explorer/ui/browse_models.py src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/html_report.py src/helianthus_vrc_explorer/ui/summary.py tests/test_summary.py tests/test_browse_store.py tests/test_html_report.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_protocol_terminology.py`
- `PYTHONPATH=src ../helianthus-vrc-explorer/venv/bin/python scripts/check_docs_sync.py`