### PR TITLE
scanner: demote classic GG discovery to advisory metadata (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Transport note:
 - On shared live `ebusd-tcp` setups, the first B524 directory probe (`GG=0x00`) can transiently return a status-only `00`. The scanner treats this as transient noise and continues discovery instead of declaring B524 unsupported immediately.
 - On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received` now trigger a fixed 5-second quiet backoff before retry so the bus can settle.
 - On `ebusd-tcp`, `ERR: no signal` now triggers a fixed 15-second quiet backoff before retry so the eBUS side can recover instead of being polled aggressively.
-- Classic GG directory-probe results are retained as advisory metadata only. They are useful evidence for reverse-engineering and debugging, but they do not define semantic identity or namespace topology.
+- Classic GG directory-probe results are retained as advisory metadata for semantic identity and namespace topology. They are useful evidence for reverse-engineering and debugging, but they do not define those semantics once a group is a scan candidate. A `descriptor_type == 0.0` result is still used as a discovery-time negative hint for non-core/unknown groups in Phase A.
 
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Transport note:
 - On shared live `ebusd-tcp` setups, the first B524 directory probe (`GG=0x00`) can transiently return a status-only `00`. The scanner treats this as transient noise and continues discovery instead of declaring B524 unsupported immediately.
 - On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received` now trigger a fixed 5-second quiet backoff before retry so the bus can settle.
 - On `ebusd-tcp`, `ERR: no signal` now triggers a fixed 15-second quiet backoff before retry so the eBUS side can recover instead of being polled aggressively.
+- Classic GG directory-probe results are retained as advisory metadata only. They are useful evidence for reverse-engineering and debugging, but they do not define semantic identity or namespace topology.
 
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -123,21 +123,21 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "name": "Unknown 0x06",
         "ii_max": 0x0A,
         "rr_max": 0x0030,
-        "opcodes": [0x02, 0x06],
+        "opcodes": [0x06],
         "exhaustive_only": True,
     },
     0x07: {
         "name": "Unknown 0x07",
         "ii_max": 0x0A,
         "rr_max": 0x0030,
-        "opcodes": [0x02, 0x06],
+        "opcodes": [0x06],
         "exhaustive_only": True,
     },
     0x0B: {
         "name": "Unknown 0x0B",
         "ii_max": 0x0A,
         "rr_max": 0x0010,
-        "opcodes": [0x02, 0x06],
+        "opcodes": [0x06],
         "exhaustive_only": True,
     },
     0x0D: {
@@ -255,7 +255,7 @@ def discover_groups(
     """Phase A: Probe GG=0x00..0xFF via directory probe (opcode 0x00).
 
     Terminator logic: stop on the first NaN descriptor.
-    Descriptor `0.0` is a weak negative hint only: known core groups remain candidates.
+    Descriptor `0.0` is an advisory negative hint only: known core groups remain candidates.
     """
 
     discovered: list[DiscoveredGroup] = []
@@ -381,7 +381,7 @@ def discover_groups(
                     )
             elif observer is not None:
                 observer.log(
-                    f"GG=0x{gg:02X} descriptor=0.0, non-core group - skipped (weak hint)",
+                    f"GG=0x{gg:02X} descriptor=0.0, non-core group - skipped (advisory hint)",
                     level="info",
                 )
             continue
@@ -409,7 +409,7 @@ def classify_groups(
 ) -> list[ClassifiedGroup]:
     """Phase C (per issue wording): Map discovered groups using GROUP_CONFIG.
 
-    Descriptors are opaque hints, not structural authority.
+    Descriptors are advisory metadata only, not structural authority.
     """
 
     classified: list[ClassifiedGroup] = []

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -255,7 +255,9 @@ def discover_groups(
     """Phase A: Probe GG=0x00..0xFF via directory probe (opcode 0x00).
 
     Terminator logic: stop on the first NaN descriptor.
-    Descriptor `0.0` is an advisory negative hint only: known core groups remain candidates.
+    Directory descriptors are not semantic authority for group identity or namespace topology.
+    A descriptor of `0.0` is still used as a discovery-time negative hint for non-core groups,
+    while known core groups remain scan candidates.
     """
 
     discovered: list[DiscoveredGroup] = []
@@ -381,7 +383,9 @@ def discover_groups(
                     )
             elif observer is not None:
                 observer.log(
-                    f"GG=0x{gg:02X} descriptor=0.0, non-core group - skipped (advisory hint)",
+                    "GG=0x"
+                    f"{gg:02X} descriptor=0.0, non-core group - skipped "
+                    "(discovery-time hint only; not semantic authority)",
                     level="info",
                 )
             continue
@@ -409,7 +413,8 @@ def classify_groups(
 ) -> list[ClassifiedGroup]:
     """Phase C (per issue wording): Map discovered groups using GROUP_CONFIG.
 
-    Descriptors are advisory metadata only, not structural authority.
+    Descriptors are advisory metadata for semantic identity and namespace topology once a group
+    is a scan candidate; discovery-time filtering still happens earlier in Phase A.
     """
 
     classified: list[ClassifiedGroup] = []

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -157,6 +157,7 @@ def _ensure_group_artifact(
     name: str,
     descriptor_observed: float | None,
     dual_namespace: bool,
+    discovery_advisory: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     group_key = _hex_u8(group)
     default: dict[str, Any] = {
@@ -178,6 +179,8 @@ def _ensure_group_artifact(
     group_obj.setdefault("name", name)
     group_obj.setdefault("descriptor_observed", descriptor_observed)
     group_obj["dual_namespace"] = dual_namespace
+    if discovery_advisory is not None:
+        group_obj["discovery_advisory"] = discovery_advisory
     return cast(dict[str, Any], group_obj)
 
 
@@ -1132,12 +1135,24 @@ def scan_b524(
             # NaN descriptors come from synthetic exhaustive-mode injection;
             # store as None to keep JSON-serializable and avoid polluting analytics.
             desc_for_artifact = None if math.isnan(group.descriptor) else group.descriptor
+            discovery_advisory: dict[str, Any] = {
+                "kind": "directory_probe",
+                "semantic_authority": False,
+                "proven_register_opcodes": [_hex_u8(opcode) for opcode in opcodes],
+            }
+            if desc_for_artifact is not None:
+                discovery_advisory["descriptor_observed"] = desc_for_artifact
+            if group.expected_descriptor is not None:
+                discovery_advisory["descriptor_expected"] = group.expected_descriptor
+            if group.descriptor_mismatch:
+                discovery_advisory["descriptor_mismatch"] = True
             _ensure_group_artifact(
                 artifact,
                 group=group.group,
                 name=group.name,
                 descriptor_observed=desc_for_artifact,
                 dual_namespace=dual_namespace,
+                discovery_advisory=discovery_advisory,
             )
 
             if config is None:

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -86,7 +86,9 @@ def test_discover_groups_includes_core_with_zero_descriptor(tmp_path: Path) -> N
     assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
 
 
-def test_discover_groups_skips_non_core_known_with_zero_descriptor(tmp_path: Path) -> None:
+def test_discover_groups_uses_zero_descriptor_as_negative_hint_for_non_core_groups(
+    tmp_path: Path,
+) -> None:
     fixture_path = _write_directory_fixture(
         tmp_path,
         groups={
@@ -99,16 +101,20 @@ def test_discover_groups_skips_non_core_known_with_zero_descriptor(tmp_path: Pat
 
     discovered = discover_groups(transport, dst=0x15)
 
+    # Non-core groups still use a zero descriptor as a discovery-time negative hint.
     assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
     assert 0x09 in transport.probed_groups
 
 
-def test_discover_groups_skips_unknown_with_zero_descriptor(tmp_path: Path) -> None:
+def test_discover_groups_uses_zero_descriptor_as_negative_hint_for_unknown_groups(
+    tmp_path: Path,
+) -> None:
     fixture_path = _write_directory_fixture(tmp_path, groups={}, terminator_group=None)
     transport = RecordingTransport(DummyTransport(fixture_path))
 
     discovered = discover_groups(transport, dst=0x15)
 
+    # Unknown groups are still filtered by the directory probe in Phase A.
     assert [group.group for group in discovered] == [0x02, 0x03]
     assert transport.probed_groups[0] == 0x00
     assert transport.probed_groups[-1] == 0xFF

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -274,6 +274,9 @@ def test_group_config_completeness() -> None:
     assert GROUP_CONFIG[0x09]["rr_max_by_opcode"] == {0x02: 0x000F, 0x06: 0x0035}
     assert GROUP_CONFIG[0x0A]["rr_max"] == 0x004D
     assert GROUP_CONFIG[0x0A]["rr_max_by_opcode"] == {0x02: 0x004D, 0x06: 0x0035}
+    assert GROUP_CONFIG[0x06]["opcodes"] == [0x06]
+    assert GROUP_CONFIG[0x07]["opcodes"] == [0x06]
+    assert GROUP_CONFIG[0x0B]["opcodes"] == [0x06]
 
 
 def test_group_namespace_profiles_support_opcode_first_identity() -> None:

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -199,6 +199,9 @@ def test_opcodes_for_group_dual_namespace() -> None:
 def test_opcodes_for_group_single_namespace() -> None:
     assert opcodes_for_group(0x00) == [0x02]
     assert opcodes_for_group(0x0C) == [0x06]
+    assert opcodes_for_group(0x06) == [0x06]
+    assert opcodes_for_group(0x07) == [0x06]
+    assert opcodes_for_group(0x0B) == [0x06]
 
 
 def test_namespace_opcodes_for_group_supports_staged_remote_namespaces() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -680,6 +680,12 @@ def test_scan_instanced_group_zero_descriptor(tmp_path: Path) -> None:
     group = artifact["groups"]["0x02"]
     assert group["dual_namespace"] is False
     assert group["descriptor_observed"] == 0.0
+    assert group["discovery_advisory"]["kind"] == "directory_probe"
+    assert group["discovery_advisory"]["semantic_authority"] is False
+    assert group["discovery_advisory"]["descriptor_observed"] == 0.0
+    assert group["discovery_advisory"]["descriptor_expected"] == 1.0
+    assert group["discovery_advisory"]["descriptor_mismatch"] is True
+    assert group["discovery_advisory"]["proven_register_opcodes"] == ["0x02"]
     assert group["instances"]["0x00"]["present"] is True
     assert "0x01" not in group["instances"]
 
@@ -697,6 +703,12 @@ def test_scan_singleton_group_nonzero_descriptor(tmp_path: Path) -> None:
     group = artifact["groups"]["0x00"]
     assert group["dual_namespace"] is False
     assert group["descriptor_observed"] == 3.0
+    assert group["discovery_advisory"]["kind"] == "directory_probe"
+    assert group["discovery_advisory"]["semantic_authority"] is False
+    assert group["discovery_advisory"]["descriptor_observed"] == 3.0
+    assert group["discovery_advisory"]["descriptor_expected"] == 3.0
+    assert "descriptor_mismatch" not in group["discovery_advisory"]
+    assert group["discovery_advisory"]["proven_register_opcodes"] == ["0x02"]
     assert set(group["instances"]) == {"0x00"}
     assert artifact["meta"]["scan_plan"]["groups"]["0x00"]["instances"] == ["0x00"]
 


### PR DESCRIPTION
## What
Demote classic GG discovery and descriptor probing to advisory metadata only, and correct proven opcode sets for remote-only groups that should not keep legacy local assumptions.

## Why
Classic directory probe behavior is useful evidence, but it must not remain semantic authority. Legacy opcode assumptions can silently drive wrong planner and UI behavior after the namespace split.

## Acceptance Criteria
- [x] Directory probe outputs are explicitly labeled advisory and never treated as semantic authority.
- [x] Proven opcode sets for affected groups are corrected, including remote-only cases that should not keep `[0x02, 0x06]` as a standing assumption.
- [x] Code paths that used descriptor results as semantic identity are downgraded to metadata.
- [x] Unknown groups are not semantically promoted by descriptor defaults.

## Validation
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/test_scanner_director.py tests/test_scanner_register.py tests/test_scanner_scan.py`
- `./.venv/bin/ruff check src tests README.md`
- `./.venv/bin/mypy --strict src/helianthus_vrc_explorer/scanner/director.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/scanner/register.py`
- `PYTHONPATH=src ./.venv/bin/python scripts/validate_artifact.py fixtures/dual_namespace_scan.json`
- `PYTHONPATH=src ./.venv/bin/python scripts/validate_artifact.py fixtures/vrc720_full_scan.json`

## Issue
Closes #199
