### PR TITLE
scanner/ui: rename B524 group labels

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -85,7 +85,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
     },
     0x09: {
         "desc": 1.0,
-        "name": "Radio Sensors VRC7xx",
+        "name": "Regulators",
         "ii_max": 0x0A,
         "rr_max": 0x0035,
         "opcodes": [0x02, 0x06],
@@ -93,7 +93,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
     },
     0x0A: {
         "desc": 1.0,
-        "name": "Radio Sensors VR92",
+        "name": "Thermostats",
         "ii_max": 0x0A,
         "rr_max": 0x004D,
         "opcodes": [0x02, 0x06],
@@ -101,7 +101,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
     },
     0x0C: {
         "desc": 1.0,
-        "name": "Remote Accessories / FM5 Slots",
+        "name": "Functional Modules",
         "ii_max": 0x0A,
         "rr_max": 0x002F,
         "opcodes": [0x06],

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -52,7 +52,7 @@ def _dual_namespace_artifact() -> dict[str, object]:
         },
         "groups": {
             "0x09": {
-                "name": "Radio Sensors VRC7xx",
+                "name": "Regulators",
                 "dual_namespace": True,
                 "namespaces": {
                     "0x02": {
@@ -139,7 +139,7 @@ def test_browse_store_builds_namespace_nodes_for_dual_namespace_groups() -> None
     store = BrowseStore.from_artifact(_dual_namespace_artifact())
 
     by_node_id = {node.node_id: node for node in store.tree_nodes}
-    assert by_node_id["b524:group:0x09"].label == "Radio Sensors VRC7xx (0x09)"
+    assert by_node_id["b524:group:0x09"].label == "Regulators (0x09)"
     assert by_node_id["b524:ns:0x09:0x02"].label == "Local (0x02)"
     assert by_node_id["b524:ns:0x09:0x06"].label == "Remote (0x06)"
 

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -191,7 +191,7 @@ def test_html_report_renders_namespace_totals_and_flags_access_for_dual_namespac
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
         "groups": {
             "0x09": {
-                "name": "Radio Sensors VRC7xx",
+                "name": "Regulators",
                 "dual_namespace": True,
                 "namespaces": {
                     "0x02": {
@@ -241,7 +241,7 @@ def test_html_report_renders_namespace_totals_and_flags_access_for_dual_namespac
 
     assert "Namespace Totals" in html
     assert "FLAGS Access" in html
-    assert "Radio Sensors VRC7xx" in html
+    assert "Regulators" in html
     assert "activeNamespaceByGroup" in html
     assert '"label":"local"' in html
     assert '"label":"remote"' in html

--- a/tests/test_results_viewer_overrides.py
+++ b/tests/test_results_viewer_overrides.py
@@ -87,7 +87,7 @@ def test_apply_row_type_override_can_target_one_namespace_only() -> None:
         "meta": {},
         "groups": {
             "0x09": {
-                "name": "Radio Sensors VRC7xx",
+                "name": "Regulators",
                 "dual_namespace": True,
                 "namespaces": {
                     "0x02": {

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -234,9 +234,9 @@ def test_group_00_rr_max_is_0x00ff() -> None:
 
 def test_group_names_match_docs() -> None:
     assert len(GROUP_CONFIG) == 10
-    assert GROUP_CONFIG[0x09]["name"] == "Radio Sensors VRC7xx"
-    assert GROUP_CONFIG[0x0A]["name"] == "Radio Sensors VR92"
-    assert GROUP_CONFIG[0x0C]["name"] == "Remote Accessories / FM5 Slots"
+    assert GROUP_CONFIG[0x09]["name"] == "Regulators"
+    assert GROUP_CONFIG[0x0A]["name"] == "Thermostats"
+    assert GROUP_CONFIG[0x0C]["name"] == "Functional Modules"
 
 
 def test_group_config_completeness() -> None:

--- a/tests/test_scanner_plan.py
+++ b/tests/test_scanner_plan.py
@@ -87,7 +87,7 @@ def test_plan_dual_namespace_creates_two_entries() -> None:
         PlannerGroup(
             group=0x09,
             opcode=0x02,
-            name="Radio Sensors VRC7xx",
+            name="Regulators",
             descriptor=1.0,
             known=True,
             ii_max=0x0A,
@@ -100,7 +100,7 @@ def test_plan_dual_namespace_creates_two_entries() -> None:
         PlannerGroup(
             group=0x09,
             opcode=0x06,
-            name="Radio Sensors VRC7xx",
+            name="Regulators",
             descriptor=1.0,
             known=True,
             ii_max=0x0A,

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -33,7 +33,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
                 },
             },
             "0x09": {
-                "name": "Radio Sensors VRC7xx",
+                "name": "Regulators",
                 "descriptor_observed": 1.0,
                 "dual_namespace": True,
                 "namespaces": {
@@ -87,7 +87,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     assert "flags_access volatile_ro=0, stable_ro=2, technical_rw=0, user_rw=1" in text
     assert "b555 reads=4 errors=1 programs=2" in text
     assert "local=1, remote=1" in text
-    assert "Radio Sensors VRC7xx" in text
+    assert "Regulators" in text
     assert "2/2" not in text
 
 


### PR DESCRIPTION
## What
Rename the B524 labels for groups 0x09, 0x0A, and 0x0C to the operator-facing names from #182.

## Why
The previous labels were misleading in BASV2 output and made scan results harder to interpret.

## Testing
- PYTHONPATH=src venv/bin/pytest -q tests/test_scanner_director.py tests/test_summary.py tests/test_scanner_plan.py tests/test_browse_store.py tests/test_results_viewer_overrides.py tests/test_html_report.py
- ruff check src/helianthus_vrc_explorer/scanner/director.py tests/test_scanner_director.py tests/test_summary.py tests/test_scanner_plan.py tests/test_browse_store.py tests/test_results_viewer_overrides.py tests/test_html_report.py

Closes #182