### PR TITLE
Issue #202: namespace-owned RR enrichment registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ device writes are planned.
 This tool can enrich raw scan output with human-readable names:
 - **myVaillant map** (`--myvaillant-map-path`): a small curated CSV mapping `(GG,II,RR)` to myVaillant-style leaf names.
   - Default: bundled in this repo as `data/myvaillant_register_map.csv` (also packaged under `src/helianthus_vrc_explorer/data/`).
+  - Opcode-aware namespace policy: `0x06` mappings must be explicit; generic opcode-less fallback rows are local `0x02` defaults only.
 - **eBUSd CSV schema** (`--ebusd-csv-path`): adds register names from an eBUSd configuration CSV (e.g. `15.720.csv`).
   - Source: typically taken from an `ebusd-configuration` checkout (not bundled here).
 

--- a/data/myvaillant_register_map.csv
+++ b/data/myvaillant_register_map.csv
@@ -36,6 +36,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x003E,environmental_yield_total,YieldTotal,state,U32,
 0x00,0x00,0x0045,esco_block_function,,config,,
 0x00,0x00,0x0046,hwc_max_flow_temp_desired,HwcMaxFlowTempDesired,config,,
+0x00,0x00,0x0048,unknown_0048,,state,UIN,0x02
 0x00,0x00,0x004B,system_flow_temperature,FlowTemp,,,
 0x00,0x00,0x004D,multi_relay_setting,MultiRelaySetting,config,,
 0x00,0x00,0x004E,fuel_consumption_heating_this_month,PrFuelSumHcThisMonth,state,U32,
@@ -79,6 +80,8 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x00CA,fuel_heating_last_month_mirror,,state,U32,
 0x00,0x00,0x00CB,gas_total_combined,,state,U32,
 0x00,0x00,0x00CD,gas_total_combined_dup,,state,U32,
+0x00,0x00,0x00DA,unknown_00da_date,,config,HDA:3,0x02
+0x00,0x00,0x00DB,unknown_00db_date,,config,HDA:3,0x02
 0x00,0x00,0x00DD,heating_curve_day_1,,config,,
 0x00,0x00,0x00DE,heating_curve_day_2,,config,,
 0x00,0x00,0x00DF,heating_curve_day_3,,config,,
@@ -97,6 +100,8 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x01,0x00,0x000F,hwc_status,,state,,
 0x01,0x00,0x0010,hwc_holiday_start_time,,config,HTI,
 0x01,0x00,0x0011,hwc_holiday_end_time,,config,HTI,
+0x01,0x00,0x0012,device_status,,state,UCH,0x06
+0x01,0x00,0x0015,unknown_0015,,state,UIN,0x06
 0x02,*,0x0001,heating_circuit_type,Hc{hc}CircuitType,,,
 0x02,*,0x0002,mixer_circuit_type_external,Hc{hc}CircuitType,,,
 0x02,*,0x0003,room_influence_type,Hc{hc}RoomInfluenceType,config,,
@@ -229,3 +234,4 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x0C,*,0x0003,device_error_code,,state,,0x06
 0x0C,*,0x0004,device_firmware_version,,state,FW,0x06
 0x0C,*,0x0012,device_status,,state,,0x06
+*,*,0x0001,device_connected,,state,BOOL,0x06

--- a/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
+++ b/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
@@ -36,6 +36,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x003E,environmental_yield_total,YieldTotal,state,U32,
 0x00,0x00,0x0045,esco_block_function,,config,,
 0x00,0x00,0x0046,hwc_max_flow_temp_desired,HwcMaxFlowTempDesired,config,,
+0x00,0x00,0x0048,unknown_0048,,state,UIN,0x02
 0x00,0x00,0x004B,system_flow_temperature,FlowTemp,,,
 0x00,0x00,0x004D,multi_relay_setting,MultiRelaySetting,config,,
 0x00,0x00,0x004E,fuel_consumption_heating_this_month,PrFuelSumHcThisMonth,state,U32,
@@ -79,6 +80,8 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x00CA,fuel_heating_last_month_mirror,,state,U32,
 0x00,0x00,0x00CB,gas_total_combined,,state,U32,
 0x00,0x00,0x00CD,gas_total_combined_dup,,state,U32,
+0x00,0x00,0x00DA,unknown_00da_date,,config,HDA:3,0x02
+0x00,0x00,0x00DB,unknown_00db_date,,config,HDA:3,0x02
 0x00,0x00,0x00DD,heating_curve_day_1,,config,,
 0x00,0x00,0x00DE,heating_curve_day_2,,config,,
 0x00,0x00,0x00DF,heating_curve_day_3,,config,,
@@ -97,6 +100,8 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x01,0x00,0x000F,hwc_status,,state,,
 0x01,0x00,0x0010,hwc_holiday_start_time,,config,HTI,
 0x01,0x00,0x0011,hwc_holiday_end_time,,config,HTI,
+0x01,0x00,0x0012,device_status,,state,UCH,0x06
+0x01,0x00,0x0015,unknown_0015,,state,UIN,0x06
 0x02,*,0x0001,heating_circuit_type,Hc{hc}CircuitType,,,
 0x02,*,0x0002,mixer_circuit_type_external,Hc{hc}CircuitType,,,
 0x02,*,0x0003,room_influence_type,Hc{hc}RoomInfluenceType,config,,
@@ -229,3 +234,4 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x0C,*,0x0003,device_error_code,,state,,0x06
 0x0C,*,0x0004,device_firmware_version,,state,FW,0x06
 0x0C,*,0x0012,device_status,,state,,0x06
+*,*,0x0001,device_connected,,state,BOOL,0x06

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -865,8 +865,8 @@ def _apply_contextual_enum_annotations(artifact: dict[str, Any]) -> None:
     gg02 = groups.get("0x02")
     if not isinstance(gg02, dict):
         return
-    gg02_instance_maps = _iter_group_instance_maps(gg02)
-    if not gg02_instance_maps:
+    gg02_instances = _group_instances_for_namespace(gg02, namespace_key="0x02")
+    if not isinstance(gg02_instances, dict) or not gg02_instances:
         return
 
     gg00 = groups.get("0x00")
@@ -885,52 +885,51 @@ def _apply_contextual_enum_annotations(artifact: dict[str, Any]) -> None:
     gg05_present = "0x05" in groups
     pool_sensor_present = False
 
-    for gg02_instances in gg02_instance_maps:
-        for instance_obj in gg02_instances.values():
-            if not isinstance(instance_obj, dict):
-                continue
-            registers = instance_obj.get("registers")
-            if not isinstance(registers, dict):
-                continue
+    for instance_obj in gg02_instances.values():
+        if not isinstance(instance_obj, dict):
+            continue
+        registers = instance_obj.get("registers")
+        if not isinstance(registers, dict):
+            continue
 
-            cooling_enabled = (
-                _entry_int_value(registers.get("0x0006"))
-                if isinstance(registers.get("0x0006"), dict)
-                else None
-            )
+        cooling_enabled = (
+            _entry_int_value(registers.get("0x0006"))
+            if isinstance(registers.get("0x0006"), dict)
+            else None
+        )
 
-            rr01 = registers.get("0x0001")
-            if isinstance(rr01, dict):
-                raw_value = _entry_int_value(rr01)
-                if raw_value is not None:
-                    raw_name, resolved_name = _resolve_heating_circuit_type_name(raw_value)
-                    rr01["enum_raw_name"] = raw_name
-                    rr01["enum_resolved_name"] = resolved_name
-                    rr01["value_display"] = f"{raw_name} ({resolved_name})"
+        rr01 = registers.get("0x0001")
+        if isinstance(rr01, dict):
+            raw_value = _entry_int_value(rr01)
+            if raw_value is not None:
+                raw_name, resolved_name = _resolve_heating_circuit_type_name(raw_value)
+                rr01["enum_raw_name"] = raw_name
+                rr01["enum_resolved_name"] = resolved_name
+                rr01["value_display"] = f"{raw_name} ({resolved_name})"
 
-            rr02 = registers.get("0x0002")
-            if isinstance(rr02, dict):
-                raw_value = _entry_int_value(rr02)
-                if raw_value is not None:
-                    raw_name, resolved_name = _resolve_mixer_circuit_type_name(
-                        raw_value,
-                        cooling_enabled=cooling_enabled,
-                        gg05_present=gg05_present,
-                        system_schema=system_schema,
-                        pool_sensor_present=pool_sensor_present,
-                    )
-                    rr02["enum_raw_name"] = raw_name
-                    rr02["enum_resolved_name"] = resolved_name
-                    rr02["value_display"] = f"{raw_name} ({resolved_name})"
+        rr02 = registers.get("0x0002")
+        if isinstance(rr02, dict):
+            raw_value = _entry_int_value(rr02)
+            if raw_value is not None:
+                raw_name, resolved_name = _resolve_mixer_circuit_type_name(
+                    raw_value,
+                    cooling_enabled=cooling_enabled,
+                    gg05_present=gg05_present,
+                    system_schema=system_schema,
+                    pool_sensor_present=pool_sensor_present,
+                )
+                rr02["enum_raw_name"] = raw_name
+                rr02["enum_resolved_name"] = resolved_name
+                rr02["value_display"] = f"{raw_name} ({resolved_name})"
 
-            rr03 = registers.get("0x0003")
-            if isinstance(rr03, dict):
-                raw_value = _entry_int_value(rr03)
-                if raw_value is not None:
-                    raw_name, resolved_name = _resolve_room_influence_type_name(raw_value)
-                    rr03["enum_raw_name"] = raw_name
-                    rr03["enum_resolved_name"] = resolved_name
-                    rr03["value_display"] = f"{raw_name} ({resolved_name})"
+        rr03 = registers.get("0x0003")
+        if isinstance(rr03, dict):
+            raw_value = _entry_int_value(rr03)
+            if raw_value is not None:
+                raw_name, resolved_name = _resolve_room_influence_type_name(raw_value)
+                rr03["enum_raw_name"] = raw_name
+                rr03["enum_resolved_name"] = resolved_name
+                rr03["value_display"] = f"{raw_name} ({resolved_name})"
 
 
 def _resolve_planner_mode(

--- a/src/helianthus_vrc_explorer/schema/myvaillant_map.py
+++ b/src/helianthus_vrc_explorer/schema/myvaillant_map.py
@@ -67,14 +67,17 @@ class MyvaillantRegisterMap:
         *,
         exact: dict[tuple[int, int, int, int | None], MyvaillantRegisterName],
         wildcard_instance: dict[tuple[int, int, int | None], MyvaillantRegisterName],
+        wildcard_group: dict[tuple[int, int | None], MyvaillantRegisterName],
     ) -> None:
         self._exact = exact
         self._wildcard_instance = wildcard_instance
+        self._wildcard_group = wildcard_group
 
     @classmethod
     def from_path(cls, path: Path) -> MyvaillantRegisterMap:
         exact: dict[tuple[int, int, int, int | None], MyvaillantRegisterName] = {}
         wildcard_instance: dict[tuple[int, int, int | None], MyvaillantRegisterName] = {}
+        wildcard_group: dict[tuple[int, int | None], MyvaillantRegisterName] = {}
 
         with path.open(newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
@@ -94,8 +97,6 @@ class MyvaillantRegisterMap:
                 type_hint = (row.get("type_hint") or "").strip().upper() or None
                 opcode_raw = (row.get("opcode") or "").strip()
                 opcode = _parse_hex_u8(opcode_raw) if opcode_raw else None
-
-                gg = _parse_hex_u8(gg_raw)
                 rr = _parse_hex_u16(rr_raw)
                 entry = MyvaillantRegisterName(
                     leaf=leaf,
@@ -104,6 +105,28 @@ class MyvaillantRegisterMap:
                     type_hint=type_hint,
                     opcode=opcode,
                 )
+
+                if gg_raw == "*":
+                    if ii_raw != "*":
+                        raise ValueError(
+                            "Group wildcard mappings require instance='*' "
+                            f"for register=0x{rr:04X}"
+                        )
+                    if opcode is None:
+                        raise ValueError(
+                            "Group wildcard mappings require an explicit opcode "
+                            f"for register=0x{rr:04X}"
+                        )
+                    wildcard_group_key = (rr, opcode)
+                    if wildcard_group_key in wildcard_group:
+                        raise ValueError(
+                            f"Duplicate group wildcard mapping for register=0x{rr:04X} "
+                            f"opcode={opcode_raw}"
+                        )
+                    wildcard_group[wildcard_group_key] = entry
+                    continue
+
+                gg = _parse_hex_u8(gg_raw)
 
                 if ii_raw == "*":
                     wildcard_key = (gg, rr, opcode)
@@ -124,7 +147,16 @@ class MyvaillantRegisterMap:
                     )
                 exact[exact_key] = entry
 
-        return cls(exact=exact, wildcard_instance=wildcard_instance)
+        return cls(
+            exact=exact,
+            wildcard_instance=wildcard_instance,
+            wildcard_group=wildcard_group,
+        )
+
+    def _allow_generic_fallback(self, *, opcode: int) -> bool:
+        # Generic opcode-less rows in the bundled map are local-first defaults.
+        # Remote namespaces must opt in with explicit opcode rows.
+        return opcode == 0x02
 
     def lookup(
         self,
@@ -139,13 +171,23 @@ class MyvaillantRegisterMap:
             if entry is not None:
                 return entry
 
-        entry = self._exact.get((group, instance, register, None))
-        if entry is not None:
-            return entry
-
-        if opcode is not None:
             entry = self._wildcard_instance.get((group, register, opcode))
             if entry is not None:
                 return entry
 
-        return self._wildcard_instance.get((group, register, None))
+            entry = self._wildcard_group.get((register, opcode))
+            if entry is not None:
+                return entry
+
+            if not self._allow_generic_fallback(opcode=opcode):
+                return None
+
+        entry = self._exact.get((group, instance, register, None))
+        if entry is not None:
+            return entry
+
+        entry = self._wildcard_instance.get((group, register, None))
+        if entry is not None:
+            return entry
+
+        return self._wildcard_group.get((register, None))

--- a/src/helianthus_vrc_explorer/schema/myvaillant_map.py
+++ b/src/helianthus_vrc_explorer/schema/myvaillant_map.py
@@ -109,8 +109,7 @@ class MyvaillantRegisterMap:
                 if gg_raw == "*":
                     if ii_raw != "*":
                         raise ValueError(
-                            "Group wildcard mappings require instance='*' "
-                            f"for register=0x{rr:04X}"
+                            f"Group wildcard mappings require instance='*' for register=0x{rr:04X}"
                         )
                     if opcode is None:
                         raise ValueError(

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -917,17 +917,23 @@ def test_artifact_register_flags_present(tmp_path: Path) -> None:
     assert entry["read_opcode_label"] == "local"
 
 
-def test_contextual_enum_annotations_follow_dual_namespace_group_02(tmp_path: Path) -> None:
+def test_contextual_enum_annotations_are_namespace_owned_for_group_02(tmp_path: Path) -> None:
     fixture_path = _write_fixture_group_02_dual_namespace(tmp_path)
     artifact = json.loads(fixture_path.read_text(encoding="utf-8"))
     _apply_contextual_enum_annotations(artifact)
 
+    local_registers = artifact["groups"]["0x02"]["namespaces"]["0x02"]["instances"]["0x00"][
+        "registers"
+    ]
     remote_registers = artifact["groups"]["0x02"]["namespaces"]["0x06"]["instances"]["0x00"][
         "registers"
     ]
-    assert remote_registers["0x0001"]["enum_resolved_name"] == "MIXER_CIRCUIT_EXTERNAL"
-    assert remote_registers["0x0002"]["enum_resolved_name"] == "DHW"
-    assert remote_registers["0x0003"]["enum_resolved_name"] == "EXTENDED"
+    assert local_registers["0x0001"]["enum_resolved_name"] == "DIRECT_HEATING_CIRCUIT"
+    assert local_registers["0x0002"]["enum_resolved_name"] == "FIXED_VALUE"
+    assert local_registers["0x0003"]["enum_resolved_name"] == "ACTIVE"
+    assert "enum_resolved_name" not in remote_registers["0x0001"]
+    assert "enum_resolved_name" not in remote_registers["0x0002"]
+    assert "enum_resolved_name" not in remote_registers["0x0003"]
 
 
 def test_group_08_remote_namespace_only_marks_present_instances(

--- a/tests/test_schema_myvaillant_map.py
+++ b/tests/test_schema_myvaillant_map.py
@@ -167,19 +167,81 @@ def test_loader_prefers_opcode_specific_rows_and_exposes_type_hint(tmp_path: Pat
     schema = MyvaillantRegisterMap.from_path(csv_path)
     local = schema.lookup(group=0x09, instance=0x01, register=0x0004, opcode=0x02)
     remote = schema.lookup(group=0x09, instance=0x01, register=0x0004, opcode=0x06)
-    fallback = schema.lookup(group=0x09, instance=0x01, register=0x000F, opcode=0x06)
+    local_fallback = schema.lookup(group=0x09, instance=0x01, register=0x000F, opcode=0x02)
+    remote_fallback = schema.lookup(group=0x09, instance=0x01, register=0x000F, opcode=0x06)
 
     assert local is not None
     assert remote is not None
-    assert fallback is not None
+    assert local_fallback is not None
+    assert remote_fallback is None
     assert local.leaf == "radio_device_firmware_local"
     assert local.type_hint == "FW"
     assert local.opcode == 0x02
     assert remote.leaf == "radio_device_firmware_remote"
     assert remote.type_hint == "FW"
     assert remote.opcode == 0x06
-    assert fallback.leaf == "radio_room_temperature"
-    assert fallback.opcode is None
+    assert local_fallback.leaf == "radio_room_temperature"
+    assert local_fallback.opcode is None
+
+
+def test_loader_supports_group_wildcard_rows_with_explicit_opcode(tmp_path: Path) -> None:
+    csv_path = tmp_path / "wildcard-group.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode",
+                "*,*,0x0001,device_connected,,state,BOOL,0x06",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    schema = MyvaillantRegisterMap.from_path(csv_path)
+    gg01 = schema.lookup(group=0x01, instance=0x00, register=0x0001, opcode=0x06)
+    gg0c = schema.lookup(group=0x0C, instance=0x04, register=0x0001, opcode=0x06)
+    local = schema.lookup(group=0x01, instance=0x00, register=0x0001, opcode=0x02)
+
+    assert gg01 is not None
+    assert gg0c is not None
+    assert gg01.leaf == "device_connected"
+    assert gg01.type_hint == "BOOL"
+    assert gg0c.leaf == "device_connected"
+    assert local is None
+
+
+def test_loader_rejects_group_wildcard_without_opcode(tmp_path: Path) -> None:
+    csv_path = tmp_path / "wildcard-group-missing-opcode.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode",
+                "*,*,0x0001,device_connected,,state,BOOL,",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"require an explicit opcode"):
+        MyvaillantRegisterMap.from_path(csv_path)
+
+
+def test_loader_rejects_group_wildcard_without_instance_wildcard(tmp_path: Path) -> None:
+    csv_path = tmp_path / "wildcard-group-bad-instance.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode",
+                "*,0x00,0x0001,device_connected,,state,BOOL,0x06",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"require instance='\*'"):
+        MyvaillantRegisterMap.from_path(csv_path)
 
 
 def test_loader_rejects_duplicate_group_instance_register_opcode_rows(tmp_path: Path) -> None:
@@ -225,10 +287,53 @@ def test_zone_name_suffix_entry_exposes_string_type_hint() -> None:
     assert prefix.type_hint == "STR:*"
 
 
+def test_namespace_owned_required_tuple_rows_are_resolvable() -> None:
+    csv_path = Path(__file__).resolve().parents[1] / "data" / "myvaillant_register_map.csv"
+    schema = MyvaillantRegisterMap.from_path(csv_path)
+
+    remote_presence = schema.lookup(group=0x08, instance=0x00, register=0x0001, opcode=0x06)
+    remote_gg01_rr0012 = schema.lookup(group=0x01, instance=0x00, register=0x0012, opcode=0x06)
+    remote_gg01_rr0015 = schema.lookup(group=0x01, instance=0x00, register=0x0015, opcode=0x06)
+    local_gg00_rr0048 = schema.lookup(group=0x00, instance=0x00, register=0x0048, opcode=0x02)
+    local_gg00_rr00da = schema.lookup(group=0x00, instance=0x00, register=0x00DA, opcode=0x02)
+    local_gg00_rr00db = schema.lookup(group=0x00, instance=0x00, register=0x00DB, opcode=0x02)
+
+    assert remote_presence is not None
+    assert remote_presence.leaf == "device_connected"
+    assert remote_presence.type_hint == "BOOL"
+    assert remote_gg01_rr0012 is not None
+    assert remote_gg01_rr0012.leaf == "device_status"
+    assert remote_gg01_rr0012.type_hint == "UCH"
+    assert remote_gg01_rr0015 is not None
+    assert remote_gg01_rr0015.leaf == "unknown_0015"
+    assert remote_gg01_rr0015.type_hint == "UIN"
+    assert local_gg00_rr0048 is not None
+    assert local_gg00_rr0048.leaf == "unknown_0048"
+    assert local_gg00_rr0048.type_hint == "UIN"
+    assert local_gg00_rr00da is not None
+    assert local_gg00_rr00da.leaf == "unknown_00da_date"
+    assert local_gg00_rr00da.type_hint == "HDA:3"
+    assert local_gg00_rr00db is not None
+    assert local_gg00_rr00db.leaf == "unknown_00db_date"
+    assert local_gg00_rr00db.type_hint == "HDA:3"
+
+
+def test_remote_namespace_does_not_inherit_local_generic_rows() -> None:
+    csv_path = Path(__file__).resolve().parents[1] / "data" / "myvaillant_register_map.csv"
+    schema = MyvaillantRegisterMap.from_path(csv_path)
+
+    local = schema.lookup(group=0x02, instance=0x00, register=0x0015, opcode=0x02)
+    remote = schema.lookup(group=0x02, instance=0x00, register=0x0015, opcode=0x06)
+
+    assert local is not None
+    assert local.leaf == "room_temperature_control_mode"
+    assert remote is None
+
+
 def test_register_map_minimum_entry_count_and_no_duplicates() -> None:
     csv_path = Path(__file__).resolve().parents[1] / "data" / "myvaillant_register_map.csv"
 
-    rows: list[tuple[int, str, int, int | None]] = []
+    rows: list[tuple[str, str, int, int | None]] = []
     with csv_path.open(newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
@@ -240,7 +345,7 @@ def test_register_map_minimum_entry_count_and_no_duplicates() -> None:
                 continue
             opcode_raw = (row.get("opcode") or "").strip()
             rows.append(
-                (int(gg_raw, 0), ii_raw, int(rr_raw, 0), int(opcode_raw, 0) if opcode_raw else None)
+                (gg_raw, ii_raw, int(rr_raw, 0), int(opcode_raw, 0) if opcode_raw else None)
             )
 
     assert len(rows) >= 150


### PR DESCRIPTION
## What
Implements issue #202 by making RR enrichment namespace-owned and opcode-aware so local (`0x02`) and remote (`0x06`) register semantics cannot cross-label.

## Why
Issue #202 requires explicit minimal fallback and proven isolation between opcode namespaces, with stable enrichment output for artifact/browse/summary/HTML consumers.

## Changes
- Added opcode-scoped group wildcard support to `MyvaillantRegisterMap` for explicit remote namespace tuples.
- Enforced explicit fallback policy: generic opcode-less rows remain local (`0x02`) defaults; remote (`0x06`) requires explicit rows.
- Added required tuple rows:
  - `0x06/RR=0x0001`
  - `0x06/GG=0x01/RR=0x0015`
  - `0x06/GG=0x01/RR=0x0012`
  - `0x02/GG=0x00/RR=0x0048`
  - `0x02/GG=0x00/RR=0x00DA`
  - `0x02/GG=0x00/RR=0x00DB`
- Scoped contextual enum annotation logic for GG=`0x02` to local namespace only (`0x02`), preventing remote (`0x06`) relabeling.
- Added/updated tests for required tuples, negative fallback isolation, wildcard validation rules, and contextual enum namespace isolation.
- Updated README enrichment section with explicit opcode-aware fallback policy.

## Validation
- `PYTHONPATH=src venv/bin/python -m pytest tests/test_schema_myvaillant_map.py tests/test_scanner_scan.py`
- `venv/bin/python -m ruff check src/helianthus_vrc_explorer/schema/myvaillant_map.py src/helianthus_vrc_explorer/scanner/scan.py tests/test_schema_myvaillant_map.py tests/test_scanner_scan.py`

## Agent State
Status: ready for review
Branch: issue/202-b524-namespace-owned-rr-enrichment-registry
Last verified (lint/tests): 2026-04-04, targeted pytest + ruff pass
How to reproduce: run validation commands above
Next steps: CI + review
Notes (no secrets, no private infra): keeps existing local dirty `AGENTS.md` untouched per instruction
