### PR TITLE
scanner: decide B524 constraint scope + provenance hygiene (#198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Transport note:
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.
 - `--probe-constraints` is a separate live rescan path for opcode `0x01`; it can add hundreds of extra requests and should only be used when you need to confirm a mismatch or do research work.
+- Constraint scope decision: `gg_rr_invariant`. The opcode `0x01` probe frame (`01 GG RR`) does not carry register-read opcode (`0x02`/`0x06`) or instance, so constraints are treated as GG/RR-scoped invariants across local and remote namespaces.
+- Artifacts record this decision in `meta.constraint_scope` and per-entry fields (`constraint_scope`, `constraint_provenance`) so report/UI consumers do not guess scope semantics.
 - `--preset full` is intentionally expensive: it expands all instance slots and full RR ranges and can take hours on BASV2.
 
 Output:

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -47,6 +47,8 @@ class RegisterEntry(TypedDict):
     constraint_max: NotRequired[int | float | str]
     constraint_step: NotRequired[int | float]
     constraint_source: NotRequired[str]
+    constraint_scope: NotRequired[str]
+    constraint_provenance: NotRequired[str]
     constraint_mismatch_reason: NotRequired[str]
     register_class: NotRequired[str]
     enum_raw_name: NotRequired[str]

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -16,8 +16,11 @@ from rich.console import Console
 
 from ..protocol.b524 import RegisterOpcode, build_constraint_probe_payload
 from ..schema.b524_constraints import (
+    CONSTRAINT_SCOPE_DECISION,
+    CONSTRAINT_SCOPE_PROTOCOL,
     StaticConstraintCatalog,
     StaticConstraintEntry,
+    constraint_scope_metadata,
     load_default_b524_constraints_catalog,
     lookup_static_constraint,
 )
@@ -332,6 +335,8 @@ class ConstraintEntry:
     step_value: int | float
     raw_hex: str
     source: str = "opcode_0x01"
+    scope: str = CONSTRAINT_SCOPE_DECISION
+    provenance: str = "live_probe_from_opcode_0x01"
 
 
 def _decode_constraint_date(value: bytes) -> str:
@@ -496,6 +501,8 @@ def _constraint_map_to_dict(
                 "step": entry.step_value,
                 "raw_hex": entry.raw_hex,
                 "source": entry.source,
+                "scope": entry.scope,
+                "provenance": entry.provenance,
             }
         serializable[_hex_u8(group)] = group_obj
     return serializable
@@ -575,6 +582,8 @@ def _apply_constraint_metadata(
     entry["constraint_max"] = constraint.max_value
     entry["constraint_step"] = constraint.step_value
     entry["constraint_source"] = constraint.source
+    entry["constraint_scope"] = constraint.scope
+    entry["constraint_provenance"] = constraint.provenance
 
 
 def _constraint_mismatch_reason(
@@ -919,6 +928,7 @@ def scan_b524(
         artifact["meta"]["constraint_catalog_entries"] = _constraint_catalog_entry_count(
             static_constraints
         )
+    artifact["meta"]["constraint_scope"] = constraint_scope_metadata()
 
     incomplete_reason: str | None = None
 
@@ -1618,6 +1628,9 @@ def scan_b524(
                                 "constraint_max": constraint.max_value,
                                 "constraint_type": constraint.kind,
                                 "constraint_source": constraint.source,
+                                "constraint_scope": constraint.scope,
+                                "constraint_provenance": constraint.provenance,
+                                "constraint_probe_protocol": CONSTRAINT_SCOPE_PROTOCOL,
                                 "reason": mismatch_reason,
                             }
                         )

--- a/src/helianthus_vrc_explorer/schema/b524_constraints.py
+++ b/src/helianthus_vrc_explorer/schema/b524_constraints.py
@@ -14,6 +14,14 @@ _KIND_TO_TT = {
     "f32_range": 0x0F,
 }
 
+CONSTRAINT_SCOPE_DECISION = "gg_rr_invariant"
+CONSTRAINT_SCOPE_PROTOCOL = "opcode_0x01"
+CONSTRAINT_SCOPE_APPLIES_TO = "all_register_read_namespaces"
+CONSTRAINT_SCOPE_RATIONALE = (
+    "B524 constraint probe frames (01 GG RR) do not encode register-read opcode or "
+    "instance, so static constraints are treated as GG/RR-scoped invariants."
+)
+
 
 @dataclass(frozen=True, slots=True)
 class StaticConstraintEntry:
@@ -23,9 +31,22 @@ class StaticConstraintEntry:
     max_value: int | float | str
     step_value: int | float
     source: str = "static_catalog"
+    scope: str = CONSTRAINT_SCOPE_DECISION
+    provenance: str = "catalog_seeded_from_opcode_0x01"
 
 
 type StaticConstraintCatalog = dict[int, dict[int, StaticConstraintEntry]]
+
+
+def constraint_scope_metadata() -> dict[str, str]:
+    """Return canonical metadata describing the active constraint-scope decision."""
+
+    return {
+        "decision": CONSTRAINT_SCOPE_DECISION,
+        "protocol": CONSTRAINT_SCOPE_PROTOCOL,
+        "applies_to": CONSTRAINT_SCOPE_APPLIES_TO,
+        "rationale": CONSTRAINT_SCOPE_RATIONALE,
+    }
 
 
 def _parse_hex_u8(value: str) -> int:
@@ -125,8 +146,7 @@ def lookup_static_constraint(
     """Resolve the current static catalog using canonical register identity.
 
     The static catalog remains GG/RR-scoped because the underlying opcode-0x01
-    constraint protocol does not encode opcode or instance. The namespace-scope
-    decision is intentionally handled in follow-up issue #198.
+    constraint protocol does not encode opcode or instance.
     """
 
     _opcode, group, _instance, register = identity

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -1592,6 +1592,8 @@ __ARTIFACT_JSON__
               if (typeof entry.constraint_max !== "undefined") tipParts.push(`constraint_max=${formatValue(entry.constraint_max)}`);
               if (typeof entry.constraint_step !== "undefined") tipParts.push(`constraint_step=${formatValue(entry.constraint_step)}`);
               if (entry.constraint_tt) tipParts.push(`constraint_tt=${entry.constraint_tt}`);
+              if (entry.constraint_scope) tipParts.push(`constraint_scope=${entry.constraint_scope}`);
+              if (entry.constraint_provenance) tipParts.push(`constraint_provenance=${entry.constraint_provenance}`);
               if (tipParts.length) td.title = tipParts.join("\\n");
 
               tr.appendChild(td);

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -451,6 +451,8 @@ def test_scan_b524_collects_constraint_dictionary_entries(tmp_path: Path) -> Non
     assert constraints["min"] == 0
     assert constraints["max"] == 4
     assert constraints["step"] == 1
+    assert constraints["scope"] == "gg_rr_invariant"
+    assert constraints["provenance"] == "live_probe_from_opcode_0x01"
     assert transport.register_reads is not None
     scanned_registers = {
         rr for (_opcode, gg, ii, rr) in transport.register_reads if gg == 0x02 and ii == 0x00
@@ -500,8 +502,12 @@ def test_scan_b524_skips_constraint_dictionary_by_default(tmp_path: Path) -> Non
     assert transport.constraint_requests == []
     assert artifact["meta"]["constraint_probe_enabled"] is False
     assert artifact["meta"]["constraint_dictionary"] == {}
+    assert artifact["meta"]["constraint_scope"]["decision"] == "gg_rr_invariant"
+    assert artifact["meta"]["constraint_scope"]["protocol"] == "opcode_0x01"
     entry = artifact["groups"]["0x02"]["instances"]["0x00"]["registers"]["0x0002"]
     assert entry["constraint_source"] == "static_catalog"
+    assert entry["constraint_scope"] == "gg_rr_invariant"
+    assert entry["constraint_provenance"] == "catalog_seeded_from_opcode_0x01"
     assert entry["constraint_type"] == "u16_range"
     assert entry["constraint_min"] == 0
     assert entry["constraint_max"] == 4
@@ -543,6 +549,9 @@ def test_scan_b524_flags_seeded_constraint_mismatch(tmp_path: Path) -> None:
     assert mismatches[0]["group"] == "0x02"
     assert mismatches[0]["register"] == "0x0002"
     assert mismatches[0]["value"] == 5
+    assert mismatches[0]["constraint_scope"] == "gg_rr_invariant"
+    assert mismatches[0]["constraint_provenance"] == "catalog_seeded_from_opcode_0x01"
+    assert mismatches[0]["constraint_probe_protocol"] == "opcode_0x01"
     assert artifact["meta"]["constraint_rescan_recommended"] is True
 
 

--- a/tests/test_schema_b524_constraints.py
+++ b/tests/test_schema_b524_constraints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from helianthus_vrc_explorer.scanner.identity import make_register_identity
 from helianthus_vrc_explorer.schema.b524_constraints import (
+    constraint_scope_metadata,
     load_default_b524_constraints_catalog,
     lookup_static_constraint,
 )
@@ -19,6 +20,8 @@ def test_load_default_b524_constraints_catalog() -> None:
     assert hc_room_setpoint.max_value == 4
     assert hc_room_setpoint.step_value == 1
     assert hc_room_setpoint.source == "static_catalog"
+    assert hc_room_setpoint.scope == "gg_rr_invariant"
+    assert hc_room_setpoint.provenance == "catalog_seeded_from_opcode_0x01"
 
     zone_desired_temp = catalog[0x03][0x0002]
     assert zone_desired_temp.tt == 0x0F
@@ -43,3 +46,36 @@ def test_lookup_static_constraint_accepts_canonical_register_identity() -> None:
 
     assert entry is not None
     assert entry.kind == "u16_range"
+
+
+def test_lookup_static_constraint_is_opcode_invariant_for_same_group_register() -> None:
+    catalog, _source = load_default_b524_constraints_catalog()
+    pairs = [(0x02, 0x0002), (0x03, 0x0002), (0x09, 0x0002)]
+    for group, register in pairs:
+        local = lookup_static_constraint(
+            catalog,
+            identity=make_register_identity(
+                opcode=0x02,
+                group=group,
+                instance=0x00,
+                register=register,
+            ),
+        )
+        remote = lookup_static_constraint(
+            catalog,
+            identity=make_register_identity(
+                opcode=0x06,
+                group=group,
+                instance=0x01,
+                register=register,
+            ),
+        )
+        assert local is not None
+        assert remote is not None
+        assert local == remote
+
+
+def test_constraint_scope_metadata_declares_gg_rr_invariant_policy() -> None:
+    metadata = constraint_scope_metadata()
+    assert metadata["decision"] == "gg_rr_invariant"
+    assert metadata["protocol"] == "opcode_0x01"


### PR DESCRIPTION
## What
Implement issue #198 by making the B524 constraint-scope decision explicit and threading provenance through artifact/register metadata.

## Why
Constraint handling was ambiguous after #197 deferal: static catalog entries were used as GG/RR lookups, but scope/provenance were not explicit in scan artifact and mismatch metadata.

## Changes
- Declare and expose architectural decision: `gg_rr_invariant` for constraints sourced from opcode `0x01` (`01 GG RR`).
- Add canonical constraint-scope metadata helper and attach it to scan artifact meta (`meta.constraint_scope`).
- Add per-entry provenance/scope fields for static and live constraints.
- Carry scope/provenance into `constraint_mismatches` metadata.
- Surface scope/provenance in HTML report tooltips.
- Add tests for opcode invariance and provenance metadata.
- Document decision in README constraint notes.

## Validation
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/test_schema_b524_constraints.py tests/test_scanner_scan.py`
- `./.venv/bin/ruff check src tests README.md`
- `./.venv/bin/mypy --strict src/helianthus_vrc_explorer/schema/b524_constraints.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/scanner/register.py`
- `PYTHONPATH=src ./.venv/bin/python scripts/validate_artifact.py fixtures/dual_namespace_scan.json`
- `PYTHONPATH=src ./.venv/bin/python scripts/validate_artifact.py fixtures/vrc720_full_scan.json`

Closes #198
