### PR TITLE
cli: show scan pre-identification status

### DIFF
--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -100,6 +100,10 @@ def _load_default_myvaillant_map() -> tuple[MyvaillantRegisterMap | None, str | 
         return (None, None)
 
 
+def _emit_scan_status(console: Console, message: str) -> None:
+    console.print(f"[scan] {message}", highlight=False, markup=False, style="cyan")
+
+
 def _load_default_model_catalog() -> dict[str, _ModelCatalogEntry]:
     paths: list[Path] = []
     with contextlib.suppress(Exception):
@@ -737,18 +741,29 @@ def scan(
         else:
             b509_ranges = [(0x0000, 0x00FF)]
         while True:
+            _emit_scan_status(
+                console,
+                (
+                    f"Opening {transport_settings.protocol.upper()} transport to "
+                    f"{transport_settings.host}:{transport_settings.port}"
+                ),
+            )
             transport = _build_transport(transport_settings, trace_file=trace_file)
             opened_session = False
             try:
                 with transport.session():
                     opened_session = True
                     if requested_dst == "auto":
+                        _emit_scan_status(console, "Resolving destination address from ebusd")
                         dst_u8 = _resolve_scan_destination(transport, dst=dst)
+                        _emit_scan_status(console, f"Resolved destination to 0x{dst_u8:02X}")
                     else:
                         dst_u8 = cast(int, explicit_dst_u8)
+                        _emit_scan_status(console, f"Using explicit destination 0x{dst_u8:02X}")
                     title = f"helianthus-vrc-explorer scan (B524) dst=0x{dst_u8:02X}"
                     subtitle_lines = [f"Planner: {planner_ui_value} (preset={preset_value})"]
 
+                    _emit_scan_status(console, f"Probing regulator identity at 0x{dst_u8:02X}")
                     identity = _probe_scan_identity(transport, dst=dst_u8)
                     if redact:
                         identity["serial"] = "<SERIAL_NUMBER_REDACTED>"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,6 +255,54 @@ def test_scan_cli_defaults_planner_ui_to_disabled(monkeypatch, tmp_path: Path) -
     assert captured["b516_dump"] is False
 
 
+def test_scan_emits_pre_identification_status_during_auto_detection(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import helianthus_vrc_explorer.cli as cli_mod
+
+    class _OkTransport:
+        @contextmanager
+        def session(self):
+            yield self
+
+    def _fake_build_transport(settings, *, trace_file):  # noqa: ANN001
+        _ = settings
+        _ = trace_file
+        return _OkTransport()
+
+    @contextmanager
+    def _fake_observer(*_args, **_kwargs):
+        yield None
+
+    def _fake_scan_vrc(*_args, **_kwargs):
+        return {
+            "meta": {
+                "scan_timestamp": "2026-02-13T00:00:00Z",
+                "destination_address": "0x15",
+                "incomplete": False,
+                "schema_sources": [],
+            },
+            "groups": {},
+        }
+
+    monkeypatch.setattr(cli_mod, "_build_transport", _fake_build_transport)
+    monkeypatch.setattr(cli_mod, "_resolve_scan_destination", lambda _transport, dst: 0x15)
+    monkeypatch.setattr(cli_mod, "_probe_scan_identity", lambda _transport, *, dst: {})
+    monkeypatch.setattr(cli_mod, "make_scan_observer", _fake_observer)
+    monkeypatch.setattr(cli_mod, "scan_vrc", _fake_scan_vrc)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["scan", "--output-dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    plain = re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", result.stderr)
+    assert "[scan] Opening TCP transport to 127.0.0.1:8888" in plain
+    assert "[scan] Resolving destination address from ebusd" in plain
+    assert "[scan] Resolved destination to 0x15" in plain
+    assert "[scan] Probing regulator identity at 0x15" in plain
+
+
 def test_scan_cli_passes_explicit_planner_ui(monkeypatch, tmp_path: Path) -> None:
     import helianthus_vrc_explorer.cli as cli_mod
 


### PR DESCRIPTION
## What
Emit visible CLI status during the pre-identification phase so live scans no longer look hung before regulator detection.

## Why
On slower/live transports, the operator currently sees no output while the tool is opening transport, resolving destination, and probing identity.

## Testing
- PYTHONPATH=src venv/bin/pytest -q tests/test_cli.py
- ruff check src/helianthus_vrc_explorer/cli.py tests/test_cli.py

Closes #181