### PR TITLE
transport: rename to Enhanced, accept --transport ens/enh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -583,14 +583,14 @@ CI enforces this via `python scripts/check_docs_sync.py`.
  Scan a VRC regulator using B524 (GetExtendedRegisters).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --transport                                          TEXT     Transport backend: tcp (ebusd hex) or enh (direct ENH  │
+│ --transport                                          TEXT     Transport: tcp (ebusd hex) or ens/enh (enhanced eBUS   │
 │                                                               adapter).                                              │
 │                                                               [default: tcp]                                         │
 │ --dst                                                TEXT     Destination eBUS address (e.g. 0x15) or auto           │
 │                                                               (default).                                             │
 │                                                               [default: auto]                                        │
-│ --source-address                                     TEXT     Source initiator address for ENH transport. Ignored    │
-│                                                               for tcp.                                               │
+│ --source-address                                     TEXT     Source initiator address for enhanced transport.       │
+│                                                               Ignored for tcp.                                       │
 │                                                               [default: 0x31]                                        │
 │ --host                                               TEXT     ebusd host (TCP). [default: 127.0.0.1]                 │
 │ --port                                               INTEGER  ebusd port (TCP). [default: 8888]                      │

--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -32,7 +32,7 @@ from .schema.ebusd_csv import EbusdCsvSchema
 from .schema.myvaillant_map import MyvaillantRegisterMap
 from .transport.base import TransportCommandNotEnabled, TransportError, TransportTimeout
 from .transport.ebusd_tcp import EbusdTcpConfig, EbusdTcpTransport
-from .transport.ens_tcp import EnsTcpConfig, EnsTcpTransport
+from .transport.enhanced_tcp import EnhancedTcpConfig, EnhancedTcpTransport
 from .ui.browse_textual import run_browse_from_artifact
 from .ui.emphasis import rich_star_bold_text
 from .ui.html_report import render_html_report
@@ -256,7 +256,7 @@ def _format_fw(sw: str | None, hw: str | None) -> str:
 
 
 def _probe_scan_identity(
-    transport: EbusdTcpTransport | EnsTcpTransport,
+    transport: EbusdTcpTransport | EnhancedTcpTransport,
     *,
     dst: int,
     model_catalog: dict[str, _ModelCatalogEntry] | None = None,
@@ -372,14 +372,14 @@ def _build_transport(
     settings: _TransportSettings,
     *,
     trace_file: Path | None,
-) -> EbusdTcpTransport | EnsTcpTransport:
+) -> EbusdTcpTransport | EnhancedTcpTransport:
     if settings.protocol == "tcp":
         return EbusdTcpTransport(
             EbusdTcpConfig(host=settings.host, port=settings.port, trace_path=trace_file)
         )
-    if settings.protocol == "enh":
-        return EnsTcpTransport(
-            EnsTcpConfig(
+    if settings.protocol == "enhanced":
+        return EnhancedTcpTransport(
+            EnhancedTcpConfig(
                 host=settings.host,
                 port=settings.port,
                 src=settings.src if settings.src is not None else 0x31,
@@ -447,7 +447,7 @@ def _prompt_transport_retry_settings(
 
 
 def _probe_group_descriptor(
-    transport: EbusdTcpTransport | EnsTcpTransport,
+    transport: EbusdTcpTransport | EnhancedTcpTransport,
     *,
     dst: int,
     group: int,
@@ -471,7 +471,7 @@ def _probe_group_descriptor(
 
 
 def _probe_scan_identification(
-    transport: EbusdTcpTransport | EnsTcpTransport,
+    transport: EbusdTcpTransport | EnhancedTcpTransport,
     *,
     dst: int,
     retries: int = _SCAN_IDENT_RETRIES,
@@ -573,7 +573,7 @@ def scan(
     transport_protocol: str = typer.Option(  # noqa: B008
         _DEFAULT_TRANSPORT_PROTOCOL,
         "--transport",
-        help="Transport backend: tcp (ebusd hex) or enh (direct ENH adapter).",
+        help="Transport: tcp (ebusd hex) or ens/enh (enhanced eBUS adapter).",
     ),
     dst: str = typer.Option(  # noqa: B008
         "auto",
@@ -583,7 +583,7 @@ def scan(
     source_address: str = typer.Option(  # noqa: B008
         "0x31",
         "--source-address",
-        help="Source initiator address for ENH transport. Ignored for tcp.",
+        help="Source initiator address for enhanced transport. Ignored for tcp.",
     ),
     host: str = typer.Option(  # noqa: B008
         _DEFAULT_EBUSD_HOST,
@@ -684,9 +684,12 @@ def scan(
 ) -> None:
     """Scan a VRC regulator using B524 (GetExtendedRegisters)."""
     transport_proto = transport_protocol.strip().lower()
-    if transport_proto not in {"tcp", "enh"}:
+    # ens and enh are aliases — both use the enhanced eBUS adapter protocol.
+    if transport_proto in ("ens", "enh", "enhanced"):
+        transport_proto = "enhanced"
+    if transport_proto not in {"tcp", "enhanced"}:
         typer.echo(
-            "Invalid --transport value. Expected: tcp or enh.",
+            "Invalid --transport value. Expected: tcp, ens, or enh.",
             err=True,
         )
         raise typer.Exit(2)
@@ -697,7 +700,7 @@ def scan(
         explicit_dst_u8 = _parse_u8_address(dst)
     if transport_proto != "tcp" and requested_dst == "auto":
         typer.echo(
-            "Auto destination only supported on ebusd TCP. Use --dst 0x.. for ENH.",
+            "Auto destination only supported on ebusd TCP. Use --dst 0x.. for enhanced transport.",
             err=True,
         )
         raise typer.Exit(2)
@@ -761,7 +764,9 @@ def scan(
         )
         _emit_non_tty_session_preface(preface)
     else:
-        source_addr_u8 = _parse_u8_address(source_address) if transport_proto == "enh" else None
+        source_addr_u8 = (
+            _parse_u8_address(source_address) if transport_proto == "enhanced" else None
+        )
         transport_settings = _TransportSettings(
             protocol=transport_proto,
             host=host,

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -17,7 +17,6 @@ _EBUS_SYN = 0xAA
 _EBUS_ACK = 0x00
 _EBUS_NACK = 0xFF
 _ADDRESS_BROADCAST = 0xFE
-_DEFAULT_SOURCE_ADDRESS = 0xF1
 
 _ENH_REQ_INIT = 0x0
 _ENH_REQ_SEND = 0x1
@@ -292,11 +291,11 @@ _CRC_TABLE: tuple[int, ...] = (
 
 
 @dataclass(frozen=True)
-class EnsTcpConfig:
+class EnhancedTcpConfig:
     host: str = "127.0.0.1"
-    port: int = 19002
+    port: int = 9999
     timeout_s: float = 5.0
-    src: int = _DEFAULT_SOURCE_ADDRESS
+    src: int = 0x31
     trace_path: Path | None = None
     timeout_max_retries: int = 2
     collision_max_retries: int = 2
@@ -306,19 +305,19 @@ class EnsTcpConfig:
 
 
 @dataclass(slots=True)
-class _EnsTcpSession:
+class _EnhancedTcpSession:
     sock: socket.socket
 
 
-class _EnsCollision(TransportError):
+class _EnhancedCollision(TransportError):
     """Retryable collision or unexpected bus-ownership event."""
 
 
-class _EnsNack(TransportError):
+class _EnhancedNack(TransportError):
     """Retryable NACK from the bus peer."""
 
 
-class _EnsCrcMismatch(TransportError):
+class _EnhancedCrcMismatch(TransportError):
     """Retryable CRC mismatch while reading a target response."""
 
 
@@ -379,10 +378,10 @@ def _is_initiator_capable_address(addr: int) -> bool:
     return _part_index(addr & 0x0F) > 0 and _part_index((addr & 0xF0) >> 4) > 0
 
 
-class EnsTcpTransport(TransportInterface):
-    """Enhanced-protocol TCP client for the Helianthus proxy ENS profile."""
+class EnhancedTcpTransport(TransportInterface):
+    """Enhanced-protocol TCP client for direct eBUS adapter connections."""
 
-    def __init__(self, config: EnsTcpConfig) -> None:
+    def __init__(self, config: EnhancedTcpConfig) -> None:
         _validate_u8("src", config.src)
         if config.timeout_max_retries < 0:
             raise ValueError("timeout_max_retries must be >= 0")
@@ -398,7 +397,7 @@ class EnsTcpTransport(TransportInterface):
         self._config = config
         self._trace_seq = 0
         self._session_depth = 0
-        self._session: _EnsTcpSession | None = None
+        self._session: _EnhancedTcpSession | None = None
         self._messages = deque[tuple[str, int, int]]()
         self._enh_pending_first: int | None = None
 
@@ -432,7 +431,7 @@ class EnsTcpTransport(TransportInterface):
             session.sock.close()
 
     @contextlib.contextmanager
-    def session(self) -> Iterator[EnsTcpTransport]:
+    def session(self) -> Iterator[EnhancedTcpTransport]:
         self._session_depth += 1
         if self._session_depth == 1:
             try:
@@ -459,22 +458,22 @@ class EnsTcpTransport(TransportInterface):
             sock.settimeout(self._config.timeout_s)
         except TimeoutError as exc:
             raise TransportTimeout(
-                f"Timed out talking to ENS proxy at {self._config.host}:{self._config.port}"
+                f"Enhanced adapter timeout {self._config.host}:{self._config.port}"
             ) from exc
         except OSError as exc:
             raise TransportError(
-                f"Failed talking to ENS proxy at {self._config.host}:{self._config.port}: {exc}"
+                f"Enhanced adapter {self._config.host}:{self._config.port}: {exc}"
             ) from exc
 
-        self._session = _EnsTcpSession(sock=sock)
+        self._session = _EnhancedTcpSession(sock=sock)
         self._reset_parser()
         try:
-            self._init_transport(features=0x00)
+            self._init_transport(features=0x01)
         except Exception:
             self.close()
             raise
 
-    def _ensure_session(self) -> _EnsTcpSession:
+    def _ensure_session(self) -> _EnhancedTcpSession:
         session = self._session
         if session is not None:
             return session
@@ -490,12 +489,12 @@ class EnsTcpTransport(TransportInterface):
         except TimeoutError as exc:
             self.close()
             raise TransportTimeout(
-                f"Timed out talking to ENS proxy at {self._config.host}:{self._config.port}"
+                f"Enhanced adapter timeout {self._config.host}:{self._config.port}"
             ) from exc
         except OSError as exc:
             self.close()
             raise TransportError(
-                f"Failed talking to ENS proxy at {self._config.host}:{self._config.port}: {exc}"
+                f"Enhanced adapter {self._config.host}:{self._config.port}: {exc}"
             ) from exc
 
     def _read_message(self) -> tuple[str, int, int]:
@@ -509,18 +508,18 @@ class EnsTcpTransport(TransportInterface):
             except TimeoutError as exc:
                 self._reset_parser()
                 raise TransportTimeout(
-                    f"Timed out talking to ENS proxy at {self._config.host}:{self._config.port}"
+                    f"Enhanced adapter timeout {self._config.host}:{self._config.port}"
                 ) from exc
             except OSError as exc:
                 self.close()
                 raise TransportError(
-                    f"Failed talking to ENS proxy at {self._config.host}:{self._config.port}: {exc}"
+                    f"Enhanced adapter {self._config.host}:{self._config.port}: {exc}"
                 ) from exc
 
             if not chunk:
                 self.close()
                 raise TransportError(
-                    f"ENS proxy closed the connection at {self._config.host}:{self._config.port}"
+                    f"Enhanced adapter disconnected {self._config.host}:{self._config.port}"
                 )
 
             for value in chunk:
@@ -586,17 +585,17 @@ class EnsTcpTransport(TransportInterface):
             if command == _ENH_RES_FAILED:
                 self._trace(f"START_RESP failed winner=0x{data:02X}")
                 self._reset_parser()
-                raise _EnsCollision(
-                    f"enh arbitration failed for initiator 0x{initiator:02X}, winner 0x{data:02X}"
+                raise _EnhancedCollision(
+                    f"Arbitration failed src=0x{initiator:02X} winner=0x{data:02X}"
                 )
             if command == _ENH_RES_ERROR_EBUS:
                 self._trace(f"START_RESP ebus_error=0x{data:02X}")
                 self._reset_parser()
-                raise _EnsCollision(f"enh arbitration eBUS error 0x{data:02X}")
+                raise _EnhancedCollision(f"enhanced arbitration eBUS error 0x{data:02X}")
             if command == _ENH_RES_ERROR_HOST:
                 self._trace(f"START_RESP host_error=0x{data:02X}")
                 self._reset_parser()
-                raise _EnsCollision(f"enh arbitration host error 0x{data:02X}")
+                raise _EnhancedCollision(f"enhanced arbitration host error 0x{data:02X}")
             if command == _ENH_RES_RESETTED:
                 self._trace(f"START_RESP reset features=0x{data:02X}")
                 self._reset_parser()
@@ -614,17 +613,19 @@ class EnsTcpTransport(TransportInterface):
             if command == _ENH_RES_INFO:
                 continue
             if command == _ENH_RES_ERROR_EBUS:
-                raise TransportError(f"enh bus read eBUS error 0x{data:02X}")
+                raise TransportError(f"enhanced bus read eBUS error 0x{data:02X}")
             if command == _ENH_RES_ERROR_HOST:
-                raise TransportError(f"enh bus read host error 0x{data:02X}")
+                raise TransportError(f"enhanced bus read host error 0x{data:02X}")
 
     def _send_symbol_with_echo(self, symbol: int) -> None:
         self._send_enh_frame(_ENH_REQ_SEND, symbol)
         echo = self._recv_bus_symbol()
         if echo == _EBUS_SYN and symbol != _EBUS_SYN:
-            raise _EnsCollision("unexpected SYN while waiting for echo")
+            raise _EnhancedCollision("unexpected SYN while waiting for echo")
         if echo != symbol:
-            raise _EnsCollision(f"echo mismatch while waiting for 0x{symbol:02X}: got 0x{echo:02X}")
+            raise _EnhancedCollision(
+                f"echo mismatch while waiting for 0x{symbol:02X}: got 0x{echo:02X}"
+            )
 
     def _send_end_of_message(self) -> None:
         self._send_symbol_with_echo(_EBUS_SYN)
@@ -684,7 +685,7 @@ class EnsTcpTransport(TransportInterface):
                     f"{seq} RETRY type=timeout "
                     f"n={timeout_retries}/{self._config.timeout_max_retries}"
                 )
-            except _EnsCollision as exc:
+            except _EnhancedCollision as exc:
                 self.close()
                 collision_retries += 1
                 if collision_retries > self._config.collision_max_retries:
@@ -701,7 +702,7 @@ class EnsTcpTransport(TransportInterface):
                     f"{self._config.collision_max_retries} sleep_ms={int(round(sleep_s * 1000))}"
                 )
                 time.sleep(sleep_s)
-            except (_EnsNack, _EnsCrcMismatch) as exc:
+            except (_EnhancedNack, _EnhancedCrcMismatch) as exc:
                 self.close()
                 nack_retries += 1
                 if nack_retries > self._config.nack_max_retries:
@@ -744,7 +745,7 @@ class EnsTcpTransport(TransportInterface):
 
         ack = self._recv_bus_symbol()
         if ack == _EBUS_NACK:
-            raise _EnsNack("nack received while waiting for command ack")
+            raise _EnhancedNack("nack received while waiting for command ack")
         if ack == _EBUS_SYN:
             raise TransportTimeout("syn received while waiting for command ack")
         if ack != _EBUS_ACK:
@@ -777,7 +778,7 @@ class EnsTcpTransport(TransportInterface):
                 if response_attempt == 0:
                     continue
                 self._send_end_of_message()
-                raise _EnsCrcMismatch("response crc mismatch")
+                raise _EnhancedCrcMismatch("response crc mismatch")
 
             self._send_symbol_with_echo(_EBUS_ACK)
             self._send_end_of_message()
@@ -785,10 +786,10 @@ class EnsTcpTransport(TransportInterface):
             self._trace(f"#{seq} PARSED_PROTO len={len(parsed)} hex={_short_hex(parsed)}")
             return parsed
 
-        raise TransportTimeout("unreachable ENS response loop")
+        raise TransportTimeout("unreachable enhanced response loop")
 
     def command_lines(self, command: str, *, read_all: bool = False) -> list[str]:
         _ = read_all
         raise TransportError(
-            f"ENS proxy transport does not support ebusd command passthrough: {command!r}"
+            f"enhanced adapter transport does not support ebusd command passthrough: {command!r}"
         )

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -7,15 +7,15 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from queue import Queue
 
-from helianthus_vrc_explorer.transport.ens_tcp import (
+from helianthus_vrc_explorer.transport.enhanced_tcp import (
     _ENH_REQ_INIT,
     _ENH_REQ_SEND,
     _ENH_REQ_START,
     _ENH_RES_RECEIVED,
     _ENH_RES_RESETTED,
     _ENH_RES_STARTED,
-    EnsTcpConfig,
-    EnsTcpTransport,
+    EnhancedTcpConfig,
+    EnhancedTcpTransport,
     _crc,
     _encode_enh,
 )
@@ -92,8 +92,8 @@ def test_ens_transport_send_proto_round_trips_identification_request() -> None:
     response_crc = _crc(response_segment)
 
     def _handler(conn: socket.socket) -> None:
-        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x00)
-        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
 
         assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
         _write_enh_frame(conn, _ENH_RES_STARTED, src)
@@ -113,7 +113,9 @@ def test_ens_transport_send_proto_round_trips_identification_request() -> None:
         _write_bus_symbol(conn, 0xAA)
 
     with _run_ens_test_server(_handler) as (host, port):
-        transport = EnsTcpTransport(EnsTcpConfig(host=host, port=port, timeout_s=0.5, src=src))
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
         result = transport.send_proto(dst, 0x07, 0x04, b"")
 
     assert result == response
@@ -130,8 +132,8 @@ def test_ens_transport_send_wraps_b524_request() -> None:
     response_crc = _crc(response_segment)
 
     def _handler(conn: socket.socket) -> None:
-        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x00)
-        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
 
         assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
         _write_enh_frame(conn, _ENH_RES_STARTED, src)
@@ -151,7 +153,9 @@ def test_ens_transport_send_wraps_b524_request() -> None:
         _write_bus_symbol(conn, 0xAA)
 
     with _run_ens_test_server(_handler) as (host, port):
-        transport = EnsTcpTransport(EnsTcpConfig(host=host, port=port, timeout_s=0.5, src=src))
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
         result = transport.send(dst, payload)
 
     assert result == response
@@ -164,8 +168,8 @@ def test_ens_transport_broadcast_does_not_expect_response() -> None:
     request = request_without_crc + bytes((_crc(request_without_crc),))
 
     def _handler(conn: socket.socket) -> None:
-        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x00)
-        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
 
         assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
         _write_enh_frame(conn, _ENH_RES_STARTED, src)
@@ -178,7 +182,9 @@ def test_ens_transport_broadcast_does_not_expect_response() -> None:
         _write_bus_symbol(conn, 0xAA)
 
     with _run_ens_test_server(_handler) as (host, port):
-        transport = EnsTcpTransport(EnsTcpConfig(host=host, port=port, timeout_s=0.5, src=src))
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
         result = transport.send_proto(dst, 0x07, 0xFE, b"", expect_response=False)
 
     assert result == b""


### PR DESCRIPTION
## Summary
- Rename `ens_tcp` → `enhanced_tcp` with consistent `Enhanced` naming in all symbols
- CLI accepts `--transport ens`, `enh`, or `enhanced` (all aliases for the same protocol)
- Default adapter port: 9999, source address: 0x31
- Init handshake fixed: `features=0x01` (matches adapter-proxy behavior)

## Field validation
Recommended scan completed direct to eBUS adapter v3.1 at 192.168.100.2:9999, bypassing ebusd. Correctly identified BASV2 (VRC 720f/2, SW 0507/HW 1704). 1094 requests in ~18 minutes.

## Test plan
- [x] 333 tests pass, ruff clean, docs+terminology sync OK
- [x] Field test: `--transport ens --host 192.168.100.2 --port 9999 --dst 0x15 --preset recommended`

🤖 Generated with [Claude Code](https://claude.com/claude-code)