### PR TITLE
Issue #204: canonical namespace-aware B524 artifact model

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Transport note:
 - Artifacts retain the availability contract plus raw per-slot probe evidence under `availability_contract` and `availability_probes`, including the opcode `0x06` `RR=0x0001` `device_connected` probe used for remote namespaces.
 - Unknown groups are namespace-classified from live opcode responsiveness evidence. There is no implicit unknown-group `[0x02, 0x06]` fallback.
 - Contextual enum annotations are local-namespace scoped: group `0x02` local (`0x02`) register context never relabels remote (`0x06`) entries.
+- Canonical namespace identity is always an opcode hex key (`0x02`, `0x06`, ...). Labels like `local`/`remote` are presentation metadata only.
+- Persisted `groups[*].dual_namespace` topology is authoritative for consumers. Do not infer or rewrite namespace shape from descriptors.
+- B524 browse/report row identity is namespace-aware even for single-namespace groups: dedupe key `<group>:<namespace>:<instance>:<register>` and path format `B524/<group-name>/<namespace-display>/<instance>/<register-name>` are round-trip stable.
 - CI enforces these rules with `python scripts/check_b524_namespace_guardrails.py`.
 
 Constraint note:

--- a/scripts/check_b524_namespace_guardrails.py
+++ b/scripts/check_b524_namespace_guardrails.py
@@ -44,6 +44,16 @@ FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
         path="src/helianthus_vrc_explorer/scanner/identity.py",
         pattern=re.compile(r"return\s*\(\s*group\s*,\s*instance\s*,\s*register\s*\)"),
     ),
+    ForbiddenPattern(
+        description="B524 row identity sentinel fallback ('single') in browse store",
+        path="src/helianthus_vrc_explorer/ui/browse_store.py",
+        pattern=re.compile(r'namespace_key\s+or\s+"single"'),
+    ),
+    ForbiddenPattern(
+        description="B524 namespace sentinel fallback ('single') in HTML report",
+        path="src/helianthus_vrc_explorer/ui/html_report.py",
+        pattern=re.compile(r'\|\|\s*"single"'),
+    ),
 )
 
 

--- a/scripts/check_b524_namespace_guardrails.py
+++ b/scripts/check_b524_namespace_guardrails.py
@@ -50,9 +50,35 @@ FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
         pattern=re.compile(r'namespace_key\s+or\s+"single"'),
     ),
     ForbiddenPattern(
+        description="B524 row identity sentinel fallback ('0x00') in browse store",
+        path="src/helianthus_vrc_explorer/ui/browse_store.py",
+        pattern=re.compile(
+            r"def\s+_single_namespace_key\s*\([\s\S]*?return\s+\"0x00\"",
+            re.MULTILINE,
+        ),
+    ),
+    ForbiddenPattern(
         description="B524 namespace sentinel fallback ('single') in HTML report",
         path="src/helianthus_vrc_explorer/ui/html_report.py",
         pattern=re.compile(r'\|\|\s*"single"'),
+    ),
+    ForbiddenPattern(
+        description="B524 namespace sentinel fallback ('0x00') in HTML report",
+        path="src/helianthus_vrc_explorer/ui/html_report.py",
+        pattern=re.compile(r'namespaceKey\s*\|\|\s*"0x00"'),
+    ),
+    ForbiddenPattern(
+        description="B524 read opcode sentinel fallback ('0x00') in HTML report",
+        path="src/helianthus_vrc_explorer/ui/html_report.py",
+        pattern=re.compile(r'read_opcode[^\n]*:\s*"0x00"'),
+    ),
+    ForbiddenPattern(
+        description="B524 namespace sentinel fallback ('0x00') in summary view",
+        path="src/helianthus_vrc_explorer/ui/summary.py",
+        pattern=re.compile(
+            r"def\s+_namespace_label_from_entry\s*\([\s\S]*?return\s+\"0x00\"",
+            re.MULTILINE,
+        ),
     ),
 )
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -164,6 +164,14 @@ def _instance_discovery_decision(*, group: int, dual_namespace: bool) -> dict[st
     }
 
 
+def _namespace_plan_meta(group_plan: GroupScanPlan) -> tuple[str, dict[str, object]]:
+    namespace_key = _hex_u8(group_plan.opcode)
+    payload = group_plan.to_meta()
+    payload["namespace_key"] = namespace_key
+    payload["label"] = opcode_label(group_plan.opcode)
+    return namespace_key, payload
+
+
 def _scan_plan_meta_groups(plan: dict[PlanKey, GroupScanPlan]) -> dict[str, object]:
     serializable: dict[str, object] = {}
     grouped: dict[int, list[GroupScanPlan]] = {}
@@ -173,19 +181,43 @@ def _scan_plan_meta_groups(plan: dict[PlanKey, GroupScanPlan]) -> dict[str, obje
     for group in sorted(grouped):
         group_plans = sorted(grouped[group], key=lambda gp: gp.opcode)
         group_key = _hex_u8(group)
+        namespace_meta: dict[str, object] = {}
+        for group_plan in group_plans:
+            namespace_key, payload = _namespace_plan_meta(group_plan)
+            namespace_meta[namespace_key] = payload
         if len(group_plans) > 1:
-            namespace_meta: dict[str, object] = {}
-            for group_plan in group_plans:
-                payload = group_plan.to_meta()
-                payload["label"] = opcode_label(group_plan.opcode)
-                namespace_meta[_hex_u8(group_plan.opcode)] = payload
             serializable[group_key] = {
                 "dual_namespace": True,
+                "namespace_identity_keys": "opcode_hex",
                 "namespaces": namespace_meta,
             }
             continue
-        serializable[group_key] = group_plans[0].to_meta()
+        _, single_payload = _namespace_plan_meta(group_plans[0])
+        serializable[group_key] = {
+            **single_payload,
+            "dual_namespace": False,
+            "namespace_identity_keys": "opcode_hex",
+            "namespaces": namespace_meta,
+        }
     return serializable
+
+
+def _artifact_contract_metadata() -> dict[str, Any]:
+    return {
+        "namespace_identity_keys": "opcode_hex",
+        "namespace_labels": "presentation_only",
+        "topology_authority": (
+            "persisted groups[*].dual_namespace and groups[*].namespaces are authoritative for "
+            "consumers"
+        ),
+        "b524_row_identity": {
+            "dedupe_key_format": "<group>:<namespace>:<instance>:<register>",
+            "path_format": "B524/<group-name>/<namespace-display>/<instance>/<register-name>",
+            "round_trip_stability": (
+                "namespace keys and persisted topology must be preserved without sentinel rewrite"
+            ),
+        },
+    }
 
 
 def _ensure_group_artifact(
@@ -1087,6 +1119,7 @@ def scan_b524(
             "destination_address": _hex_u8(dst),
             "schema_sources": [],
             "incomplete": False,
+            "artifact_contract": _artifact_contract_metadata(),
         },
         "groups": {},
     }

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -9,6 +9,10 @@ from .browse_models import BrowseTab, RegisterAddress, RegisterRow, TreeNodeRef
 from .register_semantics import entry_display_value_text, visible_rr_keys
 
 
+def _hex_u8(value: int) -> str:
+    return f"0x{value:02x}"
+
+
 def _safe_int_hex(value: str) -> int:
     try:
         return int(value, 0)
@@ -139,6 +143,51 @@ def _namespace_display_label(namespace_key: str | None, namespace_label: str | N
     if label.startswith("0x"):
         return label
     return f"{label[:1].upper()}{label[1:]} ({namespace_key})"
+
+
+def _normalize_opcode_hex(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        opcode = int(raw, 0)
+    except ValueError:
+        return None
+    if opcode < 0x00 or opcode > 0xFF:
+        return None
+    return _hex_u8(opcode)
+
+
+def _namespace_label_for_key(namespace_key: str) -> str:
+    opcode = _safe_int_hex(namespace_key)
+    if opcode == 0x02:
+        return "local"
+    if opcode == 0x06:
+        return "remote"
+    return namespace_key
+
+
+def _single_namespace_key(group_key: str, group_obj: dict[str, Any]) -> str:
+    discovery_advisory = group_obj.get("discovery_advisory")
+    if isinstance(discovery_advisory, dict):
+        proven = discovery_advisory.get("proven_register_opcodes")
+        if isinstance(proven, list):
+            for opcode in proven:
+                normalized = _normalize_opcode_hex(opcode)
+                if normalized is not None:
+                    return normalized
+
+    gg = _safe_int_hex(group_key)
+    config = GROUP_CONFIG.get(gg)
+    if config is not None:
+        opcodes = config.get("opcodes")
+        if isinstance(opcodes, list):
+            for opcode in opcodes:
+                if isinstance(opcode, int):
+                    return _hex_u8(opcode)
+    return "0x00"
 
 
 def _group_namespace_views(
@@ -285,6 +334,8 @@ class BrowseStore:
                 continue
             group_name = str(group_obj.get("name") or "Unknown")
             gg = _safe_int_hex(group_key)
+            group_single_namespace_key = _single_namespace_key(group_key, group_obj)
+            group_single_namespace_label = _namespace_label_for_key(group_single_namespace_key)
             namespace_views = _group_namespace_views(group_obj)
             if not namespace_views:
                 continue
@@ -313,7 +364,15 @@ class BrowseStore:
             )
 
             for namespace_key, namespace_label, instances in namespace_views:
-                namespace_display = _namespace_display_label(namespace_key, namespace_label)
+                effective_namespace_key = (
+                    namespace_key if namespace_key is not None else group_single_namespace_key
+                )
+                effective_namespace_label = (
+                    namespace_label if namespace_key is not None else group_single_namespace_label
+                )
+                namespace_display = _namespace_display_label(
+                    effective_namespace_key, effective_namespace_label
+                )
                 if namespace_key is not None and namespace_display is not None:
                     tree_nodes.append(
                         TreeNodeRef(
@@ -339,7 +398,7 @@ class BrowseStore:
                     # For instanced groups, list instances as the leaf nodes (do not expand to RR).
                     if is_instanced:
                         node_id = ":".join(
-                            ["b524", "inst", group_key, namespace_key or "single", instance_key]
+                            ["b524", "inst", group_key, effective_namespace_key, instance_key]
                         )
                         tree_nodes.append(
                             TreeNodeRef(
@@ -353,8 +412,8 @@ class BrowseStore:
                                 level="instance",
                                 protocol="b524",
                                 group_key=group_key,
-                                namespace_key=namespace_key,
-                                namespace_label=namespace_label,
+                                namespace_key=effective_namespace_key,
+                                namespace_label=effective_namespace_label,
                                 instance_key=instance_key,
                             )
                         )
@@ -376,15 +435,28 @@ class BrowseStore:
                         ebusd_name = str(entry.get("ebusd_name") or "").strip()
                         name = myvaillant_name or register_key
                         tab = _tab_from_entry(entry)
-                        entry_namespace_label = (
+                        entry_namespace_key = effective_namespace_key
+                        read_opcode = _normalize_opcode_hex(entry.get("read_opcode"))
+                        if read_opcode is not None:
+                            entry_namespace_key = read_opcode
+                        read_opcode_label = (
                             entry.get("read_opcode_label")
                             if isinstance(entry.get("read_opcode_label"), str)
-                            else namespace_label
+                            else None
                         )
+                        if read_opcode_label:
+                            entry_namespace_label = read_opcode_label
+                        elif (
+                            namespace_key is not None
+                            and entry_namespace_key == effective_namespace_key
+                        ):
+                            entry_namespace_label = effective_namespace_label
+                        else:
+                            entry_namespace_label = _namespace_label_for_key(entry_namespace_key)
                         address = RegisterAddress(
                             protocol="b524",
                             group_key=group_key,
-                            namespace_key=namespace_key,
+                            namespace_key=entry_namespace_key,
                             namespace_label=entry_namespace_label,
                             instance_key=instance_key,
                             register_key=register_key,
@@ -394,20 +466,23 @@ class BrowseStore:
                         )
                         value_text = _fmt_value(entry)
                         raw_hex = str(entry.get("raw_hex") or "")
+                        entry_namespace_display = _namespace_display_label(
+                            entry_namespace_key, entry_namespace_label
+                        )
                         path_parts = ["B524", group_name]
-                        if namespace_display is not None:
-                            path_parts.append(namespace_display)
+                        if entry_namespace_display is not None:
+                            path_parts.append(entry_namespace_display)
                         path_parts.extend([instance_key, name])
                         path = "/".join(path_parts)
                         row_id = ":".join(
-                            [group_key, namespace_key or "single", instance_key, register_key]
+                            [group_key, entry_namespace_key, instance_key, register_key]
                         )
                         access_flags = str(entry.get("flags_access") or "—")
                         row = RegisterRow(
                             row_id=row_id,
                             protocol="b524",
                             group_key=group_key,
-                            namespace_key=namespace_key,
+                            namespace_key=entry_namespace_key,
                             namespace_label=entry_namespace_label,
                             group_name=group_name,
                             instance_key=instance_key,

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -160,7 +160,9 @@ def _normalize_opcode_hex(value: object) -> str | None:
     return _hex_u8(opcode)
 
 
-def _namespace_label_for_key(namespace_key: str) -> str:
+def _namespace_label_for_key(namespace_key: str | None) -> str | None:
+    if namespace_key is None:
+        return None
     opcode = _safe_int_hex(namespace_key)
     if opcode == 0x02:
         return "local"
@@ -169,13 +171,36 @@ def _namespace_label_for_key(namespace_key: str) -> str:
     return namespace_key
 
 
-def _single_namespace_key(group_key: str, group_obj: dict[str, Any]) -> str:
+def _single_namespace_key(group_key: str, group_obj: dict[str, Any]) -> str | None:
     discovery_advisory = group_obj.get("discovery_advisory")
     if isinstance(discovery_advisory, dict):
         proven = discovery_advisory.get("proven_register_opcodes")
         if isinstance(proven, list):
             for opcode in proven:
                 normalized = _normalize_opcode_hex(opcode)
+                if normalized is not None:
+                    return normalized
+
+    instances = group_obj.get("instances")
+    if isinstance(instances, dict):
+        for instance_key in sorted(
+            (k for k in instances if isinstance(k, str)),
+            key=_safe_int_hex,
+        ):
+            instance_obj = instances.get(instance_key)
+            if not isinstance(instance_obj, dict):
+                continue
+            registers = instance_obj.get("registers")
+            if not isinstance(registers, dict):
+                continue
+            for register_key in sorted(
+                (k for k in registers if isinstance(k, str)),
+                key=_safe_int_hex,
+            ):
+                entry = registers.get(register_key)
+                if not isinstance(entry, dict):
+                    continue
+                normalized = _normalize_opcode_hex(entry.get("read_opcode"))
                 if normalized is not None:
                     return normalized
 
@@ -187,7 +212,27 @@ def _single_namespace_key(group_key: str, group_obj: dict[str, Any]) -> str:
             for opcode in opcodes:
                 if isinstance(opcode, int):
                     return _hex_u8(opcode)
-    return "0x00"
+    return None
+
+
+def _build_b524_instance_node_id(
+    *, group_key: str, namespace_key: str | None, instance_key: str
+) -> str:
+    parts = ["b524", "inst", group_key]
+    if namespace_key is not None:
+        parts.append(namespace_key)
+    parts.append(instance_key)
+    return ":".join(parts)
+
+
+def _build_b524_row_id(
+    *, group_key: str, namespace_key: str | None, instance_key: str, register_key: str
+) -> str:
+    parts = [group_key]
+    if namespace_key is not None:
+        parts.append(namespace_key)
+    parts.extend([instance_key, register_key])
+    return ":".join(parts)
 
 
 def _group_namespace_views(
@@ -397,8 +442,10 @@ class BrowseStore:
                         continue
                     # For instanced groups, list instances as the leaf nodes (do not expand to RR).
                     if is_instanced:
-                        node_id = ":".join(
-                            ["b524", "inst", group_key, effective_namespace_key, instance_key]
+                        node_id = _build_b524_instance_node_id(
+                            group_key=group_key,
+                            namespace_key=effective_namespace_key,
+                            instance_key=instance_key,
                         )
                         tree_nodes.append(
                             TreeNodeRef(
@@ -474,8 +521,11 @@ class BrowseStore:
                             path_parts.append(entry_namespace_display)
                         path_parts.extend([instance_key, name])
                         path = "/".join(path_parts)
-                        row_id = ":".join(
-                            [group_key, entry_namespace_key, instance_key, register_key]
+                        row_id = _build_b524_row_id(
+                            group_key=group_key,
+                            namespace_key=entry_namespace_key,
+                            instance_key=instance_key,
+                            register_key=register_key,
                         )
                         access_flags = str(entry.get("flags_access") or "—")
                         row = RegisterRow(
@@ -936,14 +986,22 @@ class BrowseStore:
             and node.group_key is not None
             and node.instance_key is not None
         ):
-            return [
+            by_group_instance = [
                 row
                 for row in selected
                 if row.protocol == "b524"
                 and row.group_key == node.group_key
-                and row.namespace_key == node.namespace_key
                 and row.instance_key == node.instance_key
             ]
+            has_namespace_nodes = any(
+                tree.level == "namespace"
+                and tree.protocol == "b524"
+                and tree.group_key == node.group_key
+                for tree in self.tree_nodes
+            )
+            if node.namespace_key is None or not has_namespace_nodes:
+                return by_group_instance
+            return [row for row in by_group_instance if row.namespace_key == node.namespace_key]
         if node.level == "range" and node.protocol == "b509" and node.range_key is not None:
             parsed = _parse_range_key(node.range_key)
             if parsed is None:

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -735,7 +735,7 @@ __ARTIFACT_JSON__
       }
 
       function namespaceLabel(namespaceKey, label) {
-        const raw = typeof label === "string" && label ? label : (namespaceKey || "single");
+        const raw = typeof label === "string" && label ? label : (namespaceKey || "0x00");
         if (!namespaceKey) return raw;
         if (raw.startsWith("0x")) return raw;
         return `${raw.charAt(0).toUpperCase()}${raw.slice(1)} (${namespaceKey})`;
@@ -886,7 +886,7 @@ __ARTIFACT_JSON__
               if (!entry || typeof entry !== "object") continue;
               const label = typeof entry.read_opcode_label === "string" && entry.read_opcode_label
                 ? entry.read_opcode_label
-                : (typeof entry.read_opcode === "string" && entry.read_opcode ? entry.read_opcode : "single");
+                : (typeof entry.read_opcode === "string" && entry.read_opcode ? entry.read_opcode : "0x00");
               totalRegisters += 1;
               totals.set(label, (totals.get(label) || 0) + 1);
             }

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -734,8 +734,18 @@ __ARTIFACT_JSON__
         state.overrides[groupKey][rrKey] = typeSpec;
       }
 
+      function normalizeOpcodeKey(opcodeRaw) {
+        if (typeof opcodeRaw !== "string") return null;
+        const trimmed = opcodeRaw.trim();
+        if (!trimmed) return null;
+        const parsed = Number(trimmed);
+        if (!Number.isInteger(parsed) || parsed < 0 || parsed > 0xff) return null;
+        return `0x${parsed.toString(16).padStart(2, "0")}`;
+      }
+
       function namespaceLabel(namespaceKey, label) {
-        const raw = typeof label === "string" && label ? label : (namespaceKey || "0x00");
+        const raw = typeof label === "string" && label ? label : namespaceKey;
+        if (!raw) return "";
         if (!namespaceKey) return raw;
         if (raw.startsWith("0x")) return raw;
         return `${raw.charAt(0).toUpperCase()}${raw.slice(1)} (${namespaceKey})`;
@@ -879,19 +889,18 @@ __ARTIFACT_JSON__
           }
 
           const instances = groupObj.instances && typeof groupObj.instances === "object" ? groupObj.instances : {};
-          for (const instanceObj of Object.values(instances)) {
-            if (!instanceObj || typeof instanceObj !== "object") continue;
-            const registers = instanceObj.registers && typeof instanceObj.registers === "object" ? instanceObj.registers : {};
-            for (const entry of Object.values(registers)) {
-              if (!entry || typeof entry !== "object") continue;
-              const label = typeof entry.read_opcode_label === "string" && entry.read_opcode_label
-                ? entry.read_opcode_label
-                : (typeof entry.read_opcode === "string" && entry.read_opcode ? entry.read_opcode : "0x00");
-              totalRegisters += 1;
-              totals.set(label, (totals.get(label) || 0) + 1);
+            for (const instanceObj of Object.values(instances)) {
+              if (!instanceObj || typeof instanceObj !== "object") continue;
+              const registers = instanceObj.registers && typeof instanceObj.registers === "object" ? instanceObj.registers : {};
+              for (const entry of Object.values(registers)) {
+                if (!entry || typeof entry !== "object") continue;
+                const label = normalizeOpcodeKey(entry.read_opcode) || normalizeOpcodeKey(entry.read_opcode_label);
+                if (!label) continue;
+                totalRegisters += 1;
+                totals.set(label, (totals.get(label) || 0) + 1);
+              }
             }
           }
-        }
 
         const chips = [["total", totalRegisters], ...Array.from(totals.entries())];
         for (const [label, count] of chips) {

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -153,10 +153,10 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 for entry in registers.values():
                     if not isinstance(entry, dict):
                         continue
-                    namespace_label = _namespace_label_from_entry(entry)
-                    if namespace_label is not None:
-                        namespace_registers[namespace_label] = (
-                            namespace_registers.get(namespace_label, 0) + 1
+                    namespace_label_opt = _namespace_label_from_entry(entry)
+                    if namespace_label_opt is not None:
+                        namespace_registers[namespace_label_opt] = (
+                            namespace_registers.get(namespace_label_opt, 0) + 1
                         )
                     if entry.get("error") is not None:
                         registers_errors += 1

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -65,13 +65,19 @@ def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]
 
 
 def _namespace_label_from_entry(entry: dict[str, Any]) -> str:
+    opcode = entry.get("read_opcode")
+    if isinstance(opcode, str) and opcode.strip():
+        try:
+            parsed = int(opcode.strip(), 0)
+        except ValueError:
+            pass
+        else:
+            if 0 <= parsed <= 0xFF:
+                return f"0x{parsed:02x}"
     label = entry.get("read_opcode_label")
     if isinstance(label, str) and label.strip():
         return label.strip()
-    opcode = entry.get("read_opcode")
-    if isinstance(opcode, str) and opcode.strip():
-        return opcode.strip()
-    return "single"
+    return "0x00"
 
 
 def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -64,20 +64,17 @@ def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]
                     yield entry
 
 
-def _namespace_label_from_entry(entry: dict[str, Any]) -> str:
-    opcode = entry.get("read_opcode")
-    if isinstance(opcode, str) and opcode.strip():
+def _namespace_label_from_entry(entry: dict[str, Any]) -> str | None:
+    for raw in (entry.get("read_opcode"), entry.get("read_opcode_label")):
+        if not isinstance(raw, str) or not raw.strip():
+            continue
         try:
-            parsed = int(opcode.strip(), 0)
+            parsed = int(raw.strip(), 0)
         except ValueError:
-            pass
-        else:
-            if 0 <= parsed <= 0xFF:
-                return f"0x{parsed:02x}"
-    label = entry.get("read_opcode_label")
-    if isinstance(label, str) and label.strip():
-        return label.strip()
-    return "0x00"
+            continue
+        if 0 <= parsed <= 0xFF:
+            return f"0x{parsed:02x}"
+    return None
 
 
 def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
@@ -157,9 +154,10 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                     if not isinstance(entry, dict):
                         continue
                     namespace_label = _namespace_label_from_entry(entry)
-                    namespace_registers[namespace_label] = (
-                        namespace_registers.get(namespace_label, 0) + 1
-                    )
+                    if namespace_label is not None:
+                        namespace_registers[namespace_label] = (
+                            namespace_registers.get(namespace_label, 0) + 1
+                        )
                     if entry.get("error") is not None:
                         registers_errors += 1
 
@@ -184,6 +182,8 @@ def _compute_namespace_totals(artifact: dict[str, Any]) -> dict[str, int]:
     totals: dict[str, int] = {}
     for entry in _iter_register_entries(artifact):
         label = _namespace_label_from_entry(entry)
+        if label is None:
+            continue
         totals[label] = totals.get(label, 0) + 1
     return dict(sorted(totals.items()))
 

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -170,8 +170,9 @@ def test_browse_store_single_namespace_instance_node_uses_opcode_identity() -> N
     )
 
 
-def test_browse_store_instance_selection_keeps_mixed_opcode_rows_in_single_namespace_group(
-) -> None:
+def test_browse_store_instance_selection_keeps_mixed_opcode_rows_in_single_namespace_group() -> (
+    None
+):
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
         "groups": {

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -115,6 +115,11 @@ def test_browse_store_builds_rows_and_left_tree_uses_only_myvaillant_name() -> N
     assert by_register["0x0002"].myvaillant_name == "limit_value"
     assert by_register["0x0002"].ebusd_name == ""
     assert by_register["0x0001"].access_flags == "user_rw"
+    assert by_register["0x0001"].row_id == "0x00:0x02:0x00:0x0001"
+    assert by_register["0x0002"].row_id == "0x00:0x06:0x00:0x0002"
+    assert by_register["0x0001"].path == "B524/Regulator Parameters/Local (0x02)/0x00/0x0001"
+    assert by_register["0x0002"].path == "B524/Regulator Parameters/Remote (0x06)/0x00/limit_value"
+    assert all(":single:" not in row.row_id for row in store.rows if row.protocol == "b524")
 
     by_node_id = {node.node_id: node for node in store.tree_nodes}
     assert by_node_id["proto:b524"].label == "B524"
@@ -133,6 +138,36 @@ def test_browse_store_filters_rows_for_tree_selection() -> None:
     assert len(store.rows_for_selection(protocol_node, tab="config")) == 1
     assert len(store.rows_for_selection(group_node, tab="config_limits")) == 1
     assert len(store.rows_for_selection(group_node, tab="state")) == 1
+
+
+def test_browse_store_single_namespace_instance_node_uses_opcode_identity() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0002": {
+                                "value": 1,
+                                "raw_hex": "0100",
+                                "flags_access": "stable_ro",
+                                "read_opcode": "0x02",
+                            }
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    by_node_id = {node.node_id: node for node in store.tree_nodes}
+    assert "b524:inst:0x02:0x02:0x00" in by_node_id
+    assert not any(
+        ":single:" in node.node_id for node in store.tree_nodes if node.protocol == "b524"
+    )
 
 
 def test_browse_store_builds_namespace_nodes_for_dual_namespace_groups() -> None:

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -170,6 +170,47 @@ def test_browse_store_single_namespace_instance_node_uses_opcode_identity() -> N
     )
 
 
+def test_browse_store_instance_selection_keeps_mixed_opcode_rows_in_single_namespace_group(
+) -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {
+                                "value": 1,
+                                "raw_hex": "01",
+                                "flags_access": "stable_ro",
+                                "read_opcode": "0x02",
+                            },
+                            "0x0002": {
+                                "value": 2,
+                                "raw_hex": "02",
+                                "flags_access": "stable_ro",
+                                "read_opcode": "0x06",
+                            },
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    instance_node = next(
+        node for node in store.tree_nodes if node.node_id == "b524:inst:0x02:0x02:0x00"
+    )
+
+    rows = store.rows_for_selection(instance_node, tab="state")
+    assert {(row.register_key, row.namespace_key) for row in rows} == {
+        ("0x0001", "0x02"),
+        ("0x0002", "0x06"),
+    }
+
+
 def test_browse_store_builds_namespace_nodes_for_dual_namespace_groups() -> None:
     store = BrowseStore.from_artifact(_dual_namespace_artifact())
 

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -271,3 +271,31 @@ def test_html_report_renders_identity_card_with_star_bold_markers() -> None:
     assert "<strong>BA</strong>se" in html
     assert "<strong>S</strong>tation" in html
     assert "<strong>V</strong>aillant-branded Revision <strong>2</strong>" in html
+
+
+def test_html_report_does_not_use_single_namespace_identity_sentinel() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {
+            "0x00": {
+                "name": "Regulator Parameters",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {
+                                "raw_hex": "00",
+                                "value": 1,
+                                "error": None,
+                                "flags_access": "stable_ro",
+                                "read_opcode": "0x02",
+                            }
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+    assert 'namespaceKey || "single"' not in html
+    assert '|| "single"' not in html

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -299,3 +299,5 @@ def test_html_report_does_not_use_single_namespace_identity_sentinel() -> None:
     html = render_html_report(artifact, title="test")
     assert 'namespaceKey || "single"' not in html
     assert '|| "single"' not in html
+    assert 'namespaceKey || "0x00"' not in html
+    assert ': "0x00"' not in html

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -778,7 +778,13 @@ def test_scan_singleton_group_nonzero_descriptor(tmp_path: Path) -> None:
     assert "descriptor_mismatch" not in group["discovery_advisory"]
     assert group["discovery_advisory"]["proven_register_opcodes"] == ["0x02"]
     assert set(group["instances"]) == {"0x00"}
-    assert artifact["meta"]["scan_plan"]["groups"]["0x00"]["instances"] == ["0x00"]
+    plan = artifact["meta"]["scan_plan"]["groups"]["0x00"]
+    assert plan["instances"] == ["0x00"]
+    assert plan["dual_namespace"] is False
+    assert plan["namespace_key"] == "0x02"
+    assert plan["label"] == "local"
+    assert plan["namespace_identity_keys"] == "opcode_hex"
+    assert set(plan["namespaces"]) == {"0x02"}
 
     scanned_instances = {ii for (_opcode, gg, ii, _rr) in transport.register_reads if gg == 0x00}
     assert scanned_instances == {0x00}
@@ -788,6 +794,15 @@ def test_artifact_schema_version(tmp_path: Path) -> None:
     artifact = scan_b524(DummyTransport(_write_fixture_group_00(tmp_path)), dst=0x15)
 
     assert artifact["schema_version"] == "2.0"
+    contract = artifact["meta"]["artifact_contract"]
+    assert contract["namespace_identity_keys"] == "opcode_hex"
+    assert contract["namespace_labels"] == "presentation_only"
+    assert "dual_namespace" in contract["topology_authority"]
+    assert (
+        contract["b524_row_identity"]["dedupe_key_format"]
+        == "<group>:<namespace>:<instance>:<register>"
+    )
+    assert "round_trip_stability" in contract["b524_row_identity"]
 
 
 def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -83,7 +83,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     render_summary(console, artifact, output_path=tmp_path / "artifact.json")
 
     text = console.export_text()
-    assert "namespaces local=2, remote=1" in text
+    assert "namespaces 0x02=2, 0x06=1" in text
     assert "flags_access volatile_ro=0, stable_ro=2, technical_rw=0, user_rw=1" in text
     assert "b555 reads=4 errors=1 programs=2" in text
     assert "local=1, remote=1" in text


### PR DESCRIPTION
## What
Define and enforce a canonical namespace-aware B524 artifact model where namespace identity keys are opcode hex values and presentation labels remain metadata.

## Why
Issue #204 requires artifact identity to be unambiguous for browse/report/fixture consumers and to prevent GG-centric or sentinel-based identity leakage.

## Changes
- Canonicalized B524 single-namespace browse identities to carry opcode namespace keys (no `single` sentinel row/node IDs).
- Added explicit artifact contract metadata under `meta.artifact_contract` (topology authority, dedupe key format, path format, round-trip stability).
- Enriched scan-plan metadata for single-namespace groups with namespace identity (`namespace_key`, `label`, `dual_namespace`, `namespaces`).
- Removed `single` namespace fallback sentinel in HTML report and summary namespace aggregation paths.
- Extended namespace guardrail script to block sentinel fallbacks.
- Updated README contract bullets and added targeted tests for identity/path behavior and sentinel absence.

## Acceptance Criteria
- [x] Artifact identity keys use opcode hex values as namespace keys; labels remain presentation-only metadata.
- [x] No B524 artifact output contains the sentinel `single` in row IDs or namespace identity keys.
- [x] Plan metadata and row/path identifiers carry namespace-aware identity for single-namespace groups.
- [x] Artifact contract states persisted `dual_namespace` topology is authoritative for consumers.
- [x] Model is explicit about dedupe rules, path format, and round-trip stability.

## Validation
- `PYTHONPATH=src uv run pytest tests/test_browse_store.py tests/test_scanner_scan.py tests/test_html_report.py tests/test_scanner_plan.py tests/test_scanner_identity.py`
- `uv run ruff check src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/summary.py tests/test_browse_store.py tests/test_scanner_scan.py tests/test_html_report.py scripts/check_b524_namespace_guardrails.py`
- `python3 scripts/check_b524_namespace_guardrails.py`

## Agent State
Status: ready for review
Branch: issue/204-b524-canonical-namespace-aware-artifact-model
Last verified (lint/tests): ruff + targeted pytest + guardrail script passed on 2026-04-04
How to reproduce: run the validation commands listed above
Next steps: reviewer/tester pass, then squash-merge into `wip/b524-opcode-namespace-split-integration`
Notes (no secrets, no private infra): local workspace had unrelated pre-existing modifications (`AGENTS.md`, local untracked dirs/files) left untouched

Closes #204