### PR TITLE
b524: namespace-specific discovery and availability contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,9 +492,16 @@ def parse_b524_id(id_hex: str) -> dict:
 
 - **GG=0x02 (Heating Circuits):** Probe RR=0x0002 (CircuitType u16). Absent if response is 0x0000, 0xFFFF, or NaN.
 - **GG=0x03 (Zones):** Probe RR=0x001C (zone index u8). Absent if response is 0xFF.
-- **GG=0x08 (Buffer / Solar Cylinder 2):** Include it in documented group enumerations; local `0x02` stays singleton while remote `0x06` can be instanced.
-- **GG=0x09 / 0x0A (Radio Sensors VRC7xx / Radio Sensors VR92):** Present if RR=0x0007 or RR=0x000F returns non-NaN.
-- **GG=0x0C (Remote Accessories / FM5 Slots):** Present if any of RR in {0x0002, 0x0007, 0x000F, 0x0016} responds.
+- **GG=0x05 (Hot Water Cylinder):** Probe RR=0x0004 (EXP). Present if the decoded value is not null.
+- **GG=0x08 / opcode 0x06 (Buffer / Solar Cylinder 2 remote namespace):** Probe RR=0x0001 (`BOOL`). Present if `device_connected == true`.
+- **GG=0x09 / 0x0A / opcode 0x02 (local namespace):** Probe RR=0x0001 in the local namespace. Present if the read succeeds and is not `absent`.
+- **GG=0x09 / 0x0A / opcode 0x06 (remote namespace):** Probe RR=0x0001 (`BOOL`). Present if `device_connected == true`.
+- **GG=0x0C (Remote Accessories / FM5 Slots):** Probe RR=0x0001 (`BOOL`). Present if `device_connected == true`.
+
+**Shared vs independent namespace discovery:**
+
+- **GG=0x09 / 0x0A** use **independent namespace discovery**. Local (`0x02`) and remote (`0x06`) instance presence may diverge, so the scanner must not copy remote results into the local namespace.
+- Raw presence-probe evidence is retained in the artifact under `availability_probes`, and the contract used for each namespace is retained under `availability_contract`.
 
 **Instance discovery probes all slots from 0x00 to ii_max** (do not stop at gaps, they are legitimate holes). The default register scan then uses the discovered present set; only the `full` preset expands back to every slot.
 
@@ -1245,9 +1252,10 @@ Example: `./out/b524_scan_0x15_2026-02-06T194424Z.json`
 
 **Presence detection logic:**
 
-Presence is determined by group-specific heuristics in `src/helianthus_vrc_explorer/scanner/register.py`
-(function `is_instance_present`). It uses `tt_kind` + decoded values to avoid false positives
-(e.g. NaN or TT=00 "no data").
+Presence is determined by explicit namespace availability contracts in
+`src/helianthus_vrc_explorer/scanner/register.py` (function `probe_instance_availability`, with
+`is_instance_present` as the boolean wrapper). The scanner keeps the raw probe evidence in the
+artifact so later UI/report layers can inspect why a slot was considered present or absent.
 
 **Instance discovery probes ALL slots 0x00..ii_max** (do not stop at gaps, they are legitimate holes). The default register scan remains presence-aware; only the `full` preset expands back to every slot.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Transport note:
 - On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received` now trigger a fixed 5-second quiet backoff before retry so the bus can settle.
 - On `ebusd-tcp`, `ERR: no signal` now triggers a fixed 15-second quiet backoff before retry so the eBUS side can recover instead of being polled aggressively.
 - Classic GG directory-probe results are retained as advisory metadata for semantic identity and namespace topology. They are useful evidence for reverse-engineering and debugging, but they do not define those semantics once a group is a scan candidate. A `descriptor_type == 0.0` result is still used as a discovery-time negative hint for non-core/unknown groups in Phase A.
+- Instance availability is namespace-specific. Dual-namespace radio groups (`0x09`, `0x0A`) are discovered independently per opcode namespace instead of sharing remote results across local and remote.
+- Artifacts retain the availability contract plus raw per-slot probe evidence under `availability_contract` and `availability_probes`, including the opcode `0x06` `RR=0x0001` `device_connected` probe used for remote namespaces.
 
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-import math
-from typing import Final, NotRequired, TypedDict, cast
+from dataclasses import dataclass
+from typing import Final, Literal, NotRequired, TypedDict, cast
 
 from ..protocol.b524 import RegisterOpcode, build_register_read_payload
 from ..protocol.parser import ValueParseError, parse_typed_value
@@ -56,6 +56,23 @@ class RegisterEntry(TypedDict):
     value_display: NotRequired[str]
 
 
+@dataclass(frozen=True, slots=True)
+class NamespaceAvailabilityContract:
+    source: Literal["heuristic_probe", "always_present"]
+    namespace_relationship: Literal["single_namespace", "independent"]
+    probe_register: int | None
+    probe_type_hint: str | None
+    positive_when: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceAvailabilityProbe:
+    present: bool
+    contract: NamespaceAvailabilityContract
+    evidence: RegisterEntry | None
+
+
 def opcodes_for_group(group: int) -> list[RegisterOpcode]:
     """Return active B524 register opcode families for a group."""
 
@@ -77,6 +94,101 @@ def namespace_opcodes_for_group(group: int) -> list[RegisterOpcode]:
         return [0x02, 0x06]
     raw_opcodes = config.get("namespace_opcodes", config["opcodes"])
     return [cast(RegisterOpcode, opcode) for opcode in raw_opcodes]
+
+
+def _namespace_relationship(group: int) -> Literal["single_namespace", "independent"]:
+    return "independent" if len(opcodes_for_group(group)) > 1 else "single_namespace"
+
+
+def namespace_availability_contract(
+    *,
+    group: int,
+    opcode: RegisterOpcode,
+) -> NamespaceAvailabilityContract:
+    """Return the explicit availability contract for a namespace.
+
+    The contract documents whether presence is derived from a namespace-specific
+    probe or from a conscious always-present fallback.
+    """
+
+    relationship = _namespace_relationship(group)
+
+    if group == 0x02 and opcode == 0x02:
+        return NamespaceAvailabilityContract(
+            source="heuristic_probe",
+            namespace_relationship=relationship,
+            probe_register=0x0002,
+            probe_type_hint="UIN",
+            positive_when="value not in {0x0000, 0xFFFF}",
+            description="Heating circuit CircuitType must decode to a non-empty u16.",
+        )
+
+    if group == 0x03 and opcode == 0x02:
+        return NamespaceAvailabilityContract(
+            source="heuristic_probe",
+            namespace_relationship=relationship,
+            probe_register=0x001C,
+            probe_type_hint="UCH",
+            positive_when="value != 0xFF",
+            description="Zone index 0xFF marks an absent zone slot.",
+        )
+
+    if group == 0x05 and opcode == 0x02:
+        return NamespaceAvailabilityContract(
+            source="heuristic_probe",
+            namespace_relationship=relationship,
+            probe_register=0x0004,
+            probe_type_hint="EXP",
+            positive_when="decoded EXP value is not null",
+            description="Cylinder availability requires a decodable float payload.",
+        )
+
+    if group in {0x08, 0x09, 0x0A, 0x0C} and opcode == 0x06:
+        return NamespaceAvailabilityContract(
+            source="heuristic_probe",
+            namespace_relationship=relationship,
+            probe_register=0x0001,
+            probe_type_hint="BOOL",
+            positive_when="decoded BOOL value is true",
+            description="Remote namespace presence is derived from RR=0x0001 device-connected.",
+        )
+
+    if group in {0x09, 0x0A} and opcode == 0x02:
+        return NamespaceAvailabilityContract(
+            source="heuristic_probe",
+            namespace_relationship=relationship,
+            probe_register=0x0001,
+            probe_type_hint="UCH",
+            positive_when="register read succeeds and is not absent",
+            description="Local namespace presence is derived from a readable local slot register.",
+        )
+
+    if group in {0x06, 0x07, 0x0B, 0x0D, 0x0E, 0x0F, 0x10, 0x11}:
+        return NamespaceAvailabilityContract(
+            source="always_present",
+            namespace_relationship=relationship,
+            probe_register=None,
+            probe_type_hint=None,
+            positive_when="all configured slots are treated as present",
+            description=(
+                "Exploratory exhaustive group without a verified "
+                "namespace-specific heuristic."
+            ),
+        )
+
+    logger.debug(
+        "No explicit availability contract for GG=0x%02X OP=0x%02X; using always-present fallback",
+        group,
+        opcode,
+    )
+    return NamespaceAvailabilityContract(
+        source="always_present",
+        namespace_relationship=relationship,
+        probe_register=None,
+        probe_type_hint=None,
+        positive_when="all configured slots are treated as present",
+        description="Fallback contract for namespaces without a verified probe heuristic.",
+    )
 
 
 def _interpret_flags(flags: int, *, response_len: int) -> str:
@@ -355,6 +467,72 @@ def read_register(
     }
 
 
+def probe_instance_availability(
+    transport: TransportInterface,
+    dst: int,
+    group: int,
+    instance: int,
+    *,
+    opcode: RegisterOpcode | None = None,
+) -> InstanceAvailabilityProbe:
+    """Probe one instance slot and retain the evidence used for presence."""
+
+    if opcode is None:
+        opcode = opcodes_for_group(group)[0]
+
+    contract = namespace_availability_contract(group=group, opcode=opcode)
+    if contract.source == "always_present":
+        return InstanceAvailabilityProbe(present=True, contract=contract, evidence=None)
+
+    assert contract.probe_register is not None
+    entry = read_register(
+        transport,
+        dst,
+        opcode,
+        group=group,
+        instance=instance,
+        register=contract.probe_register,
+        type_hint=contract.probe_type_hint,
+    )
+
+    present = False
+
+    if group == 0x02 and opcode == 0x02:
+        if entry["error"] is None and entry.get("flags_access") != "absent":
+            value = entry["value"]
+            present = isinstance(value, int) and not isinstance(value, bool) and value not in {
+                0x0000,
+                0xFFFF,
+            }
+        return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
+
+    if group == 0x03 and opcode == 0x02:
+        if entry["error"] is None and entry.get("flags_access") != "absent":
+            value = entry["value"]
+            present = isinstance(value, int) and not isinstance(value, bool) and value != 0xFF
+        return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
+
+    if group == 0x05 and opcode == 0x02:
+        present = entry["error"] is None and entry.get("flags_access") != "absent" and entry[
+            "value"
+        ] is not None
+        return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
+
+    if group in {0x08, 0x09, 0x0A, 0x0C} and opcode == 0x06:
+        present = (
+            entry["error"] is None
+            and entry.get("flags_access") != "absent"
+            and entry["value"] is True
+        )
+        return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
+
+    if group in {0x09, 0x0A} and opcode == 0x02:
+        present = entry["error"] is None and entry.get("flags_access") != "absent"
+        return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
+
+    return InstanceAvailabilityProbe(present=True, contract=contract, evidence=entry)
+
+
 def is_instance_present(
     transport: TransportInterface,
     dst: int,
@@ -367,107 +545,10 @@ def is_instance_present(
 
     Source of truth: `AGENTS.md` (keep in sync).
     """
-
-    if opcode is None:
-        opcode = opcodes_for_group(group)[0]
-
-    if group == 0x02:
-        entry = read_register(
-            transport, dst, opcode, group=group, instance=instance, register=0x0002, type_hint="UIN"
-        )
-        if entry["error"] is not None:
-            return False
-        if entry.get("flags_access") == "absent":
-            return False
-        value = entry["value"]
-        if value is None:
-            return False
-        if not isinstance(value, int) or isinstance(value, bool):
-            return False
-        return value not in {0x0000, 0xFFFF}
-
-    if group == 0x03:
-        entry = read_register(
-            transport, dst, opcode, group=group, instance=instance, register=0x001C, type_hint="UCH"
-        )
-        if entry["error"] is not None:
-            return False
-        if entry.get("flags_access") == "absent":
-            return False
-        value = entry["value"]
-        if not isinstance(value, int) or isinstance(value, bool):
-            return False
-        return value != 0xFF
-
-    if group == 0x05:
-        entry = read_register(
-            transport,
-            dst,
-            opcode,
-            group=group,
-            instance=instance,
-            register=0x0004,
-            type_hint="EXP",
-        )
-        if entry["error"] is not None:
-            return False
-        if entry.get("flags_access") == "absent":
-            return False
-        return entry["value"] is not None
-
-    if group == 0x08:
-        entry = read_register(
-            transport,
-            dst,
-            opcode,
-            group=group,
-            instance=instance,
-            register=0x0001,
-        )
-        if entry["error"] is not None:
-            return False
-        return entry.get("flags_access") != "absent"
-
-    if group in {0x09, 0x0A}:
-        entry_1 = read_register(
-            transport, dst, 0x06, group=group, instance=instance, register=0x0007, type_hint="EXP"
-        )
-        value_1 = entry_1["value"]
-        if (
-            entry_1["error"] is None
-            and entry_1.get("flags_access") != "absent"
-            and value_1 is not None
-            and not (isinstance(value_1, float) and math.isnan(value_1))
-        ):
-            return True
-        entry_2 = read_register(
-            transport, dst, 0x06, group=group, instance=instance, register=0x000F, type_hint="EXP"
-        )
-        value_2 = entry_2["value"]
-        return (
-            entry_2["error"] is None
-            and entry_2.get("flags_access") != "absent"
-            and value_2 is not None
-            and not (isinstance(value_2, float) and math.isnan(value_2))
-        )
-
-    if group == 0x0C:
-        entry = read_register(
-            transport,
-            dst,
-            0x06,
-            group=group,
-            instance=instance,
-            register=0x0001,
-            type_hint="BOOL",
-        )
-        if entry["error"] is not None:
-            return False
-        if entry.get("flags_access") == "absent":
-            return False
-        return entry["value"] is True
-
-    logger.debug(
-        "No presence heuristic for GG=0x%02X; assuming present for II=0x%02X", group, instance
-    )
-    return True
+    return probe_instance_availability(
+        transport,
+        dst=dst,
+        group=group,
+        instance=instance,
+        opcode=opcode,
+    ).present

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -171,8 +171,7 @@ def namespace_availability_contract(
             probe_type_hint=None,
             positive_when="all configured slots are treated as present",
             description=(
-                "Exploratory exhaustive group without a verified "
-                "namespace-specific heuristic."
+                "Exploratory exhaustive group without a verified namespace-specific heuristic."
             ),
         )
 
@@ -500,10 +499,15 @@ def probe_instance_availability(
     if group == 0x02 and opcode == 0x02:
         if entry["error"] is None and entry.get("flags_access") != "absent":
             value = entry["value"]
-            present = isinstance(value, int) and not isinstance(value, bool) and value not in {
-                0x0000,
-                0xFFFF,
-            }
+            present = (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value
+                not in {
+                    0x0000,
+                    0xFFFF,
+                }
+            )
         return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
 
     if group == 0x03 and opcode == 0x02:
@@ -513,9 +517,11 @@ def probe_instance_availability(
         return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
 
     if group == 0x05 and opcode == 0x02:
-        present = entry["error"] is None and entry.get("flags_access") != "absent" and entry[
-            "value"
-        ] is not None
+        present = (
+            entry["error"] is None
+            and entry.get("flags_access") != "absent"
+            and entry["value"] is not None
+        )
         return InstanceAvailabilityProbe(present=present, contract=contract, evidence=entry)
 
     if group in {0x08, 0x09, 0x0A, 0x0C} and opcode == 0x06:

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -48,7 +48,15 @@ from .plan import (
     estimate_register_requests,
     make_plan_key,
 )
-from .register import RegisterEntry, is_instance_present, opcodes_for_group, read_register
+from .register import (
+    InstanceAvailabilityProbe,
+    NamespaceAvailabilityContract,
+    RegisterEntry,
+    namespace_availability_contract,
+    opcodes_for_group,
+    probe_instance_availability,
+    read_register,
+)
 
 
 def _hex_u8(value: int) -> str:
@@ -125,6 +133,31 @@ def _ii_max_for_opcode(*, group: int, default_ii_max: int | None, opcode: int) -
 
 def _plan_key(group: int, opcode: int) -> PlanKey:
     return make_plan_key(group, opcode)
+
+
+def _instance_discovery_decision(*, group: int, dual_namespace: bool) -> dict[str, Any]:
+    if not dual_namespace:
+        return {
+            "strategy": "single_namespace",
+            "decision": "independent_per_namespace",
+            "tradeoff": "not_applicable",
+        }
+
+    if group in {0x09, 0x0A}:
+        return {
+            "strategy": "dual_namespace",
+            "decision": "independent_per_namespace",
+            "tradeoff": (
+                "extra presence probes accepted to avoid cross-namespace false-equivalence "
+                "assumptions"
+            ),
+        }
+
+    return {
+        "strategy": "dual_namespace",
+        "decision": "independent_per_namespace",
+        "tradeoff": "independent probing is authoritative over shared inference",
+    }
 
 
 def _scan_plan_meta_groups(plan: dict[PlanKey, GroupScanPlan]) -> dict[str, object]:
@@ -210,6 +243,72 @@ def _instances_object(
         namespace_obj = _ensure_namespace_artifact(group_obj, opcode=opcode)
         return cast(dict[str, Any], namespace_obj.setdefault("instances", {}))
     return cast(dict[str, Any], group_obj.setdefault("instances", {}))
+
+
+def _availability_object(
+    artifact: dict[str, Any],
+    *,
+    group: int,
+    opcode: int,
+) -> dict[str, Any]:
+    group_obj = artifact["groups"][_hex_u8(group)]
+    if bool(group_obj.get("dual_namespace")):
+        return _ensure_namespace_artifact(group_obj, opcode=opcode)
+    return cast(dict[str, Any], group_obj)
+
+
+def _serialize_availability_contract(
+    contract: NamespaceAvailabilityContract,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "source": contract.source,
+        "namespace_relationship": contract.namespace_relationship,
+        "positive_when": contract.positive_when,
+        "description": contract.description,
+    }
+    if contract.probe_register is not None:
+        payload["probe_register"] = _hex_u16(contract.probe_register)
+    if contract.probe_type_hint is not None:
+        payload["probe_type_hint"] = contract.probe_type_hint
+    return payload
+
+
+def _serialize_availability_probe(
+    probe: InstanceAvailabilityProbe,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "present": probe.present,
+        "source": probe.contract.source,
+    }
+    evidence = probe.evidence
+    if evidence is not None:
+        payload.update(dict(evidence))
+    return payload
+
+
+def _record_availability_contract(
+    artifact: dict[str, Any],
+    *,
+    group: int,
+    opcode: int,
+    contract: NamespaceAvailabilityContract,
+) -> None:
+    target = _availability_object(artifact, group=group, opcode=opcode)
+    target["availability_contract"] = _serialize_availability_contract(contract)
+    target.setdefault("availability_probes", {})
+
+
+def _record_availability_probes(
+    artifact: dict[str, Any],
+    *,
+    group: int,
+    opcode: int,
+    probes: Mapping[int, InstanceAvailabilityProbe],
+) -> None:
+    target = _availability_object(artifact, group=group, opcode=opcode)
+    probe_map = cast(dict[str, Any], target.setdefault("availability_probes", {}))
+    for instance, probe in sorted(probes.items()):
+        probe_map[_hex_u8(instance)] = _serialize_availability_probe(probe)
 
 
 def _present_instances_for_opcode(
@@ -299,23 +398,22 @@ def _probe_present_instances(
     opcode: RegisterOpcode,
     ii_max: int,
     observer: ScanObserver | None,
-) -> tuple[int, ...]:
-    present_instances: list[int] = []
+) -> dict[int, InstanceAvailabilityProbe]:
+    probes: dict[int, InstanceAvailabilityProbe] = {}
     for ii in range(0x00, ii_max + 1):
         if observer is not None:
             observer.status(f"Probe presence GG=0x{group:02X} OP={_hex_u8(opcode)} II=0x{ii:02X}")
-        is_present = is_instance_present(
+        probe = probe_instance_availability(
             transport,
             dst=dst,
             group=group,
             instance=ii,
             opcode=opcode,
         )
-        if is_present:
-            present_instances.append(ii)
+        probes[ii] = probe
         if observer is not None:
             observer.phase_advance("instance_discovery", advance=1)
-    return tuple(present_instances)
+    return probes
 
 
 @dataclass(frozen=True, slots=True)
@@ -1101,17 +1199,6 @@ def scan_b524(
                     _group_opcodes(group.group)
                 )
                 continue
-            if group.group in {0x09, 0x0A}:
-                shared_present: tuple[int, ...]
-                shared_ii_max = _ii_max_for_opcode(
-                    group=group.group,
-                    default_ii_max=meta.ii_max,
-                    opcode=_REMOTE_REGISTER_OPCODE,
-                )
-                if _is_instanced_group(shared_ii_max):
-                    assert shared_ii_max is not None
-                    instance_total += shared_ii_max + 1
-                continue
             for opcode in _group_opcodes(group.group):
                 namespace_ii_max = _ii_max_for_opcode(
                     group=group.group,
@@ -1140,6 +1227,10 @@ def scan_b524(
                 "semantic_authority": False,
                 "proven_register_opcodes": [_hex_u8(opcode) for opcode in opcodes],
             }
+            discovery_advisory["instance_discovery_decision"] = _instance_discovery_decision(
+                group=group.group,
+                dual_namespace=dual_namespace,
+            )
             if desc_for_artifact is not None:
                 discovery_advisory["descriptor_observed"] = desc_for_artifact
             if group.expected_descriptor is not None:
@@ -1186,43 +1277,6 @@ def scan_b524(
                     )
                 continue
 
-            if group.group in {0x09, 0x0A}:
-                shared_ii_max = _ii_max_for_opcode(
-                    group=group.group,
-                    default_ii_max=meta.ii_max,
-                    opcode=_REMOTE_REGISTER_OPCODE,
-                )
-                if not _is_instanced_group(shared_ii_max):
-                    shared_present = (0x00,)
-                else:
-                    assert shared_ii_max is not None
-                    emit_trace_label(
-                        transport,
-                        "Identifying instances in group "
-                        f"0x{group.group:02X} via shared remote probe",
-                    )
-                    shared_present = _probe_present_instances(
-                        transport,
-                        dst=dst,
-                        group=group.group,
-                        opcode=_REMOTE_REGISTER_OPCODE,
-                        ii_max=shared_ii_max,
-                        observer=observer,
-                    )
-                for opcode in opcodes:
-                    instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
-                    _mark_present_instances(instances_obj, instances=shared_present)
-                if observer is not None:
-                    total_instances = 1 if shared_ii_max is None else shared_ii_max + 1
-                    observer.log(
-                        f"GG=0x{group.group:02X} {group.name}: "
-                        f"{len(shared_present)}/{total_instances} present "
-                        f"(shared across local/remote), "
-                        f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
-                        level="info",
-                    )
-                continue
-
             known_namespace_probe_counts: list[str] = []
             for opcode in opcodes:
                 namespace_ii_max = _ii_max_for_opcode(
@@ -1230,7 +1284,15 @@ def scan_b524(
                     default_ii_max=meta.ii_max,
                     opcode=opcode,
                 )
+                contract = namespace_availability_contract(group=group.group, opcode=opcode)
                 instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
+                if _is_instanced_group(namespace_ii_max):
+                    _record_availability_contract(
+                        artifact,
+                        group=group.group,
+                        opcode=opcode,
+                        contract=contract,
+                    )
                 if not _is_instanced_group(namespace_ii_max):
                     _mark_present_instances(instances_obj, instances=(0x00,))
                     known_namespace_probe_counts.append(f"{opcode_label(opcode)} 1/1")
@@ -1241,7 +1303,7 @@ def scan_b524(
                     transport,
                     f"Identifying instances in group 0x{group.group:02X} ({opcode_label(opcode)})",
                 )
-                present_instances = _probe_present_instances(
+                probes = _probe_present_instances(
                     transport,
                     dst=dst,
                     group=group.group,
@@ -1249,6 +1311,13 @@ def scan_b524(
                     ii_max=namespace_ii_max,
                     observer=observer,
                 )
+                _record_availability_probes(
+                    artifact,
+                    group=group.group,
+                    opcode=opcode,
+                    probes=probes,
+                )
+                present_instances = tuple(ii for ii, probe in probes.items() if probe.present)
                 _mark_present_instances(instances_obj, instances=present_instances)
                 known_namespace_probe_counts.append(
                     f"{opcode_label(opcode)} {len(present_instances)}/{namespace_ii_max + 1}"

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -8,6 +8,7 @@ from helianthus_vrc_explorer.scanner.register import (
     is_instance_present,
     namespace_opcodes_for_group,
     opcodes_for_group,
+    probe_instance_availability,
     read_register,
 )
 from helianthus_vrc_explorer.transport.base import (
@@ -307,8 +308,8 @@ def test_instance_present_buffer(monkeypatch: pytest.MonkeyPatch) -> None:
         calls.append((int(opcode), int(kwargs["group"]), int(kwargs["register"])))
         return {
             "raw_hex": "01",
-            "type": "UCH",
-            "value": 1,
+            "type": "BOOL",
+            "value": True,
             "error": None,
             "flags_access": "stable_ro",
         }
@@ -328,7 +329,9 @@ def test_instance_present_buffer(monkeypatch: pytest.MonkeyPatch) -> None:
     assert calls == [(0x06, 0x08, 0x0001)]
 
 
-def test_is_instance_present_group_09_rejects_nan_values(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_is_instance_present_group_09_remote_requires_device_connected_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import helianthus_vrc_explorer.scanner.register as register
 
     calls: list[int] = []
@@ -336,10 +339,11 @@ def test_is_instance_present_group_09_rejects_nan_values(monkeypatch: pytest.Mon
     def _fake_read_register(*_args, **kwargs):  # type: ignore[no-untyped-def]
         calls.append(int(kwargs["register"]))
         return {
-            "raw_hex": "00000000",
-            "type": "EXP",
-            "value": float("nan"),
+            "raw_hex": "00",
+            "type": "BOOL",
+            "value": False,
             "error": None,
+            "flags_access": "stable_ro",
         }
 
     monkeypatch.setattr(register, "read_register", _fake_read_register)
@@ -350,25 +354,25 @@ def test_is_instance_present_group_09_rejects_nan_values(monkeypatch: pytest.Mon
             dst=0x15,
             group=0x09,
             instance=0x00,
+            opcode=0x06,
         )
         is False
     )
-    assert calls == [0x0007, 0x000F]
+    assert calls == [0x0001]
 
 
-def test_is_instance_present_group_09_accepts_non_nan_values(
+def test_is_instance_present_group_09_remote_accepts_device_connected_true(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import helianthus_vrc_explorer.scanner.register as register
 
-    values = iter([float("nan"), 1.0])
-
-    def _fake_read_register(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+    def _fake_read_register(*_args, **kwargs):  # type: ignore[no-untyped-def]
         return {
-            "raw_hex": "00000000",
-            "type": "EXP",
-            "value": next(values),
+            "raw_hex": "01",
+            "type": "BOOL",
+            "value": True,
             "error": None,
+            "flags_access": "stable_ro",
         }
 
     monkeypatch.setattr(register, "read_register", _fake_read_register)
@@ -379,9 +383,71 @@ def test_is_instance_present_group_09_accepts_non_nan_values(
             dst=0x15,
             group=0x09,
             instance=0x00,
+            opcode=0x06,
         )
         is True
     )
+
+
+def test_probe_instance_availability_group_09_local_uses_rr_0001(monkeypatch) -> None:
+    import helianthus_vrc_explorer.scanner.register as register
+
+    calls: list[tuple[int, int]] = []
+
+    def _fake_read_register(_transport, _dst, opcode, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append((int(opcode), int(kwargs["register"])))
+        return {
+            "raw_hex": "34",
+            "type": "UCH",
+            "value": 0x34,
+            "error": None,
+            "flags_access": "stable_ro",
+        }
+
+    monkeypatch.setattr(register, "read_register", _fake_read_register)
+
+    probe = probe_instance_availability(
+        _StatusOnlyTransport(),
+        dst=0x15,
+        group=0x09,
+        instance=0x02,
+        opcode=0x02,
+    )
+
+    assert probe.present is True
+    assert probe.contract.probe_register == 0x0001
+    assert calls == [(0x02, 0x0001)]
+
+
+def test_probe_instance_availability_group_09_remote_uses_rr_0001_bool_probe(monkeypatch) -> None:
+    import helianthus_vrc_explorer.scanner.register as register
+
+    calls: list[tuple[int, int, str | None]] = []
+
+    def _fake_read_register(_transport, _dst, opcode, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append((int(opcode), int(kwargs["register"]), kwargs.get("type_hint")))
+        return {
+            "raw_hex": "01",
+            "type": "BOOL",
+            "value": True,
+            "error": None,
+            "flags_access": "stable_ro",
+        }
+
+    monkeypatch.setattr(register, "read_register", _fake_read_register)
+
+    probe = probe_instance_availability(
+        _StatusOnlyTransport(),
+        dst=0x15,
+        group=0x09,
+        instance=0x01,
+        opcode=0x06,
+    )
+
+    assert probe.present is True
+    assert probe.contract.probe_register == 0x0001
+    assert probe.contract.probe_type_hint == "BOOL"
+    assert calls == [(0x06, 0x0001, "BOOL")]
 
 
 def test_fw_not_added_to_inferred_type_selection() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -210,17 +210,67 @@ def _write_fixture_group_09(tmp_path: Path) -> Path:
         "groups": {
             "0x09": {
                 "descriptor_type": 1.0,
-                "instances": {
-                    "0x00": {
-                        "registers": {
-                            "0x0000": {"raw_hex": "00"},
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                    "0x0001": {"raw_hex": "34"},
+                                }
+                            }
                         }
-                    }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                    "0x0001": {"raw_hex": "01"},
+                                }
+                            }
+                        }
+                    },
                 },
             }
         },
     }
     path = tmp_path / "fixture_group_09.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
+def _write_fixture_group_09_presence_divergence(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x0a"}},
+        "groups": {
+            "0x09": {
+                "descriptor_type": 1.0,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                    "0x0001": {"raw_hex": "34"},
+                                }
+                            }
+                        }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {"raw_hex": "00"},
+                                }
+                            }
+                        }
+                    },
+                },
+            }
+        },
+    }
+    path = tmp_path / "fixture_group_09_presence_divergence.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
     return path
 
@@ -729,9 +779,6 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
 
     transport = RecordingTransport(DummyTransport(_write_fixture_group_09(tmp_path)))
 
-    def fake_is_instance_present(*_args, **kwargs):  # type: ignore[no-untyped-def]
-        return kwargs["instance"] == 0x00
-
     def fake_prompt_scan_plan(*_args, **_kwargs):
         return {
             make_plan_key(0x09, 0x02): GroupScanPlan(
@@ -748,7 +795,6 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
             ),
         }
 
-    monkeypatch.setattr(scan_mod, "is_instance_present", fake_is_instance_present)
     monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
@@ -769,6 +815,15 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     remote_ns = group["namespaces"]["0x06"]
     assert local_ns["label"] == "local"
     assert remote_ns["label"] == "remote"
+    assert (
+        group["discovery_advisory"]["instance_discovery_decision"]["decision"]
+        == "independent_per_namespace"
+    )
+    assert local_ns["availability_contract"]["namespace_relationship"] == "independent"
+    assert local_ns["availability_contract"]["probe_register"] == "0x0001"
+    assert remote_ns["availability_contract"]["probe_register"] == "0x0001"
+    assert local_ns["availability_probes"]["0x00"]["raw_hex"] == "34"
+    assert remote_ns["availability_probes"]["0x00"]["raw_hex"] == "01"
     assert local_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode"] == "0x02"
     assert local_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode_label"] == "local"
     assert remote_ns["instances"]["0x00"]["registers"]["0x0000"]["read_opcode"] == "0x06"
@@ -781,9 +836,66 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     scanned_opcodes = {
         opcode
         for (opcode, gg, ii, rr) in transport.register_reads
-        if gg == 0x09 and ii == 0x00 and rr == 0x0000
+        if gg == 0x09 and ii == 0x00 and rr in {0x0000, 0x0001}
     }
     assert scanned_opcodes == {0x02, 0x06}
+
+
+def test_dual_namespace_presence_is_independent_and_retains_raw_probe_evidence(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    transport = RecordingTransport(
+        DummyTransport(_write_fixture_group_09_presence_divergence(tmp_path))
+    )
+
+    def fake_prompt_scan_plan(*_args, **_kwargs):
+        return {
+            make_plan_key(0x09, 0x02): GroupScanPlan(
+                group=0x09,
+                opcode=0x02,
+                rr_max=0x0000,
+                instances=(0x00,),
+            ),
+            make_plan_key(0x09, 0x06): GroupScanPlan(
+                group=0x09,
+                opcode=0x06,
+                rr_max=0x0000,
+                instances=(),
+            ),
+        }
+
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+    )
+
+    local_ns = artifact["groups"]["0x09"]["namespaces"]["0x02"]
+    remote_ns = artifact["groups"]["0x09"]["namespaces"]["0x06"]
+
+    assert local_ns["availability_contract"]["namespace_relationship"] == "independent"
+    assert remote_ns["availability_contract"]["namespace_relationship"] == "independent"
+    assert local_ns["availability_probes"]["0x00"]["present"] is True
+    assert local_ns["availability_probes"]["0x00"]["raw_hex"] == "34"
+    assert remote_ns["availability_probes"]["0x00"]["present"] is False
+    assert remote_ns["availability_probes"]["0x00"]["reply_hex"] == "0109010000"
+    assert remote_ns["availability_probes"]["0x00"]["type"] == "BOOL"
+    assert set(local_ns["instances"]) == {"0x00"}
+    assert remote_ns["instances"] == {}
+    remote_reads = {
+        rr for (opcode, gg, _ii, rr) in transport.register_reads if opcode == 0x06 and gg == 0x09
+    }
+    assert remote_reads == {0x0001}
 
 
 def test_artifact_single_namespace_unchanged(tmp_path: Path) -> None:
@@ -871,10 +983,15 @@ def test_type_hint_propagation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "groups": {
             "0x09": {
                 "descriptor_type": 1.0,
-                "instances": {
-                    "0x00": {
-                        "registers": {
-                            "0x0004": {"raw_hex": "021703"},
+                "namespaces": {
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {"raw_hex": "01"},
+                                    "0x0004": {"raw_hex": "021703"},
+                                }
+                            }
                         }
                     }
                 },
@@ -907,7 +1024,6 @@ def test_type_hint_propagation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         }
 
     monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
-    monkeypatch.setattr(scan_mod, "is_instance_present", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
     artifact = scan_b524(
@@ -936,6 +1052,10 @@ def test_scan_b524_replays_dual_namespace_fixture_end_to_end(
 
     import helianthus_vrc_explorer.scanner.scan as scan_mod
     from helianthus_vrc_explorer.scanner.director import DiscoveredGroup
+    from helianthus_vrc_explorer.scanner.register import (
+        InstanceAvailabilityProbe,
+        namespace_availability_contract,
+    )
     from helianthus_vrc_explorer.schema.myvaillant_map import MyvaillantRegisterMap
 
     transport = RecordingTransport(DummyTransport(dual_namespace_scan_path))
@@ -980,11 +1100,20 @@ def test_scan_b524_replays_dual_namespace_fixture_end_to_end(
     )
     monkeypatch.setattr(
         scan_mod,
-        "is_instance_present",
+        "probe_instance_availability",
         lambda *_args, **kwargs: (
-            kwargs["instance"] in {0x00, 0x01}
-            if kwargs["group"] == 0x09
-            else (kwargs["group"] == 0x0C and kwargs["instance"] == 0x00)
+            InstanceAvailabilityProbe(
+                present=(
+                    kwargs["instance"] in {0x00, 0x01}
+                    if kwargs["group"] == 0x09
+                    else (kwargs["group"] == 0x0C and kwargs["instance"] == 0x00)
+                ),
+                contract=namespace_availability_contract(
+                    group=kwargs["group"],
+                    opcode=kwargs["opcode"],
+                ),
+                evidence=None,
+            )
         ),
     )
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -1101,19 +1101,17 @@ def test_scan_b524_replays_dual_namespace_fixture_end_to_end(
     monkeypatch.setattr(
         scan_mod,
         "probe_instance_availability",
-        lambda *_args, **kwargs: (
-            InstanceAvailabilityProbe(
-                present=(
-                    kwargs["instance"] in {0x00, 0x01}
-                    if kwargs["group"] == 0x09
-                    else (kwargs["group"] == 0x0C and kwargs["instance"] == 0x00)
-                ),
-                contract=namespace_availability_contract(
-                    group=kwargs["group"],
-                    opcode=kwargs["opcode"],
-                ),
-                evidence=None,
-            )
+        lambda *_args, **kwargs: InstanceAvailabilityProbe(
+            present=(
+                kwargs["instance"] in {0x00, 0x01}
+                if kwargs["group"] == 0x09
+                else (kwargs["group"] == 0x0C and kwargs["instance"] == 0x00)
+            ),
+            contract=namespace_availability_contract(
+                group=kwargs["group"],
+                opcode=kwargs["opcode"],
+            ),
+            evidence=None,
         ),
     )
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)


### PR DESCRIPTION
## What\n- switch B524 instance discovery to namespace-specific probing (no shared local/remote presence inference)\n- persist namespace availability contracts and per-instance probe evidence into artifacts\n- retain raw opcode=0x06 RR=0x0001 presence evidence for later UI/report inspection\n- add discovery advisory metadata that records the shared-vs-independent decision and trade-off\n\n## Validation\n- PYTHONPATH=src .venv/bin/ruff check src/helianthus_vrc_explorer/scanner/scan.py tests/test_scanner_register.py tests/test_scanner_scan.py\n- PYTHONPATH=src .venv/bin/pytest -q tests/test_scanner_register.py tests/test_scanner_scan.py\n\nCloses #200