### PR TITLE
scanner: broaden unknown-group exploration

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -58,7 +58,7 @@ def opcodes_for_group(group: int) -> list[RegisterOpcode]:
 
     config = GROUP_CONFIG.get(group)
     if config is None:
-        return [0x02]
+        return [0x02, 0x06]
     return [cast(RegisterOpcode, opcode) for opcode in config["opcodes"]]
 
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -56,7 +56,10 @@ def _hex_u16(value: int) -> str:
 _LOCAL_REGISTER_OPCODE: RegisterOpcode = 0x02
 _REMOTE_REGISTER_OPCODE: RegisterOpcode = 0x06
 _UNKNOWN_GROUP_DEFAULT_RR_MAX = 0x0030
-_UNKNOWN_GROUP_DEFAULT_II_MAX = 0x00
+_UNKNOWN_GROUP_DEFAULT_II_MAX = 0x0A
+_UNKNOWN_GROUP_INITIAL_INSTANCES: tuple[int, ...] = (0x00, 0x01)
+_UNKNOWN_GROUP_EXPANDED_INSTANCES: tuple[int, ...] = tuple(range(0x00, 0x0B)) + (0xFF,)
+_UNKNOWN_GROUP_PRESENCE_REGISTER = 0x0000
 
 PlannerUiMode = Literal["disabled", "auto", "textual", "classic"]
 _KNOWN_DESCRIPTOR_TYPES = frozenset(
@@ -227,6 +230,64 @@ def _present_instances_for_opcode(
 def _mark_present_instances(instances_obj: dict[str, Any], *, instances: tuple[int, ...]) -> None:
     for instance in instances:
         instances_obj[_hex_u8(instance)] = {"present": True}
+
+
+def _entry_is_readable(entry: RegisterEntry) -> bool:
+    return entry["error"] is None and entry.get("flags_access") != "absent"
+
+
+def _probe_unknown_present_instances(
+    transport: TransportInterface,
+    *,
+    dst: int,
+    group: int,
+    opcode: RegisterOpcode,
+    observer: ScanObserver | None,
+) -> tuple[int, ...]:
+    present_instances: list[int] = []
+    probed: set[int] = set()
+    should_expand = False
+
+    for ii in _UNKNOWN_GROUP_INITIAL_INSTANCES:
+        if observer is not None:
+            observer.status(f"Probe presence GG=0x{group:02X} OP={_hex_u8(opcode)} II=0x{ii:02X}")
+        entry = read_register(
+            transport,
+            dst,
+            opcode,
+            group=group,
+            instance=ii,
+            register=_UNKNOWN_GROUP_PRESENCE_REGISTER,
+        )
+        probed.add(ii)
+        if _entry_is_readable(entry):
+            present_instances.append(ii)
+            should_expand = True
+        if observer is not None:
+            observer.phase_advance("instance_discovery", advance=1)
+
+    if not should_expand:
+        return tuple(present_instances)
+
+    for ii in _UNKNOWN_GROUP_EXPANDED_INSTANCES:
+        if ii in probed:
+            continue
+        if observer is not None:
+            observer.status(f"Probe presence GG=0x{group:02X} OP={_hex_u8(opcode)} II=0x{ii:02X}")
+        entry = read_register(
+            transport,
+            dst,
+            opcode,
+            group=group,
+            instance=ii,
+            register=_UNKNOWN_GROUP_PRESENCE_REGISTER,
+        )
+        if _entry_is_readable(entry):
+            present_instances.append(ii)
+        if observer is not None:
+            observer.phase_advance("instance_discovery", advance=1)
+
+    return tuple(sorted(set(present_instances)))
 
 
 def _probe_present_instances(
@@ -961,6 +1022,11 @@ def scan_b524(
         instance_total = 0
         for group in classified:
             meta = metadata_map[group.group]
+            if GROUP_CONFIG.get(group.group) is None:
+                instance_total += len(_UNKNOWN_GROUP_EXPANDED_INSTANCES) * len(
+                    _group_opcodes(group.group)
+                )
+                continue
             if group.group in {0x09, 0x0A}:
                 shared_present: tuple[int, ...]
                 shared_ii_max = _ii_max_for_opcode(
@@ -991,6 +1057,7 @@ def scan_b524(
             rr_max = meta.rr_max
             opcodes = _group_opcodes(group.group)
             dual_namespace = len(opcodes) > 1
+            config = GROUP_CONFIG.get(group.group)
             _ensure_group_artifact(
                 artifact,
                 group=group.group,
@@ -998,6 +1065,37 @@ def scan_b524(
                 descriptor_observed=group.descriptor,
                 dual_namespace=dual_namespace,
             )
+
+            if config is None:
+                namespace_probe_counts: list[str] = []
+                total_slots = len(_UNKNOWN_GROUP_EXPANDED_INSTANCES)
+                for opcode in opcodes:
+                    instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
+                    emit_trace_label(
+                        transport,
+                        "Exploring unknown group "
+                        f"0x{group.group:02X} ({_opcode_label(opcode)}) "
+                        "across multiple instances",
+                    )
+                    present_instances = _probe_unknown_present_instances(
+                        transport,
+                        dst=dst,
+                        group=group.group,
+                        opcode=opcode,
+                        observer=observer,
+                    )
+                    _mark_present_instances(instances_obj, instances=present_instances)
+                    namespace_probe_counts.append(
+                        f"{_opcode_label(opcode)} {len(present_instances)}/{total_slots}"
+                    )
+                if observer is not None:
+                    observer.log(
+                        f"GG=0x{group.group:02X} {group.name}: "
+                        f"{', '.join(namespace_probe_counts)} present (experimental), "
+                        f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
+                        level="info",
+                    )
+                continue
 
             if group.group in {0x09, 0x0A}:
                 shared_ii_max = _ii_max_for_opcode(
@@ -1036,7 +1134,7 @@ def scan_b524(
                     )
                 continue
 
-            namespace_probe_counts: list[str] = []
+            known_namespace_probe_counts: list[str] = []
             for opcode in opcodes:
                 namespace_ii_max = _ii_max_for_opcode(
                     group=group.group,
@@ -1046,7 +1144,7 @@ def scan_b524(
                 instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
                 if not _is_instanced_group(namespace_ii_max):
                     _mark_present_instances(instances_obj, instances=(0x00,))
-                    namespace_probe_counts.append(f"{_opcode_label(opcode)} 1/1")
+                    known_namespace_probe_counts.append(f"{_opcode_label(opcode)} 1/1")
                     continue
 
                 assert namespace_ii_max is not None
@@ -1063,14 +1161,14 @@ def scan_b524(
                     observer=observer,
                 )
                 _mark_present_instances(instances_obj, instances=present_instances)
-                namespace_probe_counts.append(
+                known_namespace_probe_counts.append(
                     f"{_opcode_label(opcode)} {len(present_instances)}/{namespace_ii_max + 1}"
                 )
 
             if observer is not None:
                 observer.log(
                     f"GG=0x{group.group:02X} {group.name}: "
-                    f"{', '.join(namespace_probe_counts)} present, "
+                    f"{', '.join(known_namespace_probe_counts)} present, "
                     f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
                     level="info",
                 )
@@ -1463,9 +1561,7 @@ def scan_b524(
                     group=task.group,
                     name="Unknown",
                     descriptor_observed=None,
-                    dual_namespace=bool(
-                        task.group in GROUP_CONFIG and _is_dual_namespace_group(task.group)
-                    ),
+                    dual_namespace=_is_dual_namespace_group(task.group),
                 )
                 instances_obj = _instances_object(
                     artifact,

--- a/src/helianthus_vrc_explorer/transport/dummy.py
+++ b/src/helianthus_vrc_explorer/transport/dummy.py
@@ -133,7 +133,7 @@ class DummyTransport(TransportInterface):
             if configured:
                 return configured
 
-        return (0x02,)
+        return (0x02, 0x06)
 
     def _load_instances(
         self,

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -151,7 +151,10 @@ def _instances_for_preset(group: PlannerGroup, preset: PlannerPreset) -> tuple[i
         return (0x00,)
     if preset in {"conservative", "recommended"}:
         return group.present_instances
-    return tuple(range(0x00, group.ii_max + 1))
+    full_range = tuple(range(0x00, group.ii_max + 1))
+    if 0xFF in group.present_instances:
+        return full_range + (0xFF,)
+    return full_range
 
 
 def build_plan_from_preset(
@@ -302,7 +305,10 @@ def _ask_instances(
     current_instances: tuple[int, ...],
 ) -> tuple[int, ...]:
     assert group.ii_max is not None
-    full_range = tuple(range(0x00, group.ii_max + 1))
+    full_range = tuple(range(0x00, group.ii_max + 1)) + (
+        (0xFF,) if 0xFF in group.present_instances else ()
+    )
+    allowed_instances = set(full_range)
     if current_instances == group.present_instances:
         default_mode = "present"
     elif current_instances == full_range:
@@ -330,10 +336,22 @@ def _ask_instances(
             parsed_instances = parse_int_set(
                 raw_instances,
                 min_value=0x00,
-                max_value=group.ii_max,
+                max_value=(0xFF if 0xFF in group.present_instances else group.ii_max),
             )
         except ValueError as exc:
             console.print(f"[red]Invalid instance selection:[/red] {exc}")
+            continue
+        invalid_instances = [
+            instance for instance in parsed_instances if instance not in allowed_instances
+        ]
+        if invalid_instances:
+            invalid_text = ", ".join(_hex_u8(instance) for instance in invalid_instances)
+            console.print(
+                "[red]Invalid instance selection:[/red] "
+                f"allowed values are 0x00..{_hex_u8(group.ii_max)}"
+                + (" plus 0xFF" if 0xFF in allowed_instances else "")
+                + f"; got {invalid_text}"
+            )
             continue
         return tuple(parsed_instances)
 

--- a/tests/test_planner_unknown_groups.py
+++ b/tests/test_planner_unknown_groups.py
@@ -126,3 +126,22 @@ def test_build_plan_from_preset_recommended_skips_unknown_groups() -> None:
     plan = build_plan_from_preset(groups, preset="recommended")
     assert sorted(plan.keys()) == [(0x02, 0x02)]
     assert plan[(0x02, 0x02)].instances == (0x00, 0x01)
+
+
+def test_build_plan_from_preset_full_keeps_ff_when_present() -> None:
+    groups = [
+        PlannerGroup(
+            group=0x69,
+            opcode=0x06,
+            name="Unknown",
+            descriptor=1.0,
+            known=False,
+            ii_max=0x0A,
+            rr_max=0x30,
+            rr_max_full=0x30,
+            present_instances=(0x00, 0xFF),
+        )
+    ]
+
+    plan = build_plan_from_preset(groups, preset="full")
+    assert plan[(0x69, 0x06)].instances == tuple(range(0x0A + 1)) + (0xFF,)

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -153,6 +153,36 @@ def _write_fixture_unknown_group_69(tmp_path: Path) -> Path:
     return path
 
 
+def _write_fixture_unknown_group_69_with_ff(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x6a"}},
+        "groups": {
+            "0x69": {
+                "descriptor_type": 1.0,
+                "namespaces": {
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                }
+                            },
+                            "0xff": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "7f"},
+                                }
+                            },
+                        }
+                    }
+                },
+            }
+        },
+    }
+    path = tmp_path / "fixture_unknown_ff.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
 def _write_fixture_unknown_descriptor(tmp_path: Path) -> Path:
     fixture = {
         "meta": {"dummy_transport": {"directory_terminator_group": "0x01"}},
@@ -494,7 +524,13 @@ def test_scan_b524_scans_enabled_unknown_group_via_planner(monkeypatch, tmp_path
                 opcode=0x02,
                 rr_max=0x0000,
                 instances=(0x00,),
-            )
+            ),
+            (0x69, 0x06): GroupScanPlan(
+                group=0x69,
+                opcode=0x06,
+                rr_max=0x0000,
+                instances=(0x00,),
+            ),
         }
 
     monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
@@ -509,8 +545,12 @@ def test_scan_b524_scans_enabled_unknown_group_via_planner(monkeypatch, tmp_path
     )
 
     assert "0x69" in artifact["groups"]
-    registers = artifact["groups"]["0x69"]["instances"]["0x00"]["registers"]
-    assert registers["0x0000"]["raw_hex"] == "00"
+    group = artifact["groups"]["0x69"]
+    assert group["dual_namespace"] is True
+    local_registers = group["namespaces"]["0x02"]["instances"]["0x00"]["registers"]
+    remote_registers = group["namespaces"]["0x06"]["instances"]["0x00"]["registers"]
+    assert local_registers["0x0000"]["raw_hex"] == "00"
+    assert remote_registers["0x0000"]["raw_hex"] == "00"
     issue_suggestion = artifact["meta"]["issue_suggestion"]
     assert issue_suggestion["unknown_groups"] == ["0x69"]
     assert issue_suggestion["suggest_issue"] is True
@@ -952,10 +992,11 @@ def test_scan_b524_normalizes_legacy_aggressive_preset_to_full_for_textual_defau
     assert captured["default_preset"] == "full"
     default_plan = captured["default_plan"]
     assert isinstance(default_plan, dict)
-    assert (0x69, 0x02) in default_plan
-    group_plan = default_plan[(0x69, 0x02)]
-    assert group_plan.rr_max == 0x30
-    assert group_plan.instances == (0x00,)
+    for key in ((0x69, 0x02), (0x69, 0x06)):
+        assert key in default_plan
+        group_plan = default_plan[key]
+        assert group_plan.rr_max == 0x30
+        assert group_plan.instances == tuple(range(0x0B))
 
 
 def test_scan_b524_applies_preset_in_non_interactive_mode(tmp_path: Path) -> None:
@@ -968,12 +1009,19 @@ def test_scan_b524_applies_preset_in_non_interactive_mode(tmp_path: Path) -> Non
 
     scan_plan = artifact["meta"]["scan_plan"]["groups"]
     assert "0x69" in scan_plan
-    assert scan_plan["0x69"]["rr_max"] == "0x0030"
-    assert scan_plan["0x69"]["instances"] == ["0x00"]
+    assert scan_plan["0x69"]["dual_namespace"] is True
+    assert set(scan_plan["0x69"]["namespaces"]) == {"0x02", "0x06"}
+    for namespace in ("0x02", "0x06"):
+        assert scan_plan["0x69"]["namespaces"][namespace]["rr_max"] == "0x0030"
+        assert scan_plan["0x69"]["namespaces"][namespace]["instances"] == [
+            f"0x{ii:02x}" for ii in range(0x0B)
+        ]
 
     group = artifact["groups"]["0x69"]
-    assert set(group["instances"]) == {"0x00"}
-    assert group["instances"]["0x00"]["present"] is True
+    assert group["dual_namespace"] is True
+    assert set(group["namespaces"]) == {"0x02", "0x06"}
+    assert group["namespaces"]["0x02"]["instances"]["0x00"]["present"] is True
+    assert group["namespaces"]["0x06"]["instances"]["0x00"]["present"] is True
 
 
 def test_scan_b524_disabled_planner_skips_interactive_planner_even_on_tty(
@@ -1009,9 +1057,11 @@ def test_scan_b524_disabled_planner_skips_interactive_planner_even_on_tty(
     assert artifact["meta"]["incomplete"] is False
 
 
-def test_scan_unknown_group_defaults_to_singleton(tmp_path: Path) -> None:
+def test_scan_unknown_group_probes_both_opcodes_and_two_instances(tmp_path: Path) -> None:
+    transport = RecordingTransport(DummyTransport(_write_fixture_unknown_group_69(tmp_path)))
+
     artifact = scan_b524(
-        DummyTransport(_write_fixture_unknown_group_69(tmp_path)),
+        transport,
         dst=0x15,
         planner_ui="auto",
         planner_preset="full",
@@ -1019,8 +1069,38 @@ def test_scan_unknown_group_defaults_to_singleton(tmp_path: Path) -> None:
 
     group = artifact["groups"]["0x69"]
     assert group["descriptor_observed"] == 1.0
-    assert set(group["instances"]) == {"0x00"}
-    assert artifact["meta"]["scan_plan"]["groups"]["0x69"]["instances"] == ["0x00"]
+    assert group["dual_namespace"] is True
+    assert set(group["namespaces"]) == {"0x02", "0x06"}
+    probed_instances = {
+        (opcode, ii)
+        for (opcode, gg, ii, rr) in transport.register_reads
+        if gg == 0x69 and rr == 0x0000 and ii in {0x00, 0x01}
+    }
+    assert probed_instances >= {
+        (0x02, 0x00),
+        (0x02, 0x01),
+        (0x06, 0x00),
+        (0x06, 0x01),
+    }
+
+
+def test_scan_unknown_group_expands_to_instance_ff_after_readable_probe(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        DummyTransport(_write_fixture_unknown_group_69_with_ff(tmp_path))
+    )
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        planner_ui="auto",
+        planner_preset="recommended",
+    )
+
+    group = artifact["groups"]["0x69"]
+    remote_instances = group["namespaces"]["0x06"]["instances"]
+    assert remote_instances["0x00"]["present"] is True
+    assert remote_instances["0xff"]["present"] is True
+    assert (0x06, 0x69, 0xFF, 0x0000) in transport.register_reads
 
 
 def test_scan_b524_textual_failure_falls_back_to_classic_in_auto_mode(


### PR DESCRIPTION
## What
Probe unknown B524 groups more conservatively in the reverse-engineering direction: try both local/remote opcode families, probe at least two instances up front, and expand unknown instance discovery when readable registers are found.

## Why
The old fallback assumed unknown groups were singleton and local-only, which can hide valid namespaces or instance slots.

## Testing
- PYTHONPATH=src venv/bin/pytest -q tests/test_scanner_scan.py tests/test_planner_unknown_groups.py
- ruff check src/helianthus_vrc_explorer/scanner/register.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/transport/dummy.py src/helianthus_vrc_explorer/ui/planner.py tests/test_scanner_scan.py tests/test_planner_unknown_groups.py
- ruff format --check src/helianthus_vrc_explorer/scanner/register.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/transport/dummy.py src/helianthus_vrc_explorer/ui/planner.py tests/test_scanner_scan.py tests/test_planner_unknown_groups.py

Closes #183