### PR TITLE
Issue #205: version namespace-aware artifacts and migrate fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Transport note:
 - Canonical namespace identity is always an opcode hex key (`0x02`, `0x06`, ...). Labels like `local`/`remote` are presentation metadata only.
 - Persisted `groups[*].dual_namespace` topology is authoritative for consumers. Do not infer or rewrite namespace shape from descriptors.
 - B524 browse/report row identity is namespace-aware even for single-namespace groups: dedupe key `<group>:<namespace>:<instance>:<register>` and path format `B524/<group-name>/<namespace-display>/<instance>/<register-name>` are round-trip stable.
+- Artifact schema contract is versioned (`schema_version: "2.1"` current). Readers keep backward compatibility by migrating unversioned and `2.0` artifacts in-memory.
 - CI enforces these rules with `python scripts/check_b524_namespace_guardrails.py`.
 
 Constraint note:

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -7,8 +7,19 @@ This directory contains **scan artifact fixtures** used for deterministic, offli
 
 A fixture is a JSON object with:
 
+- `schema_version`: Artifact schema version. Current: `2.1`.
 - `meta`: arbitrary metadata about the scan (timestamps, device info, etc.).
 - `groups`: mapping of group id -> group data.
+
+## Schema Compatibility Strategy
+
+- Writers emit `schema_version: "2.1"` (namespace-aware contract).
+- Readers support legacy artifacts by in-memory migration:
+  - unversioned fixtures (no `schema_version`)
+  - `schema_version: "2.0"`
+- Migration preserves register counts and register payload entries; no registers are dropped or
+  synthesized during migration.
+- Checked-in fixtures in this repository are migrated to `2.1` in lockstep.
 
 ### `groups`
 
@@ -43,10 +54,12 @@ Each register entry contains:
 
 ```json
 {
+  "schema_version": "2.1",
   "meta": {},
   "groups": {
     "0x02": {
       "descriptor_type": 1.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "registers": {

--- a/fixtures/demo_browse.json
+++ b/fixtures/demo_browse.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "2.1",
   "meta": {
     "destination_address": "0x15",
     "device_info": {
@@ -22,7 +23,8 @@
   },
   "groups": {
     "0x00": {
-      "descriptor_type": 3.0,
+      "descriptor_observed": 3.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "present": true,
@@ -61,7 +63,7 @@
               "flags": 3,
               "flags_access": "user_rw",
               "type": "HDA:3",
-              "value": "2013-01-01"
+              "value": "2019-01-01"
             }
           }
         }
@@ -69,7 +71,8 @@
       "name": "Regulator Parameters"
     },
     "0x01": {
-      "descriptor_type": 3.0,
+      "descriptor_observed": 3.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "present": true,
@@ -116,7 +119,8 @@
       "name": "Hot Water Circuit"
     },
     "0x02": {
-      "descriptor_type": 1.0,
+      "descriptor_observed": 1.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "present": true,
@@ -163,7 +167,8 @@
       "name": "Heating Circuits"
     },
     "0x03": {
-      "descriptor_type": 1.0,
+      "descriptor_observed": 1.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "present": true,

--- a/fixtures/dual_namespace_scan.json
+++ b/fixtures/dual_namespace_scan.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.0",
+  "schema_version": "2.1",
   "meta": {
     "destination_address": "0x15",
     "scan_timestamp": "2026-03-08T00:00:00Z",
@@ -11,6 +11,7 @@
     "0x00": {
       "name": "Regulator Parameters",
       "descriptor_observed": 3.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "present": true,
@@ -131,6 +132,7 @@
     "0x0C": {
       "name": "Remote Accessories / FM5 Slots",
       "descriptor_observed": 1.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "present": true,

--- a/fixtures/vrc720_full_scan.json
+++ b/fixtures/vrc720_full_scan.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "2.1",
   "meta": {
     "scan_timestamp": "1970-01-01T00:00:00Z",
     "scan_duration_seconds": 0.0,
@@ -20,7 +21,8 @@
   },
   "groups": {
     "0x02": {
-      "descriptor_type": 1.0,
+      "descriptor_observed": 1.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "registers": {

--- a/scripts/validate_artifact.py
+++ b/scripts/validate_artifact.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from helianthus_vrc_explorer.artifact_schema import (
+    LEGACY_VERSIONED_SCHEMAS,
     LEGACY_UNVERSIONED_SCHEMA,
     ArtifactSchemaError,
     count_register_entries,
@@ -92,6 +93,12 @@ def validate_scan_artifact(
     source_schema_version = detect_schema_version(artifact)
     if not allow_legacy and source_schema_version == LEGACY_UNVERSIONED_SCHEMA:
         errors.append("schema_version: legacy unversioned artifact rejected (--reject-legacy)")
+        return errors, artifact, source_schema_version
+    if not allow_legacy and source_schema_version in LEGACY_VERSIONED_SCHEMAS:
+        errors.append(
+            "schema_version: legacy versioned artifact "
+            f"{source_schema_version!r} rejected (--reject-legacy)"
+        )
         return errors, artifact, source_schema_version
 
     try:

--- a/scripts/validate_artifact.py
+++ b/scripts/validate_artifact.py
@@ -7,6 +7,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from helianthus_vrc_explorer.artifact_schema import (
+    LEGACY_UNVERSIONED_SCHEMA,
+    ArtifactSchemaError,
+    count_register_entries,
+    detect_schema_version,
+    iter_register_entries,
+    migrate_artifact_schema,
+)
 from helianthus_vrc_explorer.protocol.parser import ValueParseError, parse_typed_value
 
 
@@ -17,33 +25,86 @@ def _parse_hex_key(key: str) -> int | None:
         return None
 
 
-def _iter_register_entries(artifact: dict[str, Any]):
+def _normalize_opcode_hex(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        opcode = int(raw, 0)
+    except ValueError:
+        return None
+    if not (0x00 <= opcode <= 0xFF):
+        return None
+    return f"0x{opcode:02x}"
+
+
+def _validate_schema_shape(artifact: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
     groups = artifact.get("groups")
     if not isinstance(groups, dict):
-        return
+        return ['groups: missing required top-level object "groups"']
+
     for group_key, group_obj in groups.items():
         if not isinstance(group_key, str) or not isinstance(group_obj, dict):
+            errors.append(f"{group_key!r}: group entry must be an object keyed by hex string")
             continue
-        instances = group_obj.get("instances")
-        if not isinstance(instances, dict):
+
+        descriptor_observed = group_obj.get("descriptor_observed")
+        descriptor_type = group_obj.get("descriptor_type")
+        if not isinstance(descriptor_observed, (int, float)) and not isinstance(
+            descriptor_type, (int, float)
+        ):
+            errors.append(
+                f"{group_key}: expected numeric descriptor_observed (or descriptor_type for legacy)"
+            )
+
+        dual_namespace = group_obj.get("dual_namespace")
+        if not isinstance(dual_namespace, bool):
+            errors.append(f"{group_key}: missing required boolean dual_namespace")
             continue
-        for instance_key, instance_obj in instances.items():
-            if not isinstance(instance_key, str) or not isinstance(instance_obj, dict):
-                continue
-            registers = instance_obj.get("registers")
-            if not isinstance(registers, dict):
-                continue
-            for rr_key, entry in registers.items():
-                if not isinstance(rr_key, str) or not isinstance(entry, dict):
-                    continue
-                yield group_key, instance_key, rr_key, entry
+
+        has_namespaces = isinstance(group_obj.get("namespaces"), dict)
+        has_instances = isinstance(group_obj.get("instances"), dict)
+
+        if dual_namespace:
+            if not has_namespaces:
+                errors.append(f"{group_key}: dual_namespace=true requires namespaces object")
+            if has_instances:
+                errors.append(f"{group_key}: dual_namespace=true must not include flat instances")
+            continue
+
+        if has_namespaces:
+            errors.append(f"{group_key}: dual_namespace=false must not include namespaces")
+        if not has_instances:
+            errors.append(f"{group_key}: dual_namespace=false requires instances object")
+
+    return errors
 
 
-def validate_scan_artifact(artifact: dict[str, Any]) -> list[str]:
+def validate_scan_artifact(
+    artifact: dict[str, Any],
+    *,
+    allow_legacy: bool,
+) -> tuple[list[str], dict[str, Any], str]:
     errors: list[str] = []
+    source_schema_version = detect_schema_version(artifact)
+    if not allow_legacy and source_schema_version == LEGACY_UNVERSIONED_SCHEMA:
+        errors.append("schema_version: legacy unversioned artifact rejected (--reject-legacy)")
+        return errors, artifact, source_schema_version
 
-    for group_key, instance_key, rr_key, entry in _iter_register_entries(artifact):
-        loc = f"{group_key}/{instance_key}/{rr_key}"
+    try:
+        migrated, _migration = migrate_artifact_schema(artifact)
+    except ArtifactSchemaError as exc:
+        errors.append(f"schema_version: {exc}")
+        return errors, artifact, source_schema_version
+
+    errors.extend(_validate_schema_shape(migrated))
+
+    for group_key, namespace_key, instance_key, rr_key, entry in iter_register_entries(migrated):
+        namespace_loc = namespace_key if namespace_key is not None else "flat"
+        loc = f"{group_key}/{namespace_loc}/{instance_key}/{rr_key}"
         gg = _parse_hex_key(group_key)
         rr = _parse_hex_key(rr_key)
         if gg is None:
@@ -52,6 +113,17 @@ def validate_scan_artifact(artifact: dict[str, Any]) -> list[str]:
         if rr is None:
             errors.append(f"{loc}: invalid register key")
             continue
+
+        if namespace_key is not None:
+            namespace_opcode = _normalize_opcode_hex(namespace_key)
+            if namespace_opcode is None:
+                errors.append(f"{loc}: invalid namespace key")
+                continue
+            read_opcode = _normalize_opcode_hex(entry.get("read_opcode"))
+            if read_opcode is not None and read_opcode != namespace_opcode:
+                errors.append(
+                    f"{loc}: read_opcode {read_opcode} does not match namespace {namespace_opcode}"
+                )
 
         reply_hex = entry.get("reply_hex")
         raw_hex = entry.get("raw_hex")
@@ -116,15 +188,25 @@ def validate_scan_artifact(artifact: dict[str, Any]) -> list[str]:
                     f"{loc}: value mismatch type={type_spec} expected={parsed!r} got={value!r}"
                 )
 
-    return errors
+    return errors, migrated, source_schema_version
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 2 or argv[1] in {"-h", "--help"}:
-        print("Usage: validate_artifact.py <artifact.json>", file=sys.stderr)
+    args = argv[1:]
+    if not args or args[0] in {"-h", "--help"}:
+        print("Usage: validate_artifact.py [--reject-legacy] <artifact.json>", file=sys.stderr)
         return 2
 
-    path = Path(argv[1])
+    reject_legacy = False
+    if args and args[0] == "--reject-legacy":
+        reject_legacy = True
+        args = args[1:]
+
+    if len(args) != 1:
+        print("Usage: validate_artifact.py [--reject-legacy] <artifact.json>", file=sys.stderr)
+        return 2
+
+    path = Path(args[0])
     try:
         artifact = json.loads(path.read_text(encoding="utf-8"))
     except OSError as exc:
@@ -138,7 +220,10 @@ def main(argv: list[str]) -> int:
         print("Invalid artifact root (expected JSON object).", file=sys.stderr)
         return 2
 
-    errors = validate_scan_artifact(artifact)
+    errors, migrated, source_schema_version = validate_scan_artifact(
+        artifact,
+        allow_legacy=not reject_legacy,
+    )
     if errors:
         for line in errors[:50]:
             print(line, file=sys.stderr)
@@ -146,7 +231,13 @@ def main(argv: list[str]) -> int:
             print(f"... ({len(errors) - 50} more)", file=sys.stderr)
         return 1
 
-    print(f"OK: validated artifact ({path.name})")
+    suffix = ""
+    if source_schema_version != str(migrated.get("schema_version")):
+        suffix = (
+            f"; migrated in-memory {source_schema_version} -> {migrated.get('schema_version')} "
+            f"(registers={count_register_entries(migrated)})"
+        )
+    print(f"OK: validated artifact ({path.name}{suffix})")
     return 0
 
 

--- a/scripts/validate_artifact.py
+++ b/scripts/validate_artifact.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import Any
 
 from helianthus_vrc_explorer.artifact_schema import (
-    LEGACY_VERSIONED_SCHEMAS,
     LEGACY_UNVERSIONED_SCHEMA,
+    LEGACY_VERSIONED_SCHEMAS,
     ArtifactSchemaError,
     count_register_entries,
     detect_schema_version,

--- a/src/helianthus_vrc_explorer/artifact_schema.py
+++ b/src/helianthus_vrc_explorer/artifact_schema.py
@@ -47,7 +47,7 @@ def iter_register_entries(
             continue
 
         namespaces = group_obj.get("namespaces")
-        if isinstance(namespaces, dict):
+        if isinstance(namespaces, dict) and namespaces:
             for namespace_key, namespace_obj in namespaces.items():
                 if not isinstance(namespace_key, str) or not isinstance(namespace_obj, dict):
                     continue
@@ -90,6 +90,15 @@ def _migrate_group(group_obj: dict[str, Any]) -> bool:
 
     namespaces = group_obj.get("namespaces")
     has_namespaces = isinstance(namespaces, dict)
+    instances = group_obj.get("instances")
+    has_instances = isinstance(instances, dict)
+
+    # Legacy artifacts can contain an empty namespaces object plus populated flat instances.
+    # Keep flat instances canonical in this shape so namespace-first readers do not drop data.
+    if has_namespaces and not namespaces and has_instances and instances:
+        group_obj.pop("namespaces", None)
+        has_namespaces = False
+        changed = True
 
     dual_namespace = group_obj.get("dual_namespace")
     if not isinstance(dual_namespace, bool):

--- a/src/helianthus_vrc_explorer/artifact_schema.py
+++ b/src/helianthus_vrc_explorer/artifact_schema.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+CURRENT_ARTIFACT_SCHEMA_VERSION = "2.1"
+LEGACY_UNVERSIONED_SCHEMA = "legacy-unversioned"
+LEGACY_VERSIONED_SCHEMAS = frozenset({"2.0"})
+
+
+class ArtifactSchemaError(ValueError):
+    """Raised when an artifact schema version is unsupported or malformed."""
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactMigrationReport:
+    source_schema_version: str
+    target_schema_version: str
+    changed: bool
+    register_count_before: int
+    register_count_after: int
+
+
+def _normalize_schema_version(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized if normalized else None
+
+
+def detect_schema_version(artifact: dict[str, Any]) -> str:
+    normalized = _normalize_schema_version(artifact.get("schema_version"))
+    if normalized is None:
+        return LEGACY_UNVERSIONED_SCHEMA
+    return normalized
+
+
+def iter_register_entries(
+    artifact: dict[str, Any],
+):
+    groups = artifact.get("groups")
+    if not isinstance(groups, dict):
+        return
+    for group_key, group_obj in groups.items():
+        if not isinstance(group_key, str) or not isinstance(group_obj, dict):
+            continue
+
+        namespaces = group_obj.get("namespaces")
+        if isinstance(namespaces, dict):
+            for namespace_key, namespace_obj in namespaces.items():
+                if not isinstance(namespace_key, str) or not isinstance(namespace_obj, dict):
+                    continue
+                instances = namespace_obj.get("instances")
+                if not isinstance(instances, dict):
+                    continue
+                for instance_key, instance_obj in instances.items():
+                    if not isinstance(instance_key, str) or not isinstance(instance_obj, dict):
+                        continue
+                    registers = instance_obj.get("registers")
+                    if not isinstance(registers, dict):
+                        continue
+                    for register_key, entry in registers.items():
+                        if not isinstance(register_key, str) or not isinstance(entry, dict):
+                            continue
+                        yield group_key, namespace_key, instance_key, register_key, entry
+            continue
+
+        instances = group_obj.get("instances")
+        if not isinstance(instances, dict):
+            continue
+        for instance_key, instance_obj in instances.items():
+            if not isinstance(instance_key, str) or not isinstance(instance_obj, dict):
+                continue
+            registers = instance_obj.get("registers")
+            if not isinstance(registers, dict):
+                continue
+            for register_key, entry in registers.items():
+                if not isinstance(register_key, str) or not isinstance(entry, dict):
+                    continue
+                yield group_key, None, instance_key, register_key, entry
+
+
+def count_register_entries(artifact: dict[str, Any]) -> int:
+    return sum(1 for _ in iter_register_entries(artifact))
+
+
+def _migrate_group(group_obj: dict[str, Any]) -> bool:
+    changed = False
+
+    namespaces = group_obj.get("namespaces")
+    has_namespaces = isinstance(namespaces, dict)
+
+    dual_namespace = group_obj.get("dual_namespace")
+    if not isinstance(dual_namespace, bool):
+        group_obj["dual_namespace"] = has_namespaces
+        changed = True
+
+    descriptor_observed = group_obj.get("descriptor_observed")
+    if descriptor_observed is None:
+        descriptor_type = group_obj.get("descriptor_type")
+        if isinstance(descriptor_type, (int, float)) and not isinstance(descriptor_type, bool):
+            group_obj["descriptor_observed"] = float(descriptor_type)
+            changed = True
+
+    return changed
+
+
+def migrate_artifact_schema(
+    artifact: dict[str, Any],
+) -> tuple[dict[str, Any], ArtifactMigrationReport]:
+    if not isinstance(artifact, dict):
+        raise ArtifactSchemaError("Artifact root must be a JSON object.")
+
+    source_schema_version = detect_schema_version(artifact)
+    if source_schema_version not in {
+        LEGACY_UNVERSIONED_SCHEMA,
+        CURRENT_ARTIFACT_SCHEMA_VERSION,
+        *LEGACY_VERSIONED_SCHEMAS,
+    }:
+        raise ArtifactSchemaError(
+            "Unsupported schema_version "
+            f"{source_schema_version!r}; supported: {CURRENT_ARTIFACT_SCHEMA_VERSION}, "
+            f"{', '.join(sorted(LEGACY_VERSIONED_SCHEMAS))}, or omitted legacy version."
+        )
+
+    migrated = deepcopy(artifact)
+    register_count_before = count_register_entries(migrated)
+    changed = False
+
+    if source_schema_version in {LEGACY_UNVERSIONED_SCHEMA, *LEGACY_VERSIONED_SCHEMAS}:
+        migrated["schema_version"] = CURRENT_ARTIFACT_SCHEMA_VERSION
+        changed = True
+        groups = migrated.get("groups")
+        if isinstance(groups, dict):
+            for group_obj in groups.values():
+                if isinstance(group_obj, dict):
+                    changed = _migrate_group(group_obj) or changed
+
+    register_count_after = count_register_entries(migrated)
+    if register_count_before != register_count_after:
+        raise ArtifactSchemaError(
+            "Artifact migration changed register count "
+            f"({register_count_before} -> {register_count_after})."
+        )
+
+    report = ArtifactMigrationReport(
+        source_schema_version=source_schema_version,
+        target_schema_version=CURRENT_ARTIFACT_SCHEMA_VERSION,
+        changed=changed,
+        register_count_before=register_count_before,
+        register_count_after=register_count_after,
+    )
+    return migrated, report

--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from rich.text import Text
 
 from . import __version__
+from .artifact_schema import ArtifactSchemaError, migrate_artifact_schema
 from .ebusd import parse_ebusd_info_target_addresses
 from .protocol.b524 import build_directory_probe_payload
 from .protocol.basv import (
@@ -774,6 +775,12 @@ def scan(
             origin = fixture_source or "vrc720_full_scan.json"
             typer.echo(f"Invalid JSON fixture: {origin} ({exc})", err=True)
             raise typer.Exit(2) from exc
+        try:
+            artifact, _migration = migrate_artifact_schema(artifact)
+        except ArtifactSchemaError as exc:
+            origin = fixture_source or "vrc720_full_scan.json"
+            typer.echo(f"Unsupported dry-run fixture schema: {origin} ({exc})", err=True)
+            raise typer.Exit(2) from exc
         preface = _build_scan_session_preface(
             dst=dst_u8,
             endpoint="n/a (dry-run fixture)",
@@ -1128,6 +1135,11 @@ def browse(
     if not isinstance(artifact, dict):
         typer.echo(f"Invalid artifact root object: {file}", err=True)
         raise typer.Exit(2)
+    try:
+        artifact, _migration = migrate_artifact_schema(artifact)
+    except ArtifactSchemaError as exc:
+        typer.echo(f"Unsupported artifact schema: {file} ({exc})", err=True)
+        raise typer.Exit(2) from exc
 
     if not Console().is_terminal:
         console = Console(stderr=True)

--- a/src/helianthus_vrc_explorer/fixtures/vrc720_full_scan.json
+++ b/src/helianthus_vrc_explorer/fixtures/vrc720_full_scan.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "2.1",
   "meta": {
     "scan_timestamp": "1970-01-01T00:00:00Z",
     "scan_duration_seconds": 0.0,
@@ -20,7 +21,8 @@
   },
   "groups": {
     "0x02": {
-      "descriptor_type": 1.0,
+      "descriptor_observed": 1.0,
+      "dual_namespace": false,
       "instances": {
         "0x00": {
           "registers": {

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, cast
 
 from rich.console import Console
 
+from ..artifact_schema import CURRENT_ARTIFACT_SCHEMA_VERSION
 from ..protocol.b524 import RegisterOpcode, build_constraint_probe_payload
 from ..schema.b524_constraints import (
     CONSTRAINT_SCOPE_DECISION,
@@ -1112,7 +1113,7 @@ def scan_b524(
     transport = counting_transport
 
     artifact: dict[str, Any] = {
-        "schema_version": "2.0",
+        "schema_version": CURRENT_ARTIFACT_SCHEMA_VERSION,
         "meta": {
             "scan_timestamp": scan_timestamp,
             "scan_duration_seconds": 0.0,

--- a/src/helianthus_vrc_explorer/transport/dummy.py
+++ b/src/helianthus_vrc_explorer/transport/dummy.py
@@ -5,6 +5,7 @@ import struct
 from pathlib import Path
 from typing import Any
 
+from ..artifact_schema import migrate_artifact_schema
 from ..scanner.director import GROUP_CONFIG
 from .base import TransportError, TransportInterface, TransportTimeout
 
@@ -206,6 +207,7 @@ class DummyTransport(TransportInterface):
         data: Any = json.loads(raw)
         if not isinstance(data, dict):
             raise ValueError("Fixture root must be a JSON object")
+        data, _migration = migrate_artifact_schema(data)
 
         meta = data.get("meta", {})
         if not isinstance(meta, dict):

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from ..artifact_schema import migrate_artifact_schema
 from ..scanner.director import GROUP_CONFIG
 from .browse_models import BrowseTab, RegisterAddress, RegisterRow, TreeNodeRef
 from .register_semantics import entry_display_value_text, visible_rr_keys
@@ -337,6 +338,8 @@ class BrowseStore:
 
     @classmethod
     def from_artifact(cls, artifact: dict[str, Any]) -> BrowseStore:
+        artifact, _migration = migrate_artifact_schema(artifact)
+
         meta = artifact.get("meta")
         if not isinstance(meta, dict):
             meta = {}

--- a/tests/test_artifact_schema.py
+++ b/tests/test_artifact_schema.py
@@ -11,6 +11,7 @@ import pytest
 
 from helianthus_vrc_explorer.artifact_schema import (
     CURRENT_ARTIFACT_SCHEMA_VERSION,
+    LEGACY_VERSIONED_SCHEMAS,
     LEGACY_UNVERSIONED_SCHEMA,
     count_register_entries,
     iter_register_entries,
@@ -157,6 +158,16 @@ def test_validator_can_reject_legacy_when_requested() -> None:
     assert any("legacy unversioned artifact rejected" in error for error in errors)
 
 
+def test_validator_can_reject_legacy_versioned_when_requested() -> None:
+    artifact = _load_fixture("vrc720_full_scan.json")
+    artifact["schema_version"] = next(iter(LEGACY_VERSIONED_SCHEMAS))
+
+    errors, _migrated, source_schema = _validate_scan_artifact(artifact, allow_legacy=False)
+
+    assert source_schema in LEGACY_VERSIONED_SCHEMAS
+    assert any("legacy versioned artifact" in error for error in errors)
+
+
 def test_validator_detects_namespace_opcode_mismatch() -> None:
     artifact = _load_fixture("dual_namespace_scan.json")
     artifact["groups"]["0x09"]["namespaces"]["0x06"]["instances"]["0x00"]["registers"]["0x0004"][
@@ -166,3 +177,36 @@ def test_validator_detects_namespace_opcode_mismatch() -> None:
     errors, _migrated, _source_schema = _validate_scan_artifact(artifact, allow_legacy=True)
 
     assert any("does not match namespace 0x06" in error for error in errors)
+
+
+def test_migrate_legacy_empty_namespaces_preserves_flat_instances() -> None:
+    legacy_artifact = {
+        "schema_version": "2.0",
+        "meta": {},
+        "groups": {
+            "0x02": {
+                "descriptor_type": 1.0,
+                "namespaces": {},
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x000f": {"raw_hex": "3412"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    migrated, report = migrate_artifact_schema(legacy_artifact)
+    group = migrated["groups"]["0x02"]
+    entries = list(iter_register_entries(migrated))
+
+    assert report.register_count_before == 1
+    assert report.register_count_after == 1
+    assert group["dual_namespace"] is False
+    assert "namespaces" not in group
+    assert group["instances"]["0x00"]["registers"]["0x000f"]["raw_hex"] == "3412"
+    assert entries == [
+        ("0x02", None, "0x00", "0x000f", {"raw_hex": "3412"}),
+    ]

--- a/tests/test_artifact_schema.py
+++ b/tests/test_artifact_schema.py
@@ -11,8 +11,8 @@ import pytest
 
 from helianthus_vrc_explorer.artifact_schema import (
     CURRENT_ARTIFACT_SCHEMA_VERSION,
-    LEGACY_VERSIONED_SCHEMAS,
     LEGACY_UNVERSIONED_SCHEMA,
+    LEGACY_VERSIONED_SCHEMAS,
     count_register_entries,
     iter_register_entries,
     migrate_artifact_schema,

--- a/tests/test_artifact_schema.py
+++ b/tests/test_artifact_schema.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from copy import deepcopy
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from helianthus_vrc_explorer.artifact_schema import (
+    CURRENT_ARTIFACT_SCHEMA_VERSION,
+    LEGACY_UNVERSIONED_SCHEMA,
+    count_register_entries,
+    iter_register_entries,
+    migrate_artifact_schema,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURES_DIR = _REPO_ROOT / "fixtures"
+
+
+def _load_validator_module() -> ModuleType:
+    script_path = _REPO_ROOT / "scripts" / "validate_artifact.py"
+    spec = importlib.util.spec_from_file_location("validate_artifact_script", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load validator module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_VALIDATOR = _load_validator_module()
+_validate_scan_artifact = _VALIDATOR.validate_scan_artifact
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    path = _FIXTURES_DIR / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _register_identity_set(artifact: dict[str, Any]) -> set[tuple[Any, ...]]:
+    identities: set[tuple[Any, ...]] = set()
+    for (
+        group_key,
+        namespace_key,
+        instance_key,
+        register_key,
+        entry,
+    ) in iter_register_entries(artifact):
+        identities.add(
+            (
+                group_key,
+                namespace_key,
+                instance_key,
+                register_key,
+                entry.get("raw_hex"),
+                entry.get("error"),
+                entry.get("read_opcode"),
+            )
+        )
+    return identities
+
+
+def test_migrate_unversioned_fixture_promotes_schema_and_preserves_register_count() -> None:
+    legacy_artifact = {
+        "meta": {},
+        "groups": {
+            "0x02": {
+                "descriptor_type": 1.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x000f": {"raw_hex": "3412"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    migrated, report = migrate_artifact_schema(legacy_artifact)
+
+    assert migrated["schema_version"] == CURRENT_ARTIFACT_SCHEMA_VERSION
+    assert report.source_schema_version == LEGACY_UNVERSIONED_SCHEMA
+    assert report.register_count_before == 1
+    assert report.register_count_after == 1
+    assert migrated["groups"]["0x02"]["dual_namespace"] is False
+    assert migrated["groups"]["0x02"]["descriptor_observed"] == 1.0
+    register = migrated["groups"]["0x02"]["instances"]["0x00"]["registers"]["0x000f"]
+    assert register["raw_hex"] == "3412"
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_register_count"),
+    [
+        ("vrc720_full_scan.json", 1),
+        ("dual_namespace_scan.json", 10),
+        ("demo_browse.json", 12),
+    ],
+)
+def test_checked_in_fixtures_are_versioned_and_register_count_preserved(
+    fixture_name: str,
+    expected_register_count: int,
+) -> None:
+    artifact = _load_fixture(fixture_name)
+
+    assert artifact["schema_version"] == CURRENT_ARTIFACT_SCHEMA_VERSION
+    assert count_register_entries(artifact) == expected_register_count
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    ["vrc720_full_scan.json", "dual_namespace_scan.json", "demo_browse.json"],
+)
+def test_migration_preserves_register_identities_for_fixture_legacy_copies(
+    fixture_name: str,
+) -> None:
+    current = _load_fixture(fixture_name)
+    legacy = deepcopy(current)
+    legacy.pop("schema_version", None)
+    groups = legacy.get("groups")
+    assert isinstance(groups, dict)
+    for group_obj in groups.values():
+        if not isinstance(group_obj, dict):
+            continue
+        if "descriptor_observed" in group_obj:
+            group_obj["descriptor_type"] = group_obj.pop("descriptor_observed")
+        group_obj.pop("dual_namespace", None)
+
+    migrated, report = migrate_artifact_schema(legacy)
+
+    assert report.register_count_before == report.register_count_after
+    assert _register_identity_set(migrated) == _register_identity_set(current)
+
+
+def test_validator_accepts_legacy_when_enabled() -> None:
+    artifact = _load_fixture("vrc720_full_scan.json")
+    artifact.pop("schema_version", None)
+    group = artifact["groups"]["0x02"]
+    group["descriptor_type"] = group.pop("descriptor_observed")
+    group.pop("dual_namespace", None)
+
+    errors, _migrated, source_schema = _validate_scan_artifact(artifact, allow_legacy=True)
+
+    assert errors == []
+    assert source_schema == LEGACY_UNVERSIONED_SCHEMA
+
+
+def test_validator_can_reject_legacy_when_requested() -> None:
+    artifact = _load_fixture("vrc720_full_scan.json")
+    artifact.pop("schema_version", None)
+
+    errors, _migrated, _source_schema = _validate_scan_artifact(artifact, allow_legacy=False)
+
+    assert any("legacy unversioned artifact rejected" in error for error in errors)
+
+
+def test_validator_detects_namespace_opcode_mismatch() -> None:
+    artifact = _load_fixture("dual_namespace_scan.json")
+    artifact["groups"]["0x09"]["namespaces"]["0x06"]["instances"]["0x00"]["registers"]["0x0004"][
+        "read_opcode"
+    ] = "0x02"
+
+    errors, _migrated, _source_schema = _validate_scan_artifact(artifact, allow_legacy=True)
+
+    assert any("does not match namespace 0x06" in error for error in errors)

--- a/tests/test_dummy_transport.py
+++ b/tests/test_dummy_transport.py
@@ -184,6 +184,35 @@ def test_dummy_transport_artifact_v2_namespaces_do_not_require_dual_namespace_fl
     assert transport.send(0x15, remote_payload) == bytes.fromhex("01090400021703")
 
 
+def test_dummy_transport_legacy_empty_namespaces_keeps_flat_instances_reachable(
+    tmp_path: Path,
+) -> None:
+    fixture = {
+        "schema_version": "2.0",
+        "meta": {},
+        "groups": {
+            "0x02": {
+                "descriptor_type": 1.0,
+                "namespaces": {},
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x000f": {"raw_hex": "3412"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+    fixture_path = tmp_path / "fixture_empty_namespaces_flat_instances.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    transport = DummyTransport(fixture_path)
+    payload = build_register_read_payload(0x02, group=0x02, instance=0x00, register=0x000F)
+
+    assert transport.send(0x15, payload) == bytes.fromhex("01020f003412")
+
+
 def test_dummy_transport_unknown_group_flat_fixture_requires_explicit_namespace(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from rich.console import Console
 
+from helianthus_vrc_explorer.artifact_schema import CURRENT_ARTIFACT_SCHEMA_VERSION
 from helianthus_vrc_explorer.scanner.observer import ScanObserver
 from helianthus_vrc_explorer.scanner.plan import GroupScanPlan, make_plan_key
 from helianthus_vrc_explorer.scanner.scan import (
@@ -793,7 +794,7 @@ def test_scan_singleton_group_nonzero_descriptor(tmp_path: Path) -> None:
 def test_artifact_schema_version(tmp_path: Path) -> None:
     artifact = scan_b524(DummyTransport(_write_fixture_group_00(tmp_path)), dst=0x15)
 
-    assert artifact["schema_version"] == "2.0"
+    assert artifact["schema_version"] == CURRENT_ARTIFACT_SCHEMA_VERSION
     contract = artifact["meta"]["artifact_contract"]
     assert contract["namespace_identity_keys"] == "opcode_hex"
     assert contract["namespace_labels"] == "presentation_only"
@@ -1182,7 +1183,7 @@ def test_scan_b524_replays_dual_namespace_fixture_end_to_end(
         myvaillant_map=MyvaillantRegisterMap.from_path(map_path),
     )
 
-    assert artifact["schema_version"] == "2.0"
+    assert artifact["schema_version"] == CURRENT_ARTIFACT_SCHEMA_VERSION
     local_fw = artifact["groups"]["0x09"]["namespaces"]["0x02"]["instances"]["0x00"]["registers"][
         "0x0004"
     ]


### PR DESCRIPTION
## Summary
- add explicit artifact schema versioning contract (`2.1`) with a shared migration layer for legacy artifacts (`unversioned`, `2.0`)
- route checked-in artifact readers (scan dry-run fixture load, `browse --file`, `BrowseStore`, `DummyTransport`) through migration so legacy fixtures continue to load
- migrate repository fixtures (`vrc720_full_scan.json`, `dual_namespace_scan.json`, `demo_browse.json`, packaged dry-run fixture) to `schema_version: "2.1"`, add explicit `dual_namespace` topology flags, and keep register counts stable
- extend `scripts/validate_artifact.py` to validate namespace-aware topology, namespace/read_opcode consistency, and legacy compatibility behavior
- add regression tests for migration/count preservation/no silent data loss and validator behavior

## Compatibility Strategy (Issue #205 AC)
- writers now emit `schema_version: "2.1"`
- readers remain backward-compatible via in-memory migration of legacy artifacts (missing `schema_version`) and `schema_version: "2.0"`
- fixture migration is in lockstep for checked-in artifacts; migration path is still covered by tests

## Validation
- `ruff check src/helianthus_vrc_explorer/artifact_schema.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/transport/dummy.py src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/cli.py scripts/validate_artifact.py tests/test_artifact_schema.py tests/test_scanner_scan.py`
- `PYTHONPATH=src uv run pytest -q tests/test_artifact_schema.py tests/test_dummy_transport.py tests/test_scanner_scan.py tests/test_cli.py tests/test_browse_store.py`
- `PYTHONPATH=src uv run python scripts/validate_artifact.py fixtures/vrc720_full_scan.json`
- `PYTHONPATH=src uv run python scripts/validate_artifact.py fixtures/dual_namespace_scan.json`
- `PYTHONPATH=src uv run python scripts/validate_artifact.py fixtures/demo_browse.json`

Closes #205.