### PR TITLE
b524: eradicate GG-centric fallbacks and add namespace guardrails (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Protocol terminology gate
         run: python scripts/check_protocol_terminology.py
 
+      - name: B524 namespace guardrails
+        run: python scripts/check_b524_namespace_guardrails.py
+
       - name: Docs sync gate (CLI + README)
         run: python scripts/check_docs_sync.py
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Transport note:
 - Classic GG directory-probe results are retained as advisory metadata for semantic identity and namespace topology. They are useful evidence for reverse-engineering and debugging, but they do not define those semantics once a group is a scan candidate. A `descriptor_type == 0.0` result is still used as a discovery-time negative hint for non-core/unknown groups in Phase A.
 - Instance availability is namespace-specific. Dual-namespace radio groups (`0x09`, `0x0A`) are discovered independently per opcode namespace instead of sharing remote results across local and remote.
 - Artifacts retain the availability contract plus raw per-slot probe evidence under `availability_contract` and `availability_probes`, including the opcode `0x06` `RR=0x0001` `device_connected` probe used for remote namespaces.
+- Unknown groups are namespace-classified from live opcode responsiveness evidence. There is no implicit unknown-group `[0x02, 0x06]` fallback.
+- Contextual enum annotations are local-namespace scoped: group `0x02` local (`0x02`) register context never relabels remote (`0x06`) entries.
+- CI enforces these rules with `python scripts/check_b524_namespace_guardrails.py`.
 
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.

--- a/scripts/check_b524_namespace_guardrails.py
+++ b/scripts/check_b524_namespace_guardrails.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ForbiddenPattern:
+    description: str
+    path: str
+    pattern: re.Pattern[str]
+
+
+@dataclass(frozen=True, slots=True)
+class RequiredPattern:
+    description: str
+    path: str
+    pattern: re.Pattern[str]
+
+
+FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
+    ForbiddenPattern(
+        description="unknown-group implicit [0x02, 0x06] fallback in scanner opcode helpers",
+        path="src/helianthus_vrc_explorer/scanner/register.py",
+        pattern=re.compile(
+            r"if\s+config\s+is\s+None:\s*return\s*\[\s*0x02\s*,\s*0x06\s*\]",
+            re.MULTILINE,
+        ),
+    ),
+    ForbiddenPattern(
+        description="unknown-group implicit (0x02, 0x06) fallback in dummy transport",
+        path="src/helianthus_vrc_explorer/transport/dummy.py",
+        pattern=re.compile(
+            r"if\s+config\s+is\s+None:\s*return\s*\(\s*0x02\s*,\s*0x06\s*\)",
+            re.MULTILINE,
+        ),
+    ),
+    ForbiddenPattern(
+        description="GG-only register identity tuple shortcut",
+        path="src/helianthus_vrc_explorer/scanner/identity.py",
+        pattern=re.compile(r"return\s*\(\s*group\s*,\s*instance\s*,\s*register\s*\)"),
+    ),
+)
+
+
+REQUIRED_PATTERNS: tuple[RequiredPattern, ...] = (
+    RequiredPattern(
+        description="opcode-first register identity return tuple",
+        path="src/helianthus_vrc_explorer/scanner/identity.py",
+        pattern=re.compile(r"return\s*\(\s*opcode\s*,\s*group\s*,\s*instance\s*,\s*register\s*\)"),
+    ),
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _tracked_paths(repo_root: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    return {raw.decode("utf-8") for raw in result.stdout.split(b"\0") if raw}
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def main() -> int:
+    repo_root = _repo_root()
+    tracked = _tracked_paths(repo_root)
+    violations: list[str] = []
+
+    for check in FORBIDDEN_PATTERNS:
+        if check.path not in tracked:
+            continue
+        content = (repo_root / check.path).read_text(encoding="utf-8", errors="ignore")
+        for match in check.pattern.finditer(content):
+            line = _line_number(content, match.start())
+            violations.append(f"{check.path}:{line}: forbidden pattern: {check.description}")
+
+    for check in REQUIRED_PATTERNS:
+        if check.path not in tracked:
+            violations.append(
+                f"{check.path}: missing required file for guard check: {check.description}"
+            )
+            continue
+        content = (repo_root / check.path).read_text(encoding="utf-8", errors="ignore")
+        if check.pattern.search(content) is None:
+            violations.append(f"{check.path}: missing required pattern: {check.description}")
+
+    if violations:
+        print(
+            (
+                "B524 namespace guardrails failed. Remove GG-centric fallbacks "
+                "and keep opcode-first identity."
+            ),
+            file=sys.stderr,
+        )
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -78,7 +78,11 @@ def opcodes_for_group(group: int) -> list[RegisterOpcode]:
 
     config = GROUP_CONFIG.get(group)
     if config is None:
-        return [0x02, 0x06]
+        raise ValueError(
+            "Unknown group 0x"
+            f"{group:02X} has no implicit opcode defaults. "
+            "Use discovery evidence to classify namespace opcodes."
+        )
     return [cast(RegisterOpcode, opcode) for opcode in config["opcodes"]]
 
 
@@ -91,7 +95,11 @@ def namespace_opcodes_for_group(group: int) -> list[RegisterOpcode]:
 
     config = GROUP_CONFIG.get(group)
     if config is None:
-        return [0x02, 0x06]
+        raise ValueError(
+            "Unknown group 0x"
+            f"{group:02X} has no implicit namespace defaults. "
+            "Use discovery evidence to classify namespace opcodes."
+        )
     raw_opcodes = config.get("namespace_opcodes", config["opcodes"])
     return [cast(RegisterOpcode, opcode) for opcode in raw_opcodes]
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -693,41 +693,46 @@ def _constraint_for_register(
     )
 
 
-def _iter_group_instance_maps(group_obj: dict[str, Any]) -> list[dict[str, Any]]:
+def _iter_group_namespace_instance_maps(
+    group_obj: dict[str, Any],
+) -> list[tuple[str | None, dict[str, Any]]]:
     if bool(group_obj.get("dual_namespace")):
         namespaces = group_obj.get("namespaces")
         if not isinstance(namespaces, dict):
             return []
-        instance_maps: list[dict[str, Any]] = []
-        for namespace_obj in namespaces.values():
+        instance_maps: list[tuple[str | None, dict[str, Any]]] = []
+        for namespace_key, namespace_obj in namespaces.items():
+            if not isinstance(namespace_key, str):
+                continue
             if not isinstance(namespace_obj, dict):
                 continue
             instances = namespace_obj.get("instances")
             if isinstance(instances, dict):
-                instance_maps.append(instances)
+                instance_maps.append((namespace_key, instances))
         return instance_maps
 
     instances = group_obj.get("instances")
     if isinstance(instances, dict):
-        return [instances]
+        return [(None, instances)]
     return []
 
 
 def _group_instances_for_namespace(
     group_obj: dict[str, Any], *, namespace_key: str | None = None
 ) -> dict[str, Any] | None:
-    if namespace_key is not None and bool(group_obj.get("dual_namespace")):
-        namespaces = group_obj.get("namespaces")
-        if not isinstance(namespaces, dict):
-            return None
-        namespace_obj = namespaces.get(namespace_key)
-        if not isinstance(namespace_obj, dict):
-            return None
-        instances = namespace_obj.get("instances")
-        return instances if isinstance(instances, dict) else None
+    instance_maps = _iter_group_namespace_instance_maps(group_obj)
+    if namespace_key is None:
+        return instance_maps[0][1] if instance_maps else None
 
-    instance_maps = _iter_group_instance_maps(group_obj)
-    return instance_maps[0] if instance_maps else None
+    for candidate_namespace, instances in instance_maps:
+        if candidate_namespace == namespace_key:
+            return instances
+    if not bool(group_obj.get("dual_namespace")) and namespace_key == _hex_u8(
+        _LOCAL_REGISTER_OPCODE
+    ):
+        # Single-namespace artifacts are local by definition.
+        return instance_maps[0][1] if instance_maps else None
+    return None
 
 
 def _apply_constraint_metadata(
@@ -865,8 +870,16 @@ def _apply_contextual_enum_annotations(artifact: dict[str, Any]) -> None:
     gg02 = groups.get("0x02")
     if not isinstance(gg02, dict):
         return
-    gg02_instances = _group_instances_for_namespace(gg02, namespace_key="0x02")
-    if not isinstance(gg02_instances, dict) or not gg02_instances:
+    gg02_namespace_maps = _iter_group_namespace_instance_maps(gg02)
+    if bool(gg02.get("dual_namespace")):
+        gg02_instance_maps = [
+            instances
+            for namespace_key, instances in gg02_namespace_maps
+            if namespace_key == _hex_u8(_LOCAL_REGISTER_OPCODE)
+        ]
+    else:
+        gg02_instance_maps = [instances for _namespace_key, instances in gg02_namespace_maps]
+    if not gg02_instance_maps:
         return
 
     gg00 = groups.get("0x00")
@@ -885,51 +898,52 @@ def _apply_contextual_enum_annotations(artifact: dict[str, Any]) -> None:
     gg05_present = "0x05" in groups
     pool_sensor_present = False
 
-    for instance_obj in gg02_instances.values():
-        if not isinstance(instance_obj, dict):
-            continue
-        registers = instance_obj.get("registers")
-        if not isinstance(registers, dict):
-            continue
+    for gg02_instances in gg02_instance_maps:
+        for instance_obj in gg02_instances.values():
+            if not isinstance(instance_obj, dict):
+                continue
+            registers = instance_obj.get("registers")
+            if not isinstance(registers, dict):
+                continue
 
-        cooling_enabled = (
-            _entry_int_value(registers.get("0x0006"))
-            if isinstance(registers.get("0x0006"), dict)
-            else None
-        )
+            cooling_enabled = (
+                _entry_int_value(registers.get("0x0006"))
+                if isinstance(registers.get("0x0006"), dict)
+                else None
+            )
 
-        rr01 = registers.get("0x0001")
-        if isinstance(rr01, dict):
-            raw_value = _entry_int_value(rr01)
-            if raw_value is not None:
-                raw_name, resolved_name = _resolve_heating_circuit_type_name(raw_value)
-                rr01["enum_raw_name"] = raw_name
-                rr01["enum_resolved_name"] = resolved_name
-                rr01["value_display"] = f"{raw_name} ({resolved_name})"
+            rr01 = registers.get("0x0001")
+            if isinstance(rr01, dict):
+                raw_value = _entry_int_value(rr01)
+                if raw_value is not None:
+                    raw_name, resolved_name = _resolve_heating_circuit_type_name(raw_value)
+                    rr01["enum_raw_name"] = raw_name
+                    rr01["enum_resolved_name"] = resolved_name
+                    rr01["value_display"] = f"{raw_name} ({resolved_name})"
 
-        rr02 = registers.get("0x0002")
-        if isinstance(rr02, dict):
-            raw_value = _entry_int_value(rr02)
-            if raw_value is not None:
-                raw_name, resolved_name = _resolve_mixer_circuit_type_name(
-                    raw_value,
-                    cooling_enabled=cooling_enabled,
-                    gg05_present=gg05_present,
-                    system_schema=system_schema,
-                    pool_sensor_present=pool_sensor_present,
-                )
-                rr02["enum_raw_name"] = raw_name
-                rr02["enum_resolved_name"] = resolved_name
-                rr02["value_display"] = f"{raw_name} ({resolved_name})"
+            rr02 = registers.get("0x0002")
+            if isinstance(rr02, dict):
+                raw_value = _entry_int_value(rr02)
+                if raw_value is not None:
+                    raw_name, resolved_name = _resolve_mixer_circuit_type_name(
+                        raw_value,
+                        cooling_enabled=cooling_enabled,
+                        gg05_present=gg05_present,
+                        system_schema=system_schema,
+                        pool_sensor_present=pool_sensor_present,
+                    )
+                    rr02["enum_raw_name"] = raw_name
+                    rr02["enum_resolved_name"] = resolved_name
+                    rr02["value_display"] = f"{raw_name} ({resolved_name})"
 
-        rr03 = registers.get("0x0003")
-        if isinstance(rr03, dict):
-            raw_value = _entry_int_value(rr03)
-            if raw_value is not None:
-                raw_name, resolved_name = _resolve_room_influence_type_name(raw_value)
-                rr03["enum_raw_name"] = raw_name
-                rr03["enum_resolved_name"] = resolved_name
-                rr03["value_display"] = f"{raw_name} ({resolved_name})"
+            rr03 = registers.get("0x0003")
+            if isinstance(rr03, dict):
+                raw_value = _entry_int_value(rr03)
+                if raw_value is not None:
+                    raw_name, resolved_name = _resolve_room_influence_type_name(raw_value)
+                    rr03["enum_raw_name"] = raw_name
+                    rr03["enum_resolved_name"] = resolved_name
+                    rr03["value_display"] = f"{raw_name} ({resolved_name})"
 
 
 def _resolve_planner_mode(

--- a/src/helianthus_vrc_explorer/transport/dummy.py
+++ b/src/helianthus_vrc_explorer/transport/dummy.py
@@ -133,7 +133,11 @@ class DummyTransport(TransportInterface):
             if configured:
                 return configured
 
-        return (0x02, 0x06)
+        raise ValueError(
+            "Unknown group "
+            f"0x{group:02X} fixture requires explicit namespace/read_opcode; "
+            "implicit [0x02, 0x06] fallback is forbidden."
+        )
 
     def _load_instances(
         self,

--- a/tests/test_dummy_transport.py
+++ b/tests/test_dummy_transport.py
@@ -182,3 +182,28 @@ def test_dummy_transport_artifact_v2_namespaces_do_not_require_dual_namespace_fl
 
     assert transport.send(0x15, local_payload) == bytes.fromhex("01090400031702")
     assert transport.send(0x15, remote_payload) == bytes.fromhex("01090400021703")
+
+
+def test_dummy_transport_unknown_group_flat_fixture_requires_explicit_namespace(
+    tmp_path: Path,
+) -> None:
+    fixture = {
+        "meta": {},
+        "groups": {
+            "0x69": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0000": {"raw_hex": "00"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture_unknown_flat.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="implicit \\[0x02, 0x06\\] fallback is forbidden"):
+        DummyTransport(fixture_path)

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -205,10 +205,20 @@ def test_opcodes_for_group_single_namespace() -> None:
     assert opcodes_for_group(0x0B) == [0x06]
 
 
+def test_opcodes_for_group_unknown_group_requires_discovery_evidence() -> None:
+    with pytest.raises(ValueError, match="Unknown group 0x69"):
+        opcodes_for_group(0x69)
+
+
 def test_namespace_opcodes_for_group_supports_staged_remote_namespaces() -> None:
     assert namespace_opcodes_for_group(0x01) == [0x02, 0x06]
     assert namespace_opcodes_for_group(0x02) == [0x02, 0x06]
     assert namespace_opcodes_for_group(0x0C) == [0x06]
+
+
+def test_namespace_opcodes_for_group_unknown_group_requires_discovery_evidence() -> None:
+    with pytest.raises(ValueError, match="Unknown group 0x69"):
+        namespace_opcodes_for_group(0x69)
 
 
 def test_read_register_infers_hex_for_unparseable_u24_values() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -142,12 +142,26 @@ def _write_fixture_unknown_group_69(tmp_path: Path) -> Path:
         "groups": {
             "0x69": {
                 "descriptor_type": 1.0,
-                "instances": {
-                    "0x00": {
-                        "registers": {
-                            "0x0000": {"raw_hex": "00"},
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                }
+                            }
                         }
-                    }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                }
+                            }
+                        }
+                    },
                 },
             }
         },
@@ -921,7 +935,7 @@ def test_artifact_register_flags_present(tmp_path: Path) -> None:
     assert entry["read_opcode_label"] == "local"
 
 
-def test_contextual_enum_annotations_are_namespace_owned_for_group_02(tmp_path: Path) -> None:
+def test_contextual_enum_annotations_do_not_relabel_remote_namespace(tmp_path: Path) -> None:
     fixture_path = _write_fixture_group_02_dual_namespace(tmp_path)
     artifact = json.loads(fixture_path.read_text(encoding="utf-8"))
     _apply_contextual_enum_annotations(artifact)
@@ -935,9 +949,13 @@ def test_contextual_enum_annotations_are_namespace_owned_for_group_02(tmp_path: 
     assert local_registers["0x0001"]["enum_resolved_name"] == "DIRECT_HEATING_CIRCUIT"
     assert local_registers["0x0002"]["enum_resolved_name"] == "FIXED_VALUE"
     assert local_registers["0x0003"]["enum_resolved_name"] == "ACTIVE"
+
     assert "enum_resolved_name" not in remote_registers["0x0001"]
     assert "enum_resolved_name" not in remote_registers["0x0002"]
     assert "enum_resolved_name" not in remote_registers["0x0003"]
+    assert "value_display" not in remote_registers["0x0001"]
+    assert "value_display" not in remote_registers["0x0002"]
+    assert "value_display" not in remote_registers["0x0003"]
 
 
 def test_group_08_remote_namespace_only_marks_present_instances(


### PR DESCRIPTION
## What
Implements issue #203 by removing remaining GG-centric namespace fallback behavior and adding explicit guardrails for opcode-first identity.

## Why
Namespace split safety depended on helper paths and fixtures no longer silently collapsing unknown groups into dual-opcode assumptions.

## Changes
- Removed implicit unknown-group defaults from `opcodes_for_group()` and `namespace_opcodes_for_group()`; unknown groups now raise and require discovery evidence.
- Removed dummy transport fallback that auto-mirrored unknown groups to `(0x02, 0x06)` without namespace evidence.
- Updated contextual enum annotation traversal to be namespace-aware and local-only for GG `0x02` contextual fallback logic.
- Added CI guard script `scripts/check_b524_namespace_guardrails.py` and wired it into lint workflow.
- Added/updated tests for:
  - unknown-group fallback rejection
  - namespace helper rejection on unknown groups
  - remote namespace annotation non-relabel behavior
  - explicit namespace requirement for unknown-group fixtures
- Updated README guardrail notes (doc gate for discovery-first + local-only annotation behavior).

## Acceptance Criteria
- [x] Unknown groups do not default to `[0x02, 0x06]`; they use discovery probing and evidence-based classification.
- [x] `_apply_contextual_enum_annotations()` and similar walkers traverse namespace-aware paths.
- [x] Review-time grep/equivalent checks detect forbidden fallback patterns and GG-only identity shortcuts.
- [x] Guardrail tests prove remote namespaces are never relabeled by local fallback logic.

## Validation
- `venv/bin/python scripts/check_protocol_terminology.py`
- `venv/bin/python scripts/check_b524_namespace_guardrails.py`
- `venv/bin/python scripts/check_docs_sync.py`
- `venv/bin/ruff check src tests scripts/check_b524_namespace_guardrails.py`
- `PYTHONPATH=src venv/bin/pytest -q` (350 passed)

## Agent State
Status: Ready for review/test
Branch: issue/203-b524-eradicate-gg-centric-fallbacks-and-guardrails
Last verified (lint/tests): 2026-04-04 (local ruff + full pytest + guard scripts)
How to reproduce:
1. `venv/bin/python scripts/check_b524_namespace_guardrails.py`
2. `PYTHONPATH=src venv/bin/pytest -q`
Next steps:
1. Reviewer/tester pass on PR
2. Merge into `wip/b524-opcode-namespace-split-integration`
Notes (no secrets, no private infra): Unknown-group flat fixtures now require explicit namespace/read_opcode evidence.

Closes #203