### PR TITLE
scanner: establish opcode-first namespace identity model (#197)

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -4,7 +4,7 @@ import logging
 import math
 import struct
 from dataclasses import dataclass
-from typing import Final, NotRequired, TypedDict
+from typing import Final, NotRequired, TypedDict, cast
 
 from ..protocol.b524 import build_directory_probe_payload
 from ..transport.base import (
@@ -237,7 +237,7 @@ def _parse_directory_descriptor(resp: bytes, group: int) -> float:
             "Short directory probe response: "
             f"expected >=4 bytes, got {len(resp)} bytes for GG=0x{group:02X}"
         )
-    return struct.unpack("<f", resp[:4])[0]
+    return cast(float, struct.unpack("<f", resp[:4])[0])
 
 
 def _directory_probe_retry_budget(group: int) -> int:

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -26,6 +26,9 @@ class GroupConfig(TypedDict):
     ii_max: int
     rr_max: int
     opcodes: list[int]
+    # Namespace-capable opcode families known for this group. This can include
+    # future namespaces even when active scanning still uses a conservative subset.
+    namespace_opcodes: NotRequired[list[int]]
     rr_max_by_opcode: NotRequired[dict[int, int]]
     ii_max_by_opcode: NotRequired[dict[int, int]]
     # When True, this group is only included in the exhaustive preset.
@@ -50,6 +53,9 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "ii_max": 0x00,
         "rr_max": 0x0013,
         "opcodes": [0x02],
+        "namespace_opcodes": [0x02, 0x06],
+        "rr_max_by_opcode": {0x02: 0x0013, 0x06: 0x0015},
+        "ii_max_by_opcode": {0x02: 0x00, 0x06: 0x00},
     },
     0x02: {
         "desc": 1.0,
@@ -57,6 +63,9 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "ii_max": 0x0A,
         "rr_max": 0x0025,
         "opcodes": [0x02],
+        "namespace_opcodes": [0x02, 0x06],
+        "rr_max_by_opcode": {0x02: 0x0025, 0x06: 0x0025},
+        "ii_max_by_opcode": {0x02: 0x0A, 0x06: 0x0A},
     },
     0x03: {
         "desc": 1.0,
@@ -168,6 +177,41 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
     },
 }
 KNOWN_CORE_GROUPS: Final[frozenset[int]] = frozenset({0x02, 0x03})
+
+
+@dataclass(frozen=True, slots=True)
+class NamespaceProfile:
+    opcode: int
+    ii_max: int
+    rr_max: int
+
+
+def group_namespace_profiles(group: int) -> dict[int, NamespaceProfile]:
+    """Return namespace-aware profile rows keyed by opcode.
+
+    The returned map is canonical for config/model surfaces that need opcode-first
+    identity decisions without depending on scanner heuristics.
+    """
+
+    config = GROUP_CONFIG.get(group)
+    if config is None:
+        return {}
+
+    namespace_opcodes = config.get("namespace_opcodes", config["opcodes"])
+    rr_overrides = config.get("rr_max_by_opcode", {})
+    ii_overrides = config.get("ii_max_by_opcode", {})
+    default_rr = int(config["rr_max"])
+    default_ii = int(config["ii_max"])
+
+    profiles: dict[int, NamespaceProfile] = {}
+    for opcode in namespace_opcodes:
+        op = int(opcode)
+        profiles[op] = NamespaceProfile(
+            opcode=op,
+            ii_max=int(ii_overrides.get(op, default_ii)),
+            rr_max=int(rr_overrides.get(op, default_rr)),
+        )
+    return profiles
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/helianthus_vrc_explorer/scanner/identity.py
+++ b/src/helianthus_vrc_explorer/scanner/identity.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 # Canonical register identity key for B524 namespace-aware surfaces.
 # Order is opcode-first to avoid GG-centric collisions.
 type RegisterIdentity = tuple[int, int, int, int]
+type NamespaceIdentity = tuple[int, int]
 
 
 def make_register_identity(
     *, opcode: int, group: int, instance: int, register: int
 ) -> RegisterIdentity:
     return (opcode, group, instance, register)
+
+
+def make_namespace_identity(*, opcode: int, group: int) -> NamespaceIdentity:
+    return (opcode, group)
 
 
 def opcode_label(opcode: int) -> str:

--- a/src/helianthus_vrc_explorer/scanner/identity.py
+++ b/src/helianthus_vrc_explorer/scanner/identity.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+# Canonical register identity key for B524 namespace-aware surfaces.
+# Order is opcode-first to avoid GG-centric collisions.
+type RegisterIdentity = tuple[int, int, int, int]
+
+
+def make_register_identity(
+    *, opcode: int, group: int, instance: int, register: int
+) -> RegisterIdentity:
+    return (opcode, group, instance, register)
+
+
+def opcode_label(opcode: int) -> str:
+    if opcode == 0x02:
+        return "local"
+    if opcode == 0x06:
+        return "remote"
+    return f"0x{opcode:02x}"

--- a/src/helianthus_vrc_explorer/scanner/plan.py
+++ b/src/helianthus_vrc_explorer/scanner/plan.py
@@ -5,9 +5,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from ..protocol.b524 import RegisterOpcode
+from .identity import NamespaceIdentity, make_namespace_identity
 
 _HEX_DIGITS = set(string.hexdigits)
-PlanKey = tuple[int, int]
+PlanKey = NamespaceIdentity
 
 
 def parse_int_token(token: str) -> int:
@@ -116,11 +117,11 @@ def _hex_u16(value: int) -> str:
 
 
 def make_plan_key(group: int, opcode: int) -> PlanKey:
-    return (group, opcode)
+    return make_namespace_identity(opcode=opcode, group=group)
 
 
 def format_plan_key(key: PlanKey) -> str:
-    group, opcode = key
+    opcode, group = key
     return f"{_hex_u8(group)}/{_hex_u8(opcode)}"
 
 

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -14,6 +14,7 @@ from ..transport.base import (
     emit_trace_label,
 )
 from .director import GROUP_CONFIG
+from .identity import make_register_identity, opcode_label
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +55,26 @@ class RegisterEntry(TypedDict):
 
 
 def opcodes_for_group(group: int) -> list[RegisterOpcode]:
-    """Return all B524 register opcode families for a group."""
+    """Return active B524 register opcode families for a group."""
 
     config = GROUP_CONFIG.get(group)
     if config is None:
         return [0x02, 0x06]
     return [cast(RegisterOpcode, opcode) for opcode in config["opcodes"]]
+
+
+def namespace_opcodes_for_group(group: int) -> list[RegisterOpcode]:
+    """Return namespace-capable opcode families for a group.
+
+    This can be broader than `opcodes_for_group` while scanner heuristics are
+    still staged. It is intended for opcode-first model/config decisions.
+    """
+
+    config = GROUP_CONFIG.get(group)
+    if config is None:
+        return [0x02, 0x06]
+    raw_opcodes = config.get("namespace_opcodes", config["opcodes"])
+    return [cast(RegisterOpcode, opcode) for opcode in raw_opcodes]
 
 
 def _interpret_flags(flags: int, *, response_len: int) -> str:
@@ -81,16 +96,6 @@ def _interpret_flags(flags: int, *, response_len: int) -> str:
             return "user_rw"
         case _:
             return "unknown"
-
-
-def _opcode_label(opcode: int) -> str:
-    match opcode:
-        case 0x02:
-            return "local"
-        case 0x06:
-            return "remote"
-        case _:
-            return f"0x{opcode:02x}"
 
 
 def _looks_like_nul_terminated_latin1(value_bytes: bytes) -> bool:
@@ -214,11 +219,17 @@ def read_register(
 ) -> RegisterEntry:
     """Read a B524 register and parse it into an artifact-ready entry."""
 
+    register_key = make_register_identity(
+        opcode=opcode, group=group, instance=instance, register=register
+    )
     read_opcode = f"0x{opcode:02x}"
-    read_opcode_label = _opcode_label(opcode)
+    read_opcode_label = opcode_label(opcode)
     emit_trace_label(
         transport,
-        f"Reading dst=0x{dst:02X} GG=0x{group:02X} II=0x{instance:02X} RR=0x{register:04X}",
+        "Reading "
+        f"key=(op=0x{register_key[0]:02X},gg=0x{register_key[1]:02X},"
+        f"ii=0x{register_key[2]:02X},rr=0x{register_key[3]:04X}) "
+        f"dst=0x{dst:02X}",
     )
     payload = build_register_read_payload(opcode, group=group, instance=instance, register=register)
     try:

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -173,7 +173,7 @@ def _ensure_group_artifact(
     group_obj.setdefault("name", name)
     group_obj.setdefault("descriptor_observed", descriptor_observed)
     group_obj["dual_namespace"] = dual_namespace
-    return group_obj
+    return cast(dict[str, Any], group_obj)
 
 
 def _ensure_namespace_artifact(group_obj: dict[str, Any], *, opcode: int) -> dict[str, Any]:
@@ -188,7 +188,7 @@ def _ensure_namespace_artifact(group_obj: dict[str, Any], *, opcode: int) -> dic
     )
     namespace_obj.setdefault("label", opcode_label(opcode))
     namespace_obj.setdefault("instances", {})
-    return namespace_obj
+    return cast(dict[str, Any], namespace_obj)
 
 
 def _instances_object(
@@ -200,8 +200,8 @@ def _instances_object(
     group_obj = artifact["groups"][_hex_u8(group)]
     if bool(group_obj.get("dual_namespace")):
         namespace_obj = _ensure_namespace_artifact(group_obj, opcode=opcode)
-        return namespace_obj.setdefault("instances", {})
-    return group_obj.setdefault("instances", {})
+        return cast(dict[str, Any], namespace_obj.setdefault("instances", {}))
+    return cast(dict[str, Any], group_obj.setdefault("instances", {}))
 
 
 def _present_instances_for_opcode(
@@ -1456,7 +1456,7 @@ def scan_b524(
                 # reply in the artifact.
                 opcodes_to_try: tuple[RegisterOpcode, ...]
                 if task.group in GROUP_CONFIG:
-                    opcodes_to_try = (cast(RegisterOpcode, task.opcode),)
+                    opcodes_to_try = (task.opcode,)
                 else:
                     opcodes_to_try = (_LOCAL_REGISTER_OPCODE, _REMOTE_REGISTER_OPCODE)
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -19,6 +19,7 @@ from ..schema.b524_constraints import (
     StaticConstraintCatalog,
     StaticConstraintEntry,
     load_default_b524_constraints_catalog,
+    lookup_static_constraint,
 )
 from ..schema.ebusd_csv import EbusdCsvSchema
 from ..schema.myvaillant_map import MyvaillantRegisterMap
@@ -34,7 +35,7 @@ from .b509 import scan_b509
 from .b516 import scan_b516
 from .b555 import scan_b555
 from .director import GROUP_CONFIG, DiscoveredGroup, classify_groups, discover_groups
-from .identity import opcode_label
+from .identity import make_register_identity, opcode_label
 from .observer import ScanObserver
 from .plan import (
     GroupScanPlan,
@@ -42,6 +43,7 @@ from .plan import (
     RegisterTask,
     build_work_queue,
     estimate_register_requests,
+    make_plan_key,
 )
 from .register import RegisterEntry, is_instance_present, opcodes_for_group, read_register
 
@@ -119,7 +121,7 @@ def _ii_max_for_opcode(*, group: int, default_ii_max: int | None, opcode: int) -
 
 
 def _plan_key(group: int, opcode: int) -> PlanKey:
-    return (group, opcode)
+    return make_plan_key(group, opcode)
 
 
 def _scan_plan_meta_groups(plan: dict[PlanKey, GroupScanPlan]) -> dict[str, object]:
@@ -505,7 +507,9 @@ def _constraint_catalog_entry_count(catalog: StaticConstraintCatalog) -> int:
 
 def _constraint_for_register(
     *,
+    opcode: int,
     group: int,
+    instance: int,
     register: int,
     live_constraints: dict[int, dict[int, ConstraintEntry]],
     static_constraints: StaticConstraintCatalog,
@@ -513,7 +517,52 @@ def _constraint_for_register(
     live = live_constraints.get(group, {}).get(register)
     if live is not None:
         return live
-    return static_constraints.get(group, {}).get(register)
+    return lookup_static_constraint(
+        static_constraints,
+        identity=make_register_identity(
+            opcode=opcode,
+            group=group,
+            instance=instance,
+            register=register,
+        ),
+    )
+
+
+def _iter_group_instance_maps(group_obj: dict[str, Any]) -> list[dict[str, Any]]:
+    if bool(group_obj.get("dual_namespace")):
+        namespaces = group_obj.get("namespaces")
+        if not isinstance(namespaces, dict):
+            return []
+        instance_maps: list[dict[str, Any]] = []
+        for namespace_obj in namespaces.values():
+            if not isinstance(namespace_obj, dict):
+                continue
+            instances = namespace_obj.get("instances")
+            if isinstance(instances, dict):
+                instance_maps.append(instances)
+        return instance_maps
+
+    instances = group_obj.get("instances")
+    if isinstance(instances, dict):
+        return [instances]
+    return []
+
+
+def _group_instances_for_namespace(
+    group_obj: dict[str, Any], *, namespace_key: str | None = None
+) -> dict[str, Any] | None:
+    if namespace_key is not None and bool(group_obj.get("dual_namespace")):
+        namespaces = group_obj.get("namespaces")
+        if not isinstance(namespaces, dict):
+            return None
+        namespace_obj = namespaces.get(namespace_key)
+        if not isinstance(namespace_obj, dict):
+            return None
+        instances = namespace_obj.get("instances")
+        return instances if isinstance(instances, dict) else None
+
+    instance_maps = _iter_group_instance_maps(group_obj)
+    return instance_maps[0] if instance_maps else None
 
 
 def _apply_constraint_metadata(
@@ -649,14 +698,14 @@ def _apply_contextual_enum_annotations(artifact: dict[str, Any]) -> None:
     gg02 = groups.get("0x02")
     if not isinstance(gg02, dict):
         return
-    gg02_instances = gg02.get("instances")
-    if not isinstance(gg02_instances, dict):
+    gg02_instance_maps = _iter_group_instance_maps(gg02)
+    if not gg02_instance_maps:
         return
 
     gg00 = groups.get("0x00")
     system_schema: int | None = None
     if isinstance(gg00, dict):
-        gg00_instances = gg00.get("instances")
+        gg00_instances = _group_instances_for_namespace(gg00, namespace_key="0x02")
         if isinstance(gg00_instances, dict):
             ii00 = gg00_instances.get("0x00")
             if isinstance(ii00, dict):
@@ -669,51 +718,52 @@ def _apply_contextual_enum_annotations(artifact: dict[str, Any]) -> None:
     gg05_present = "0x05" in groups
     pool_sensor_present = False
 
-    for instance_obj in gg02_instances.values():
-        if not isinstance(instance_obj, dict):
-            continue
-        registers = instance_obj.get("registers")
-        if not isinstance(registers, dict):
-            continue
+    for gg02_instances in gg02_instance_maps:
+        for instance_obj in gg02_instances.values():
+            if not isinstance(instance_obj, dict):
+                continue
+            registers = instance_obj.get("registers")
+            if not isinstance(registers, dict):
+                continue
 
-        cooling_enabled = (
-            _entry_int_value(registers.get("0x0006"))
-            if isinstance(registers.get("0x0006"), dict)
-            else None
-        )
+            cooling_enabled = (
+                _entry_int_value(registers.get("0x0006"))
+                if isinstance(registers.get("0x0006"), dict)
+                else None
+            )
 
-        rr01 = registers.get("0x0001")
-        if isinstance(rr01, dict):
-            raw_value = _entry_int_value(rr01)
-            if raw_value is not None:
-                raw_name, resolved_name = _resolve_heating_circuit_type_name(raw_value)
-                rr01["enum_raw_name"] = raw_name
-                rr01["enum_resolved_name"] = resolved_name
-                rr01["value_display"] = f"{raw_name} ({resolved_name})"
+            rr01 = registers.get("0x0001")
+            if isinstance(rr01, dict):
+                raw_value = _entry_int_value(rr01)
+                if raw_value is not None:
+                    raw_name, resolved_name = _resolve_heating_circuit_type_name(raw_value)
+                    rr01["enum_raw_name"] = raw_name
+                    rr01["enum_resolved_name"] = resolved_name
+                    rr01["value_display"] = f"{raw_name} ({resolved_name})"
 
-        rr02 = registers.get("0x0002")
-        if isinstance(rr02, dict):
-            raw_value = _entry_int_value(rr02)
-            if raw_value is not None:
-                raw_name, resolved_name = _resolve_mixer_circuit_type_name(
-                    raw_value,
-                    cooling_enabled=cooling_enabled,
-                    gg05_present=gg05_present,
-                    system_schema=system_schema,
-                    pool_sensor_present=pool_sensor_present,
-                )
-                rr02["enum_raw_name"] = raw_name
-                rr02["enum_resolved_name"] = resolved_name
-                rr02["value_display"] = f"{raw_name} ({resolved_name})"
+            rr02 = registers.get("0x0002")
+            if isinstance(rr02, dict):
+                raw_value = _entry_int_value(rr02)
+                if raw_value is not None:
+                    raw_name, resolved_name = _resolve_mixer_circuit_type_name(
+                        raw_value,
+                        cooling_enabled=cooling_enabled,
+                        gg05_present=gg05_present,
+                        system_schema=system_schema,
+                        pool_sensor_present=pool_sensor_present,
+                    )
+                    rr02["enum_raw_name"] = raw_name
+                    rr02["enum_resolved_name"] = resolved_name
+                    rr02["value_display"] = f"{raw_name} ({resolved_name})"
 
-        rr03 = registers.get("0x0003")
-        if isinstance(rr03, dict):
-            raw_value = _entry_int_value(rr03)
-            if raw_value is not None:
-                raw_name, resolved_name = _resolve_room_influence_type_name(raw_value)
-                rr03["enum_raw_name"] = raw_name
-                rr03["enum_resolved_name"] = resolved_name
-                rr03["value_display"] = f"{raw_name} ({resolved_name})"
+            rr03 = registers.get("0x0003")
+            if isinstance(rr03, dict):
+                raw_value = _entry_int_value(rr03)
+                if raw_value is not None:
+                    raw_name, resolved_name = _resolve_room_influence_type_name(raw_value)
+                    rr03["enum_raw_name"] = raw_name
+                    rr03["enum_resolved_name"] = resolved_name
+                    rr03["value_display"] = f"{raw_name} ({resolved_name})"
 
 
 def _resolve_planner_mode(
@@ -1544,7 +1594,9 @@ def scan_b524(
                                 entry["ebusd_name"] = mapped_ebusd_name
 
                 constraint = _constraint_for_register(
+                    opcode=task.opcode,
                     group=task.group,
+                    instance=task.instance,
                     register=task.register,
                     live_constraints=constraint_map,
                     static_constraints=static_constraints,

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -34,6 +34,7 @@ from .b509 import scan_b509
 from .b516 import scan_b516
 from .b555 import scan_b555
 from .director import GROUP_CONFIG, DiscoveredGroup, classify_groups, discover_groups
+from .identity import opcode_label
 from .observer import ScanObserver
 from .plan import (
     GroupScanPlan,
@@ -90,14 +91,6 @@ def _primary_opcode(group: int) -> RegisterOpcode:
     return _group_opcodes(group)[0]
 
 
-def _opcode_label(opcode: int) -> str:
-    labels: dict[int, str] = {
-        _LOCAL_REGISTER_OPCODE: "local",
-        _REMOTE_REGISTER_OPCODE: "remote",
-    }
-    return labels.get(opcode, _hex_u8(opcode))
-
-
 def _is_dual_namespace_group(group: int) -> bool:
     return len(_group_opcodes(group)) > 1
 
@@ -145,7 +138,7 @@ def _scan_plan_meta_groups(plan: dict[PlanKey, GroupScanPlan]) -> dict[str, obje
             namespaces = group_obj.setdefault("namespaces", {})
             assert isinstance(namespaces, dict)
             namespace_meta = group_plan.to_meta()
-            namespace_meta["label"] = _opcode_label(group_plan.opcode)
+            namespace_meta["label"] = opcode_label(group_plan.opcode)
             namespaces[_hex_u8(group_plan.opcode)] = namespace_meta
             continue
         serializable[group_key] = group_plan.to_meta()
@@ -189,11 +182,11 @@ def _ensure_namespace_artifact(group_obj: dict[str, Any], *, opcode: int) -> dic
     namespace_obj = namespaces.setdefault(
         namespace_key,
         {
-            "label": _opcode_label(opcode),
+            "label": opcode_label(opcode),
             "instances": {},
         },
     )
-    namespace_obj.setdefault("label", _opcode_label(opcode))
+    namespace_obj.setdefault("label", opcode_label(opcode))
     namespace_obj.setdefault("instances", {})
     return namespace_obj
 
@@ -1095,7 +1088,7 @@ def scan_b524(
                     emit_trace_label(
                         transport,
                         "Exploring unknown group "
-                        f"0x{group.group:02X} ({_opcode_label(opcode)}) "
+                        f"0x{group.group:02X} ({opcode_label(opcode)}) "
                         "across multiple instances",
                     )
                     present_instances = _probe_unknown_present_instances(
@@ -1107,7 +1100,7 @@ def scan_b524(
                     )
                     _mark_present_instances(instances_obj, instances=present_instances)
                     namespace_probe_counts.append(
-                        f"{_opcode_label(opcode)} {len(present_instances)}/{total_slots}"
+                        f"{opcode_label(opcode)} {len(present_instances)}/{total_slots}"
                     )
                 if observer is not None:
                     observer.log(
@@ -1165,13 +1158,13 @@ def scan_b524(
                 instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
                 if not _is_instanced_group(namespace_ii_max):
                     _mark_present_instances(instances_obj, instances=(0x00,))
-                    known_namespace_probe_counts.append(f"{_opcode_label(opcode)} 1/1")
+                    known_namespace_probe_counts.append(f"{opcode_label(opcode)} 1/1")
                     continue
 
                 assert namespace_ii_max is not None
                 emit_trace_label(
                     transport,
-                    f"Identifying instances in group 0x{group.group:02X} ({_opcode_label(opcode)})",
+                    f"Identifying instances in group 0x{group.group:02X} ({opcode_label(opcode)})",
                 )
                 present_instances = _probe_present_instances(
                     transport,
@@ -1183,7 +1176,7 @@ def scan_b524(
                 )
                 _mark_present_instances(instances_obj, instances=present_instances)
                 known_namespace_probe_counts.append(
-                    f"{_opcode_label(opcode)} {len(present_instances)}/{namespace_ii_max + 1}"
+                    f"{opcode_label(opcode)} {len(present_instances)}/{namespace_ii_max + 1}"
                 )
 
             if observer is not None:
@@ -1288,7 +1281,7 @@ def scan_b524(
                             opcode=opcode,
                         ),
                         present_instances=present_instances,
-                        namespace_label=(_opcode_label(opcode) if dual_namespace else None),
+                        namespace_label=(opcode_label(opcode) if dual_namespace else None),
                         primary=(opcode == primary_opcode),
                         exhaustive_only=bool(config and config.get("exhaustive_only")),
                     )

--- a/src/helianthus_vrc_explorer/schema/b524_constraints.py
+++ b/src/helianthus_vrc_explorer/schema/b524_constraints.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
+from ..scanner.identity import RegisterIdentity
+
 _KIND_TO_TT = {
     "u8_range": 0x06,
     "u16_range": 0x09,
@@ -115,3 +117,17 @@ def load_default_b524_constraints_catalog() -> tuple[StaticConstraintCatalog, st
             except Exception:
                 return ({}, None)
         return ({}, None)
+
+
+def lookup_static_constraint(
+    catalog: StaticConstraintCatalog, *, identity: RegisterIdentity
+) -> StaticConstraintEntry | None:
+    """Resolve the current static catalog using canonical register identity.
+
+    The static catalog remains GG/RR-scoped because the underlying opcode-0x01
+    constraint protocol does not encode opcode or instance. The namespace-scope
+    decision is intentionally handled in follow-up issue #198.
+    """
+
+    _opcode, group, _instance, register = identity
+    return catalog.get(group, {}).get(register)

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -17,6 +17,7 @@ from ..scanner.plan import (
     estimate_register_requests,
     format_int_set,
     format_plan_key,
+    make_plan_key,
     parse_int_set,
     parse_int_token,
 )
@@ -39,7 +40,7 @@ class PlannerGroup:
 
     @property
     def key(self) -> PlanKey:
-        return (self.group, self.opcode)
+        return make_plan_key(self.group, self.opcode)
 
     @property
     def display_name(self) -> str:

--- a/tests/test_planner_unknown_groups.py
+++ b/tests/test_planner_unknown_groups.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from helianthus_vrc_explorer.scanner.plan import GroupScanPlan
+from helianthus_vrc_explorer.scanner.plan import GroupScanPlan, make_plan_key
 from helianthus_vrc_explorer.ui.planner import (
     PlannerGroup,
     build_plan_from_preset,
@@ -52,7 +52,7 @@ def test_prompt_scan_plan_disables_unknown_groups_by_default(monkeypatch) -> Non
     ]
 
     plan = prompt_scan_plan(console, groups, request_rate_rps=None, default_plan=None)
-    assert sorted(plan.keys()) == [(0x02, 0x02)]
+    assert sorted(plan.keys()) == [make_plan_key(0x02, 0x02)]
 
 
 def test_prompt_scan_plan_accepts_legacy_aggressive_alias_as_full(monkeypatch) -> None:
@@ -88,7 +88,7 @@ def test_prompt_scan_plan_accepts_legacy_aggressive_alias_as_full(monkeypatch) -
 
     plan = prompt_scan_plan(console, groups, request_rate_rps=None, default_plan=None)
     assert plan == {
-        (0x69, 0x02): GroupScanPlan(
+        make_plan_key(0x69, 0x02): GroupScanPlan(
             group=0x69,
             opcode=0x02,
             rr_max=0x30,
@@ -124,8 +124,9 @@ def test_build_plan_from_preset_recommended_skips_unknown_groups() -> None:
     ]
 
     plan = build_plan_from_preset(groups, preset="recommended")
-    assert sorted(plan.keys()) == [(0x02, 0x02)]
-    assert plan[(0x02, 0x02)].instances == (0x00, 0x01)
+    key = make_plan_key(0x02, 0x02)
+    assert sorted(plan.keys()) == [key]
+    assert plan[key].instances == (0x00, 0x01)
 
 
 def test_build_plan_from_preset_full_keeps_ff_when_present() -> None:
@@ -144,4 +145,4 @@ def test_build_plan_from_preset_full_keeps_ff_when_present() -> None:
     ]
 
     plan = build_plan_from_preset(groups, preset="full")
-    assert plan[(0x69, 0x06)].instances == tuple(range(0x0A + 1)) + (0xFF,)
+    assert plan[make_plan_key(0x69, 0x06)].instances == tuple(range(0x0A + 1)) + (0xFF,)

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -12,6 +12,7 @@ from helianthus_vrc_explorer.scanner.director import (
     DiscoveredGroup,
     classify_groups,
     discover_groups,
+    group_namespace_profiles,
 )
 from helianthus_vrc_explorer.transport.base import (
     TransportCommandNotEnabled,
@@ -261,6 +262,10 @@ def test_group_config_completeness() -> None:
         0x11,
     }
     assert GROUP_CONFIG[0x08]["name"] == "Buffer / Solar Cylinder 2"
+    assert GROUP_CONFIG[0x01]["namespace_opcodes"] == [0x02, 0x06]
+    assert GROUP_CONFIG[0x01]["rr_max_by_opcode"] == {0x02: 0x0013, 0x06: 0x0015}
+    assert GROUP_CONFIG[0x02]["namespace_opcodes"] == [0x02, 0x06]
+    assert GROUP_CONFIG[0x02]["ii_max_by_opcode"] == {0x02: 0x0A, 0x06: 0x0A}
     assert GROUP_CONFIG[0x08]["opcodes"] == [0x02, 0x06]
     assert GROUP_CONFIG[0x08]["rr_max_by_opcode"] == {0x02: 0x0007, 0x06: 0x0004}
     assert GROUP_CONFIG[0x08]["ii_max_by_opcode"] == {0x02: 0x00, 0x06: 0x0A}
@@ -269,6 +274,19 @@ def test_group_config_completeness() -> None:
     assert GROUP_CONFIG[0x09]["rr_max_by_opcode"] == {0x02: 0x000F, 0x06: 0x0035}
     assert GROUP_CONFIG[0x0A]["rr_max"] == 0x004D
     assert GROUP_CONFIG[0x0A]["rr_max_by_opcode"] == {0x02: 0x004D, 0x06: 0x0035}
+
+
+def test_group_namespace_profiles_support_opcode_first_identity() -> None:
+    hw = group_namespace_profiles(0x01)
+    hc = group_namespace_profiles(0x02)
+
+    assert sorted(hw) == [0x02, 0x06]
+    assert hw[0x02].rr_max == 0x0013
+    assert hw[0x06].rr_max == 0x0015
+
+    assert sorted(hc) == [0x02, 0x06]
+    assert hc[0x02].ii_max == 0x0A
+    assert hc[0x06].ii_max == 0x0A
 
 
 def test_classify_groups_missing_desc() -> None:

--- a/tests/test_scanner_identity.py
+++ b/tests/test_scanner_identity.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from helianthus_vrc_explorer.scanner.identity import make_register_identity, opcode_label
+
+
+def test_make_register_identity_is_opcode_first() -> None:
+    assert make_register_identity(opcode=0x06, group=0x02, instance=0x01, register=0x0015) == (
+        0x06,
+        0x02,
+        0x01,
+        0x0015,
+    )
+
+
+def test_opcode_label_uses_local_remote_conventions() -> None:
+    assert opcode_label(0x02) == "local"
+    assert opcode_label(0x06) == "remote"
+    assert opcode_label(0xA5) == "0xa5"

--- a/tests/test_scanner_plan.py
+++ b/tests/test_scanner_plan.py
@@ -8,6 +8,8 @@ from helianthus_vrc_explorer.scanner.plan import (
     build_work_queue,
     estimate_register_requests,
     format_int_set,
+    format_plan_key,
+    make_plan_key,
     parse_int_set,
     parse_int_token,
 )
@@ -41,13 +43,15 @@ def test_parse_int_set_rejects_out_of_range() -> None:
 
 def test_estimate_register_requests() -> None:
     plan = {
-        (0x02, 0x02): GroupScanPlan(
+        make_plan_key(0x02, 0x02): GroupScanPlan(
             group=0x02,
             opcode=0x02,
             rr_max=0x0003,
             instances=(0x00, 0x01),
         ),
-        (0x01, 0x02): GroupScanPlan(group=0x01, opcode=0x02, rr_max=0x0001, instances=(0x00,)),
+        make_plan_key(0x01, 0x02): GroupScanPlan(
+            group=0x01, opcode=0x02, rr_max=0x0001, instances=(0x00,)
+        ),
     }
     # GG=0x02: 2 instances * (3+1) regs = 8
     # GG=0x01: 1 instance * (1+1) regs = 2
@@ -62,7 +66,7 @@ def test_format_int_set_compacts_ranges() -> None:
 
 def test_build_work_queue_skips_done_tasks() -> None:
     plan = {
-        (0x02, 0x02): GroupScanPlan(
+        make_plan_key(0x02, 0x02): GroupScanPlan(
             group=0x02,
             opcode=0x02,
             rr_max=0x0002,
@@ -113,13 +117,22 @@ def test_plan_dual_namespace_creates_two_entries() -> None:
     ]
 
     recommended = build_plan_from_preset(groups, preset="recommended")
-    assert sorted(recommended) == [(0x09, 0x02), (0x09, 0x06)]
-    assert recommended[(0x09, 0x02)].rr_max == 0x000F
-    assert recommended[(0x09, 0x06)].rr_max == 0x000F
-    assert recommended[(0x09, 0x02)].instances == (0x00,)
-    assert recommended[(0x09, 0x06)].instances == (0x00,)
+    local_key = make_plan_key(0x09, 0x02)
+    remote_key = make_plan_key(0x09, 0x06)
+    assert sorted(recommended) == [local_key, remote_key]
+    assert recommended[local_key].rr_max == 0x000F
+    assert recommended[remote_key].rr_max == 0x000F
+    assert recommended[local_key].instances == (0x00,)
+    assert recommended[remote_key].instances == (0x00,)
 
     full = build_plan_from_preset(groups, preset="full")
-    assert full[(0x09, 0x02)].instances == tuple(range(0x0A + 1))
-    assert full[(0x09, 0x06)].instances == tuple(range(0x0A + 1))
-    assert full[(0x09, 0x06)].rr_max == 0x0035
+    assert full[local_key].instances == tuple(range(0x0A + 1))
+    assert full[remote_key].instances == tuple(range(0x0A + 1))
+    assert full[remote_key].rr_max == 0x0035
+
+
+def test_plan_key_is_opcode_first_namespace_identity() -> None:
+    key = make_plan_key(0x09, 0x06)
+
+    assert key == (0x06, 0x09)
+    assert format_plan_key(key) == "0x09/0x06"

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -6,6 +6,7 @@ from helianthus_vrc_explorer.scanner.register import (
     _interpret_flags,
     _parse_inferred_value,
     is_instance_present,
+    namespace_opcodes_for_group,
     opcodes_for_group,
     read_register,
 )
@@ -198,6 +199,12 @@ def test_opcodes_for_group_dual_namespace() -> None:
 def test_opcodes_for_group_single_namespace() -> None:
     assert opcodes_for_group(0x00) == [0x02]
     assert opcodes_for_group(0x0C) == [0x06]
+
+
+def test_namespace_opcodes_for_group_supports_staged_remote_namespaces() -> None:
+    assert namespace_opcodes_for_group(0x01) == [0x02, 0x06]
+    assert namespace_opcodes_for_group(0x02) == [0x02, 0x06]
+    assert namespace_opcodes_for_group(0x0C) == [0x06]
 
 
 def test_read_register_infers_hex_for_unparseable_u24_values() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -7,8 +7,8 @@ import pytest
 from rich.console import Console
 
 from helianthus_vrc_explorer.scanner.observer import ScanObserver
-from helianthus_vrc_explorer.scanner.plan import GroupScanPlan
-from helianthus_vrc_explorer.scanner.scan import scan_b524
+from helianthus_vrc_explorer.scanner.plan import GroupScanPlan, make_plan_key
+from helianthus_vrc_explorer.scanner.scan import _apply_contextual_enum_annotations, scan_b524
 from helianthus_vrc_explorer.transport.base import TransportInterface
 from helianthus_vrc_explorer.transport.dummy import DummyTransport
 
@@ -221,6 +221,57 @@ def _write_fixture_group_09(tmp_path: Path) -> Path:
         },
     }
     path = tmp_path / "fixture_group_09.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
+def _write_fixture_group_02_dual_namespace(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x03"}},
+        "groups": {
+            "0x00": {
+                "descriptor_type": 3.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {"raw_hex": "08 00 00 00"},
+                        }
+                    }
+                },
+            },
+            "0x02": {
+                "descriptor_type": 1.0,
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {"raw_hex": "01", "value": 1},
+                                    "0x0002": {"raw_hex": "02", "value": 2},
+                                    "0x0003": {"raw_hex": "01", "value": 1},
+                                    "0x0006": {"raw_hex": "00", "value": 0},
+                                }
+                            }
+                        }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {"raw_hex": "02", "value": 2},
+                                    "0x0002": {"raw_hex": "03", "value": 3},
+                                    "0x0003": {"raw_hex": "02", "value": 2},
+                                    "0x0006": {"raw_hex": "01", "value": 1},
+                                }
+                            }
+                        }
+                    },
+                },
+            },
+        },
+    }
+    path = tmp_path / "fixture_group_02_dual_namespace.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
     return path
 
@@ -519,13 +570,13 @@ def test_scan_b524_scans_enabled_unknown_group_via_planner(monkeypatch, tmp_path
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
-            (0x69, 0x02): GroupScanPlan(
+            make_plan_key(0x69, 0x02): GroupScanPlan(
                 group=0x69,
                 opcode=0x02,
                 rr_max=0x0000,
                 instances=(0x00,),
             ),
-            (0x69, 0x06): GroupScanPlan(
+            make_plan_key(0x69, 0x06): GroupScanPlan(
                 group=0x69,
                 opcode=0x06,
                 rr_max=0x0000,
@@ -575,7 +626,7 @@ def test_scan_b524_scans_absent_instances_when_planner_overrides(
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
-            (0x02, 0x02): GroupScanPlan(
+            make_plan_key(0x02, 0x02): GroupScanPlan(
                 group=0x02,
                 opcode=0x02,
                 rr_max=0x0002,
@@ -662,13 +713,13 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
-            (0x09, 0x02): GroupScanPlan(
+            make_plan_key(0x09, 0x02): GroupScanPlan(
                 group=0x09,
                 opcode=0x02,
                 rr_max=0x0000,
                 instances=(0x00,),
             ),
-            (0x09, 0x06): GroupScanPlan(
+            make_plan_key(0x09, 0x06): GroupScanPlan(
                 group=0x09,
                 opcode=0x06,
                 rr_max=0x0000,
@@ -733,6 +784,19 @@ def test_artifact_register_flags_present(tmp_path: Path) -> None:
     assert entry["read_opcode_label"] == "local"
 
 
+def test_contextual_enum_annotations_follow_dual_namespace_group_02(tmp_path: Path) -> None:
+    fixture_path = _write_fixture_group_02_dual_namespace(tmp_path)
+    artifact = json.loads(fixture_path.read_text(encoding="utf-8"))
+    _apply_contextual_enum_annotations(artifact)
+
+    remote_registers = artifact["groups"]["0x02"]["namespaces"]["0x06"]["instances"]["0x00"][
+        "registers"
+    ]
+    assert remote_registers["0x0001"]["enum_resolved_name"] == "MIXER_CIRCUIT_EXTERNAL"
+    assert remote_registers["0x0002"]["enum_resolved_name"] == "DHW"
+    assert remote_registers["0x0003"]["enum_resolved_name"] == "EXTENDED"
+
+
 def test_group_08_remote_namespace_only_marks_present_instances(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -744,13 +808,13 @@ def test_group_08_remote_namespace_only_marks_present_instances(
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
-            (0x08, 0x02): GroupScanPlan(
+            make_plan_key(0x08, 0x02): GroupScanPlan(
                 group=0x08,
                 opcode=0x02,
                 rr_max=0x0000,
                 instances=(0x00,),
             ),
-            (0x08, 0x06): GroupScanPlan(
+            make_plan_key(0x08, 0x06): GroupScanPlan(
                 group=0x08,
                 opcode=0x06,
                 rr_max=0x0000,
@@ -813,7 +877,7 @@ def test_type_hint_propagation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
-            (0x09, 0x06): GroupScanPlan(
+            make_plan_key(0x09, 0x06): GroupScanPlan(
                 group=0x09,
                 opcode=0x06,
                 rr_max=0x0004,
@@ -857,25 +921,25 @@ def test_scan_b524_replays_dual_namespace_fixture_end_to_end(
 
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
-            (0x00, 0x02): GroupScanPlan(
+            make_plan_key(0x00, 0x02): GroupScanPlan(
                 group=0x00,
                 opcode=0x02,
                 rr_max=0x0004,
                 instances=(0x00,),
             ),
-            (0x09, 0x02): GroupScanPlan(
+            make_plan_key(0x09, 0x02): GroupScanPlan(
                 group=0x09,
                 opcode=0x02,
                 rr_max=0x0007,
                 instances=(0x00, 0x01),
             ),
-            (0x09, 0x06): GroupScanPlan(
+            make_plan_key(0x09, 0x06): GroupScanPlan(
                 group=0x09,
                 opcode=0x06,
                 rr_max=0x0007,
                 instances=(0x00, 0x01),
             ),
-            (0x0C, 0x06): GroupScanPlan(
+            make_plan_key(0x0C, 0x06): GroupScanPlan(
                 group=0x0C,
                 opcode=0x06,
                 rr_max=0x0007,
@@ -992,7 +1056,7 @@ def test_scan_b524_normalizes_legacy_aggressive_preset_to_full_for_textual_defau
     assert captured["default_preset"] == "full"
     default_plan = captured["default_plan"]
     assert isinstance(default_plan, dict)
-    for key in ((0x69, 0x02), (0x69, 0x06)):
+    for key in (make_plan_key(0x69, 0x02), make_plan_key(0x69, 0x06)):
         assert key in default_plan
         group_plan = default_plan[key]
         assert group_plan.rr_max == 0x30
@@ -1267,7 +1331,7 @@ def test_scan_b524_replan_textual_failure_prompts_classic_immediately(
     def fake_prompt_scan_plan(*_args, **_kwargs):
         classic_calls["count"] += 1
         return {
-            (0x02, 0x02): GroupScanPlan(
+            make_plan_key(0x02, 0x02): GroupScanPlan(
                 group=0x02,
                 opcode=0x02,
                 rr_max=0x0000,

--- a/tests/test_schema_b524_constraints.py
+++ b/tests/test_schema_b524_constraints.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from helianthus_vrc_explorer.schema.b524_constraints import load_default_b524_constraints_catalog
+from helianthus_vrc_explorer.scanner.identity import make_register_identity
+from helianthus_vrc_explorer.schema.b524_constraints import (
+    load_default_b524_constraints_catalog,
+    lookup_static_constraint,
+)
 
 
 def test_load_default_b524_constraints_catalog() -> None:
@@ -22,3 +26,20 @@ def test_load_default_b524_constraints_catalog() -> None:
     assert zone_desired_temp.min_value == 15.0
     assert zone_desired_temp.max_value == 30.0
     assert zone_desired_temp.step_value == 0.5
+
+
+def test_lookup_static_constraint_accepts_canonical_register_identity() -> None:
+    catalog, _source = load_default_b524_constraints_catalog()
+
+    entry = lookup_static_constraint(
+        catalog,
+        identity=make_register_identity(
+            opcode=0x06,
+            group=0x02,
+            instance=0x00,
+            register=0x0002,
+        ),
+    )
+
+    assert entry is not None
+    assert entry.kind == "u16_range"


### PR DESCRIPTION
## What
- add a dedicated scanner identity surface with canonical register identity `(opcode, group, instance, register)` and shared opcode labels
- extend `GROUP_CONFIG` to encode namespace-capable opcodes for `GG=0x01` and `GG=0x02`, including opcode-specific limits (`0x06` support for GG=0x01 up to RR=0x0015)
- add `group_namespace_profiles()` and `namespace_opcodes_for_group()` to expose opcode-first model/config data without forcing full scan-path behavior changes yet
- remove duplicated opcode label logic in scanner by wiring scan/register through the shared identity helper

## Why
Issue #197 requires an opcode-first model/config surface so downstream namespace work is not blocked by GG-centric assumptions.

## Validation
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/test_scanner_identity.py tests/test_scanner_register.py tests/test_scanner_director.py tests/test_scanner_scan.py`
- `./.venv/bin/ruff check src tests`

Closes #197
