### PR TITLE
Issue #206: split browse, summary, and HTML behavior by namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Transport note:
 - Unknown groups are namespace-classified from live opcode responsiveness evidence. There is no implicit unknown-group `[0x02, 0x06]` fallback.
 - Contextual enum annotations are local-namespace scoped: group `0x02` local (`0x02`) register context never relabels remote (`0x06`) entries.
 - Canonical namespace identity is always an opcode hex key (`0x02`, `0x06`, ...). Labels like `local`/`remote` are presentation metadata only.
+- Browse UI, CLI summary, and HTML report derive namespace labels from opcode identity and render them as qualified displays (for example `Local (0x02)`, `Remote (0x06)`).
+- Legacy artifacts that still carry mixed opcodes inside a single non-dual group are rendered per-namespace in browse/report surfaces to prevent local/remote intermixing and override bleed.
 - Persisted `groups[*].dual_namespace` topology is authoritative for consumers. Do not infer or rewrite namespace shape from descriptors.
 - B524 browse/report row identity is namespace-aware even for single-namespace groups: dedupe key `<group>:<namespace>:<instance>:<register>` and path format `B524/<group-name>/<namespace-display>/<instance>/<register-name>` are round-trip stable.
 - Artifact schema contract is versioned (`schema_version: "2.1"` current). Readers keep backward compatibility by migrating unversioned and `2.0` artifacts in-memory.

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -307,7 +307,6 @@ def _group_namespace_views(
     if not isinstance(instances, dict):
         return [(None, None, {})]
 
-    default_namespace_key = _single_namespace_key(group_key, group_obj)
     split_instances: dict[str, dict[str, Any]] = {}
     for instance_key in sorted(
         (k for k in instances if isinstance(k, str)),
@@ -326,13 +325,10 @@ def _group_namespace_views(
             entry = registers.get(register_key)
             if not isinstance(entry, dict):
                 continue
-            namespace_key = _entry_namespace_key(
-                entry,
-                fallback_namespace_key=default_namespace_key,
-            )
-            if namespace_key is None:
+            entry_namespace_key = _entry_namespace_key(entry)
+            if entry_namespace_key is None:
                 continue
-            namespace_instances = split_instances.setdefault(namespace_key, {})
+            namespace_instances = split_instances.setdefault(entry_namespace_key, {})
             namespace_instance = namespace_instances.get(instance_key)
             if not isinstance(namespace_instance, dict):
                 namespace_instance = {
@@ -592,15 +588,8 @@ class BrowseStore:
                         )
                         if entry_namespace_key is not None:
                             entry_namespace_label = _namespace_label_for_key(entry_namespace_key)
-                        elif (
-                            namespace_key is not None
-                            and entry_namespace_key == effective_namespace_key
-                        ):
-                            entry_namespace_label = effective_namespace_label
-                        elif read_opcode_label:
-                            entry_namespace_label = read_opcode_label
                         else:
-                            entry_namespace_label = _namespace_label_for_key(entry_namespace_key)
+                            entry_namespace_label = read_opcode_label
                         address = RegisterAddress(
                             protocol="b524",
                             group_key=group_key,

--- a/src/helianthus_vrc_explorer/ui/browse_store.py
+++ b/src/helianthus_vrc_explorer/ui/browse_store.py
@@ -56,7 +56,11 @@ def _fmt_group_label(group_key: str, group_name: str) -> str:
     return f"{group_name} ({group_key})"
 
 
-def _instance_display_base(*, group_key: str, group_name: str) -> str:
+def _instance_display_base(*, group_key: str, group_name: str, namespace_key: str | None) -> str:
+    if namespace_key == "0x06":
+        return "Remote Slot"
+    if namespace_key is not None and namespace_key != "0x02":
+        return f"Namespace {namespace_key} Slot"
     mapping: dict[int, str] = {
         0x02: "Heating Circuit",
         0x03: "Zone",
@@ -76,6 +80,7 @@ def _instance_label(
     *,
     group_key: str,
     group_name: str,
+    namespace_key: str | None,
     instance_key: str,
     instance_obj: dict[str, Any],
 ) -> str:
@@ -92,7 +97,11 @@ def _instance_label(
                 if isinstance(value, str) and value.strip():
                     return f"{value.strip()} ({instance_key})"
 
-    base = _instance_display_base(group_key=group_key, group_name=group_name)
+    base = _instance_display_base(
+        group_key=group_key,
+        group_name=group_name,
+        namespace_key=namespace_key,
+    )
     # Human-friendly numbering: show 1-based index, but always keep the instance ID too.
     ii = _safe_int_hex(instance_key)
     return f"{base} {ii + 1} ({instance_key})"
@@ -138,12 +147,15 @@ def _row_sort_key(row: RegisterRow) -> tuple[int, int, int, int, int]:
 def _namespace_display_label(namespace_key: str | None, namespace_label: str | None) -> str | None:
     if namespace_key is None:
         return None
-    label = (namespace_label or namespace_key).strip()
-    if not label:
-        label = namespace_key
-    if label.startswith("0x"):
-        return label
-    return f"{label[:1].upper()}{label[1:]} ({namespace_key})"
+    canonical_label = _namespace_label_for_key(namespace_key)
+    if canonical_label in {"local", "remote"}:
+        return f"{canonical_label[:1].upper()}{canonical_label[1:]} ({namespace_key})"
+    label = namespace_label.strip() if isinstance(namespace_label, str) else ""
+    if label and label.lower() != namespace_key.lower():
+        if label.startswith("0x"):
+            return namespace_key
+        return f"{label[:1].upper()}{label[1:]} ({namespace_key})"
+    return namespace_key
 
 
 def _normalize_opcode_hex(value: object) -> str | None:
@@ -159,6 +171,29 @@ def _normalize_opcode_hex(value: object) -> str | None:
     if opcode < 0x00 or opcode > 0xFF:
         return None
     return _hex_u8(opcode)
+
+
+def _namespace_key_from_label(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().lower()
+    if raw == "local":
+        return "0x02"
+    if raw == "remote":
+        return "0x06"
+    return _normalize_opcode_hex(value)
+
+
+def _entry_namespace_key(
+    entry: dict[str, Any], *, fallback_namespace_key: str | None = None
+) -> str | None:
+    namespace_key = _normalize_opcode_hex(entry.get("read_opcode"))
+    if namespace_key is not None:
+        return namespace_key
+    namespace_key = _namespace_key_from_label(entry.get("read_opcode_label"))
+    if namespace_key is not None:
+        return namespace_key
+    return fallback_namespace_key
 
 
 def _namespace_label_for_key(namespace_key: str | None) -> str | None:
@@ -237,6 +272,8 @@ def _build_b524_row_id(
 
 
 def _group_namespace_views(
+    *,
+    group_key: str,
     group_obj: dict[str, Any],
 ) -> list[tuple[str | None, str | None, dict[str, Any]]]:
     if bool(group_obj.get("dual_namespace")):
@@ -251,7 +288,11 @@ def _group_namespace_views(
             if not isinstance(namespace_obj, dict):
                 continue
             label_obj = namespace_obj.get("label")
-            namespace_label = label_obj if isinstance(label_obj, str) else namespace_key
+            namespace_label = (
+                label_obj
+                if isinstance(label_obj, str) and label_obj.strip()
+                else _namespace_label_for_key(namespace_key) or namespace_key
+            )
             instances = namespace_obj.get("instances")
             views.append(
                 (
@@ -263,7 +304,61 @@ def _group_namespace_views(
         return views
 
     instances = group_obj.get("instances")
-    return [(None, None, instances if isinstance(instances, dict) else {})]
+    if not isinstance(instances, dict):
+        return [(None, None, {})]
+
+    default_namespace_key = _single_namespace_key(group_key, group_obj)
+    split_instances: dict[str, dict[str, Any]] = {}
+    for instance_key in sorted(
+        (k for k in instances if isinstance(k, str)),
+        key=_safe_int_hex,
+    ):
+        instance_obj = instances.get(instance_key)
+        if not isinstance(instance_obj, dict):
+            continue
+        registers = instance_obj.get("registers")
+        if not isinstance(registers, dict):
+            continue
+        for register_key in sorted(
+            (k for k in registers if isinstance(k, str)),
+            key=_safe_int_hex,
+        ):
+            entry = registers.get(register_key)
+            if not isinstance(entry, dict):
+                continue
+            namespace_key = _entry_namespace_key(
+                entry,
+                fallback_namespace_key=default_namespace_key,
+            )
+            if namespace_key is None:
+                continue
+            namespace_instances = split_instances.setdefault(namespace_key, {})
+            namespace_instance = namespace_instances.get(instance_key)
+            if not isinstance(namespace_instance, dict):
+                namespace_instance = {
+                    "present": instance_obj.get("present"),
+                    "registers": {},
+                }
+                namespace_instances[instance_key] = namespace_instance
+            namespace_registers = namespace_instance.get("registers")
+            if not isinstance(namespace_registers, dict):
+                namespace_registers = {}
+                namespace_instance["registers"] = namespace_registers
+            namespace_registers[register_key] = entry
+
+    if len(split_instances) <= 1:
+        return [(None, None, instances)]
+
+    views = []
+    for namespace_key in sorted(split_instances, key=_safe_int_hex):
+        views.append(
+            (
+                namespace_key,
+                _namespace_label_for_key(namespace_key) or namespace_key,
+                split_instances[namespace_key],
+            )
+        )
+    return views
 
 
 def _parse_range_key(range_key: str) -> tuple[int, int] | None:
@@ -384,7 +479,7 @@ class BrowseStore:
             gg = _safe_int_hex(group_key)
             group_single_namespace_key = _single_namespace_key(group_key, group_obj)
             group_single_namespace_label = _namespace_label_for_key(group_single_namespace_key)
-            namespace_views = _group_namespace_views(group_obj)
+            namespace_views = _group_namespace_views(group_key=group_key, group_obj=group_obj)
             if not namespace_views:
                 continue
             all_instance_keys = sorted(
@@ -456,6 +551,7 @@ class BrowseStore:
                                 label=_instance_label(
                                     group_key=group_key,
                                     group_name=group_name,
+                                    namespace_key=effective_namespace_key,
                                     instance_key=instance_key,
                                     instance_obj=instance_obj,
                                 ),
@@ -494,13 +590,15 @@ class BrowseStore:
                             if isinstance(entry.get("read_opcode_label"), str)
                             else None
                         )
-                        if read_opcode_label:
-                            entry_namespace_label = read_opcode_label
+                        if entry_namespace_key is not None:
+                            entry_namespace_label = _namespace_label_for_key(entry_namespace_key)
                         elif (
                             namespace_key is not None
                             and entry_namespace_key == effective_namespace_key
                         ):
                             entry_namespace_label = effective_namespace_label
+                        elif read_opcode_label:
+                            entry_namespace_label = read_opcode_label
                         else:
                             entry_namespace_label = _namespace_label_for_key(entry_namespace_key)
                         address = RegisterAddress(

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -770,8 +770,8 @@ __ARTIFACT_JSON__
         if (!entry || typeof entry !== "object") return fallbackNamespaceKey;
         return (
           normalizeOpcodeKey(entry.read_opcode)
+          || normalizeOpcodeKey(fallbackNamespaceKey)
           || normalizeOpcodeKey(entry.read_opcode_label)
-          || fallbackNamespaceKey
         );
       }
 
@@ -785,7 +785,7 @@ __ARTIFACT_JSON__
             const entry = regs[rrKey];
             if (!entry || typeof entry !== "object") continue;
             const namespaceKey = namespaceKeyFromEntry(entry, fallbackNamespaceKey);
-            if (!namespaceKey) continue;
+            if (!namespaceKey) continue; // Keep namespace views isolated; do not force-assign unknown rows.
             if (!split[namespaceKey] || typeof split[namespaceKey] !== "object") {
               split[namespaceKey] = {};
             }
@@ -1729,7 +1729,7 @@ __ARTIFACT_JSON__
             }
           }
         } else {
-          const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {});
+          const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {}, null);
           const namespaceKeys = sortedHexKeys(Object.keys(splitNamespaces));
           if (namespaceKeys.length > 1) {
             const subtabs = document.createElement("div");

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -711,9 +711,12 @@ __ARTIFACT_JSON__
       function getRowOverride(groupKey, rrKey, namespaceKey = null) {
         const g = state.overrides && state.overrides[groupKey];
         if (!g || typeof g !== "object") return null;
-        if (namespaceKey && g.namespaces && typeof g.namespaces === "object") {
-          const ns = g.namespaces[namespaceKey];
-          if (ns && typeof ns === "object" && typeof ns[rrKey] === "string") return ns[rrKey];
+        if (namespaceKey) {
+          if (g.namespaces && typeof g.namespaces === "object") {
+            const ns = g.namespaces[namespaceKey];
+            if (ns && typeof ns === "object" && typeof ns[rrKey] === "string") return ns[rrKey];
+          }
+          return null;
         }
         return typeof g[rrKey] === "string" ? g[rrKey] : null;
       }
@@ -736,19 +739,66 @@ __ARTIFACT_JSON__
 
       function normalizeOpcodeKey(opcodeRaw) {
         if (typeof opcodeRaw !== "string") return null;
-        const trimmed = opcodeRaw.trim();
+        const trimmed = opcodeRaw.trim().toLowerCase();
         if (!trimmed) return null;
+        if (trimmed === "local") return "0x02";
+        if (trimmed === "remote") return "0x06";
         const parsed = Number(trimmed);
         if (!Number.isInteger(parsed) || parsed < 0 || parsed > 0xff) return null;
         return `0x${parsed.toString(16).padStart(2, "0")}`;
+      }
+
+      function canonicalNamespaceLabel(namespaceKey) {
+        if (namespaceKey === "0x02") return "local";
+        if (namespaceKey === "0x06") return "remote";
+        return null;
       }
 
       function namespaceLabel(namespaceKey, label) {
         const raw = typeof label === "string" && label ? label : namespaceKey;
         if (!raw) return "";
         if (!namespaceKey) return raw;
-        if (raw.startsWith("0x")) return raw;
+        const canonical = canonicalNamespaceLabel(namespaceKey);
+        if (canonical) {
+          return `${canonical.charAt(0).toUpperCase()}${canonical.slice(1)} (${namespaceKey})`;
+        }
+        if (raw.startsWith("0x")) return namespaceKey;
         return `${raw.charAt(0).toUpperCase()}${raw.slice(1)} (${namespaceKey})`;
+      }
+
+      function namespaceKeyFromEntry(entry, fallbackNamespaceKey = null) {
+        if (!entry || typeof entry !== "object") return fallbackNamespaceKey;
+        return (
+          normalizeOpcodeKey(entry.read_opcode)
+          || normalizeOpcodeKey(entry.read_opcode_label)
+          || fallbackNamespaceKey
+        );
+      }
+
+      function splitInstancesByNamespace(instancesObj, fallbackNamespaceKey = null) {
+        const split = {};
+        if (!instancesObj || typeof instancesObj !== "object") return split;
+        for (const iiKey of sortedHexKeys(Object.keys(instancesObj))) {
+          const inst = getInstanceObject(instancesObj[iiKey]);
+          const regs = inst.registers && typeof inst.registers === "object" ? inst.registers : {};
+          for (const rrKey of sortedHexKeys(Object.keys(regs))) {
+            const entry = regs[rrKey];
+            if (!entry || typeof entry !== "object") continue;
+            const namespaceKey = namespaceKeyFromEntry(entry, fallbackNamespaceKey);
+            if (!namespaceKey) continue;
+            if (!split[namespaceKey] || typeof split[namespaceKey] !== "object") {
+              split[namespaceKey] = {};
+            }
+            if (!split[namespaceKey][iiKey] || typeof split[namespaceKey][iiKey] !== "object") {
+              split[namespaceKey][iiKey] = {
+                present: inst.present,
+                registers: {},
+              };
+            }
+            split[namespaceKey][iiKey].registers[rrKey] = entry;
+          }
+        }
+        return split;
       }
 
       function entryStatusKind(entry) {
@@ -880,7 +930,8 @@ __ARTIFACT_JSON__
             for (const namespaceKey of sortedHexKeys(Object.keys(groupObj.namespaces))) {
               const namespaceObj = groupObj.namespaces[namespaceKey];
               if (!namespaceObj || typeof namespaceObj !== "object") continue;
-              const label = typeof namespaceObj.label === "string" ? namespaceObj.label : namespaceKey;
+              const normalizedKey = normalizeOpcodeKey(namespaceKey) || namespaceKey;
+              const label = namespaceLabel(normalizedKey, namespaceObj.label);
               const count = countRegisters(namespaceObj.instances);
               totalRegisters += count;
               totals.set(label, (totals.get(label) || 0) + count);
@@ -894,8 +945,9 @@ __ARTIFACT_JSON__
               const registers = instanceObj.registers && typeof instanceObj.registers === "object" ? instanceObj.registers : {};
               for (const entry of Object.values(registers)) {
                 if (!entry || typeof entry !== "object") continue;
-                const label = normalizeOpcodeKey(entry.read_opcode) || normalizeOpcodeKey(entry.read_opcode_label);
-                if (!label) continue;
+                const namespaceKey = namespaceKeyFromEntry(entry);
+                if (!namespaceKey) continue;
+                const label = namespaceLabel(namespaceKey, entry.read_opcode_label);
                 totalRegisters += 1;
                 totals.set(label, (totals.get(label) || 0) + 1);
               }
@@ -1656,10 +1708,11 @@ __ARTIFACT_JSON__
             for (const namespaceKey of namespaceKeys) {
               const namespaceObj = groupObj.namespaces[namespaceKey];
               if (!namespaceObj || typeof namespaceObj !== "object") continue;
+              const normalizedKey = normalizeOpcodeKey(namespaceKey) || namespaceKey;
               const btn = document.createElement("div");
               btn.className = "tab";
               if (namespaceKey === activeNamespace) btn.classList.add("active");
-              btn.textContent = namespaceLabel(namespaceKey, namespaceObj.label);
+              btn.textContent = namespaceLabel(normalizedKey, namespaceObj.label);
               btn.addEventListener("click", () => {
                 state.activeNamespaceByGroup[groupKey] = namespaceKey;
                 renderActiveGroup(groupKey);
@@ -1670,12 +1723,52 @@ __ARTIFACT_JSON__
 
             const namespaceObj = groupObj.namespaces[activeNamespace];
             if (namespaceObj && typeof namespaceObj === "object") {
-              const tableTitle = `${namespaceLabel(activeNamespace, namespaceObj.label)} Registers`;
+              const normalizedKey = normalizeOpcodeKey(activeNamespace) || activeNamespace;
+              const tableTitle = `${namespaceLabel(normalizedKey, namespaceObj.label)} Registers`;
               container.appendChild(buildGroupTable(tableTitle, namespaceObj.instances || {}, activeNamespace));
             }
           }
         } else {
-          container.appendChild(buildGroupTable("Registers", groupObj.instances || {}, null));
+          const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {});
+          const namespaceKeys = sortedHexKeys(Object.keys(splitNamespaces));
+          if (namespaceKeys.length > 1) {
+            const subtabs = document.createElement("div");
+            subtabs.className = "subtabs";
+            let activeNamespace = state.activeNamespaceByGroup[groupKey];
+            if (!namespaceKeys.includes(activeNamespace)) activeNamespace = namespaceKeys[0];
+            state.activeNamespaceByGroup[groupKey] = activeNamespace;
+
+            for (const namespaceKey of namespaceKeys) {
+              const btn = document.createElement("div");
+              btn.className = "tab";
+              if (namespaceKey === activeNamespace) btn.classList.add("active");
+              btn.textContent = namespaceLabel(namespaceKey, namespaceKey);
+              btn.addEventListener("click", () => {
+                state.activeNamespaceByGroup[groupKey] = namespaceKey;
+                renderActiveGroup(groupKey);
+              });
+              subtabs.appendChild(btn);
+            }
+            container.appendChild(subtabs);
+            container.appendChild(
+              buildGroupTable(
+                `${namespaceLabel(activeNamespace, activeNamespace)} Registers`,
+                splitNamespaces[activeNamespace] || {},
+                activeNamespace,
+              ),
+            );
+          } else if (namespaceKeys.length === 1) {
+            const namespaceKey = namespaceKeys[0];
+            container.appendChild(
+              buildGroupTable(
+                `${namespaceLabel(namespaceKey, namespaceKey)} Registers`,
+                splitNamespaces[namespaceKey] || {},
+                namespaceKey,
+              ),
+            );
+          } else {
+            container.appendChild(buildGroupTable("Registers", groupObj.instances || {}, null));
+          }
         }
 
         sheetArea.innerHTML = "";

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -24,19 +24,29 @@ class _GroupStats:
 
 
 def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    for entry, _fallback_namespace_key in _iter_register_entries_with_namespace_hint(artifact):
+        yield entry
+
+
+def _iter_register_entries_with_namespace_hint(
+    artifact: dict[str, Any],
+) -> Iterable[tuple[dict[str, Any], str | None]]:
     groups = artifact.get("groups", {})
     if not isinstance(groups, dict):
         return
     for group_obj in groups.values():
         if not isinstance(group_obj, dict):
             continue
-        if bool(group_obj.get("dual_namespace")):
-            namespaces = group_obj.get("namespaces", {})
-            if not isinstance(namespaces, dict):
-                continue
-            for namespace_obj in namespaces.values():
+        namespaces = group_obj.get("namespaces", {})
+        if isinstance(namespaces, dict) and namespaces:
+            for namespace_key, namespace_obj in namespaces.items():
+                if not isinstance(namespace_key, str):
+                    continue
                 if not isinstance(namespace_obj, dict):
                     continue
+                namespace_hint = _normalize_namespace_key(
+                    namespace_key
+                ) or _namespace_key_from_label(namespace_key)
                 instances = namespace_obj.get("instances", {})
                 if not isinstance(instances, dict):
                     continue
@@ -48,7 +58,7 @@ def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]
                         continue
                     for entry in registers.values():
                         if isinstance(entry, dict):
-                            yield entry
+                            yield entry, namespace_hint
             continue
         instances = group_obj.get("instances", {})
         if not isinstance(instances, dict):
@@ -61,7 +71,7 @@ def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]
                 continue
             for entry in registers.values():
                 if isinstance(entry, dict):
-                    yield entry
+                    yield entry, None
 
 
 def _normalize_namespace_key(value: object) -> str | None:
@@ -103,8 +113,12 @@ def _namespace_display_label(namespace_key: str, namespace_label: object = None)
     return namespace_key
 
 
-def _namespace_label_from_entry(entry: dict[str, Any]) -> str | None:
+def _namespace_label_from_entry(
+    entry: dict[str, Any], *, fallback_namespace_key: str | None = None
+) -> str | None:
     namespace_key = _normalize_namespace_key(entry.get("read_opcode"))
+    if namespace_key is None:
+        namespace_key = _normalize_namespace_key(fallback_namespace_key)
     if namespace_key is None:
         namespace_key = _namespace_key_from_label(entry.get("read_opcode_label"))
     if namespace_key is None:
@@ -234,8 +248,11 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
 
 def _compute_namespace_totals(artifact: dict[str, Any]) -> dict[str, int]:
     totals: dict[str, int] = {}
-    for entry in _iter_register_entries(artifact):
-        label = _namespace_label_from_entry(entry)
+    for entry, fallback_namespace_key in _iter_register_entries_with_namespace_hint(artifact):
+        label = _namespace_label_from_entry(
+            entry,
+            fallback_namespace_key=fallback_namespace_key,
+        )
         if label is None:
             continue
         totals[label] = totals.get(label, 0) + 1

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -64,17 +64,70 @@ def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]
                     yield entry
 
 
-def _namespace_label_from_entry(entry: dict[str, Any]) -> str | None:
-    for raw in (entry.get("read_opcode"), entry.get("read_opcode_label")):
-        if not isinstance(raw, str) or not raw.strip():
-            continue
-        try:
-            parsed = int(raw.strip(), 0)
-        except ValueError:
-            continue
-        if 0 <= parsed <= 0xFF:
-            return f"0x{parsed:02x}"
+def _normalize_namespace_key(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw, 0)
+    except ValueError:
+        return None
+    if 0 <= parsed <= 0xFF:
+        return f"0x{parsed:02x}"
     return None
+
+
+def _namespace_key_from_label(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().lower()
+    if raw == "local":
+        return "0x02"
+    if raw == "remote":
+        return "0x06"
+    return _normalize_namespace_key(value)
+
+
+def _namespace_display_label(namespace_key: str, namespace_label: object = None) -> str:
+    lowered_key = namespace_key.lower()
+    if lowered_key == "0x02":
+        return "local (0x02)"
+    if lowered_key == "0x06":
+        return "remote (0x06)"
+    if isinstance(namespace_label, str):
+        text = namespace_label.strip()
+        if text and text.lower() != lowered_key:
+            return f"{text} ({namespace_key})"
+    return namespace_key
+
+
+def _namespace_label_from_entry(entry: dict[str, Any]) -> str | None:
+    namespace_key = _normalize_namespace_key(entry.get("read_opcode"))
+    if namespace_key is None:
+        namespace_key = _namespace_key_from_label(entry.get("read_opcode_label"))
+    if namespace_key is None:
+        return None
+    return _namespace_display_label(namespace_key, entry.get("read_opcode_label"))
+
+
+def _display_namespace_sort_key(label: str) -> tuple[int, int, str]:
+    raw = label.strip()
+    if raw.startswith("0x"):
+        parsed = _normalize_namespace_key(raw)
+        if parsed is not None:
+            return (0, int(parsed, 0), raw)
+    if raw.endswith(")") and "(" in raw:
+        open_idx = raw.rfind("(")
+        parsed = _normalize_namespace_key(raw[open_idx + 1 : -1])
+        if parsed is not None:
+            return (0, int(parsed, 0), raw)
+    return (1, 0, raw.lower())
+
+
+def _sorted_namespace_counts(counts: dict[str, int]) -> dict[str, int]:
+    return dict(sorted(counts.items(), key=lambda item: _display_namespace_sort_key(item[0])))
 
 
 def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
@@ -110,11 +163,10 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
             for namespace_key, namespace_obj in namespaces.items():
                 if not isinstance(namespace_key, str) or not isinstance(namespace_obj, dict):
                     continue
-                namespace_label_obj = namespace_obj.get("label")
-                namespace_label = (
-                    namespace_label_obj
-                    if isinstance(namespace_label_obj, str) and namespace_label_obj.strip()
-                    else namespace_key
+                namespace_key_norm = _normalize_namespace_key(namespace_key) or namespace_key
+                namespace_label = _namespace_display_label(
+                    namespace_key_norm,
+                    namespace_obj.get("label"),
                 )
                 namespace_count = 0
                 namespace_instances = namespace_obj.get("instances", {})
@@ -137,7 +189,9 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                             continue
                         if entry.get("error") is not None:
                             registers_errors += 1
-                namespace_registers[namespace_label] = namespace_count
+                namespace_registers[namespace_label] = (
+                    namespace_registers.get(namespace_label, 0) + namespace_count
+                )
             instances_total = len(instance_ids_total)
             instances_present = len(instance_ids_present)
         else:
@@ -170,7 +224,7 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 instances_present=instances_present,
                 registers_scanned=registers_scanned,
                 registers_errors=registers_errors,
-                namespace_registers=namespace_registers,
+                namespace_registers=_sorted_namespace_counts(namespace_registers),
             )
         )
 
@@ -185,7 +239,7 @@ def _compute_namespace_totals(artifact: dict[str, Any]) -> dict[str, int]:
         if label is None:
             continue
         totals[label] = totals.get(label, 0) + 1
-    return dict(sorted(totals.items()))
+    return _sorted_namespace_counts(totals)
 
 
 def _compute_flags_distribution(artifact: dict[str, Any]) -> dict[str, int]:

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -212,6 +212,55 @@ def test_browse_store_instance_selection_is_namespace_isolated_for_mixed_legacy_
     assert {(row.register_key, row.namespace_key) for row in remote_rows} == {("0x0002", "0x06")}
 
 
+def test_browse_store_drops_missing_namespace_entries_from_split_views() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {
+                                "value": 1,
+                                "raw_hex": "01",
+                                "flags_access": "stable_ro",
+                                "read_opcode": "0x02",
+                            },
+                            "0x0002": {
+                                "value": 2,
+                                "raw_hex": "02",
+                                "flags_access": "stable_ro",
+                                "read_opcode": "0x06",
+                            },
+                            "0x0003": {
+                                "value": 3,
+                                "raw_hex": "03",
+                                "flags_access": "stable_ro",
+                            },
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    assert {row.register_key for row in store.rows} == {"0x0001", "0x0002"}
+    assert all(row.register_key != "0x0003" for row in store.rows)
+
+    local_instance_node = next(
+        node for node in store.tree_nodes if node.node_id == "b524:inst:0x02:0x02:0x00"
+    )
+    remote_instance_node = next(
+        node for node in store.tree_nodes if node.node_id == "b524:inst:0x02:0x06:0x00"
+    )
+    local_rows = store.rows_for_selection(local_instance_node, tab="state")
+    remote_rows = store.rows_for_selection(remote_instance_node, tab="state")
+    assert {(row.register_key, row.namespace_key) for row in local_rows} == {("0x0001", "0x02")}
+    assert {(row.register_key, row.namespace_key) for row in remote_rows} == {("0x0002", "0x06")}
+
+
 def test_browse_store_builds_namespace_nodes_for_dual_namespace_groups() -> None:
     store = BrowseStore.from_artifact(_dual_namespace_artifact())
 

--- a/tests/test_browse_store.py
+++ b/tests/test_browse_store.py
@@ -170,9 +170,7 @@ def test_browse_store_single_namespace_instance_node_uses_opcode_identity() -> N
     )
 
 
-def test_browse_store_instance_selection_keeps_mixed_opcode_rows_in_single_namespace_group() -> (
-    None
-):
+def test_browse_store_instance_selection_is_namespace_isolated_for_mixed_legacy_group() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
         "groups": {
@@ -201,15 +199,17 @@ def test_browse_store_instance_selection_keeps_mixed_opcode_rows_in_single_names
     }
 
     store = BrowseStore.from_artifact(artifact)
-    instance_node = next(
+    local_instance_node = next(
         node for node in store.tree_nodes if node.node_id == "b524:inst:0x02:0x02:0x00"
     )
+    remote_instance_node = next(
+        node for node in store.tree_nodes if node.node_id == "b524:inst:0x02:0x06:0x00"
+    )
 
-    rows = store.rows_for_selection(instance_node, tab="state")
-    assert {(row.register_key, row.namespace_key) for row in rows} == {
-        ("0x0001", "0x02"),
-        ("0x0002", "0x06"),
-    }
+    local_rows = store.rows_for_selection(local_instance_node, tab="state")
+    remote_rows = store.rows_for_selection(remote_instance_node, tab="state")
+    assert {(row.register_key, row.namespace_key) for row in local_rows} == {("0x0001", "0x02")}
+    assert {(row.register_key, row.namespace_key) for row in remote_rows} == {("0x0002", "0x06")}
 
 
 def test_browse_store_builds_namespace_nodes_for_dual_namespace_groups() -> None:
@@ -232,6 +232,44 @@ def test_browse_store_builds_namespace_nodes_for_dual_namespace_groups() -> None
     assert remote_row.namespace_label == "remote"
     assert local_row.access_flags == "stable_ro"
     assert remote_row.access_flags == "user_rw"
+
+
+def test_browse_store_remote_namespace_instance_label_drops_local_group_assumption() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T12:00:00Z"},
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x06": {
+                        "label": "local",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {
+                                    "0x0001": {
+                                        "value": 21.0,
+                                        "raw_hex": "0000a841",
+                                        "flags_access": "stable_ro",
+                                        "read_opcode": "0x06",
+                                        "read_opcode_label": "local",
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    }
+
+    store = BrowseStore.from_artifact(artifact)
+    by_node_id = {node.node_id: node for node in store.tree_nodes}
+    assert by_node_id["b524:ns:0x02:0x06"].label == "Remote (0x06)"
+    assert by_node_id["b524:inst:0x02:0x06:0x00"].label == "Remote Slot 1 (0x00)"
+    row = store.rows[0]
+    assert row.path == "B524/Heating Circuits/Remote (0x06)/0x00/0x0001"
 
 
 def test_browse_store_filters_rows_for_namespace_selection() -> None:

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -362,8 +362,38 @@ def test_html_report_splits_mixed_legacy_group_by_namespace_and_scopes_overrides
     html = render_html_report(artifact, title="test")
 
     assert "function splitInstancesByNamespace(instancesObj, fallbackNamespaceKey = null)" in html
-    assert "const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {});" in html
+    assert (
+        "const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {}, null);" in html
+    )
     assert "if (namespaceKeys.length > 1) {" in html
     assert "${namespaceLabel(activeNamespace, activeNamespace)} Registers" in html
     assert "if (namespaceKey) {" in html
     assert "return null;" in html
+
+
+def test_html_report_split_views_keep_unknown_namespace_entries_unassigned() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {"raw_hex": "01", "read_opcode": "0x02"},
+                            "0x0002": {"raw_hex": "02", "read_opcode": "0x06"},
+                            "0x0003": {"raw_hex": "03"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert '"0x0003":{"raw_hex":"03"}' in html
+    assert (
+        "const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {}, null);" in html
+    )
+    assert "if (!namespaceKey) continue;" in html

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -301,3 +301,69 @@ def test_html_report_does_not_use_single_namespace_identity_sentinel() -> None:
     assert '|| "single"' not in html
     assert 'namespaceKey || "0x00"' not in html
     assert ': "0x00"' not in html
+
+
+def test_html_report_namespace_helpers_are_opcode_key_authoritative() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {
+            "0x09": {
+                "name": "Regulators",
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x06": {
+                        "label": "local",
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {
+                                        "raw_hex": "0000a841",
+                                        "type": "EXP",
+                                        "value": 21.0,
+                                        "read_opcode": "0x06",
+                                        "read_opcode_label": "local",
+                                    }
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert "function canonicalNamespaceLabel(namespaceKey)" in html
+    assert 'if (trimmed === "local") return "0x02";' in html
+    assert 'if (trimmed === "remote") return "0x06";' in html
+    assert "if (canonical) {" in html
+    assert "(${namespaceKey})" in html
+
+
+def test_html_report_splits_mixed_legacy_group_by_namespace_and_scopes_overrides() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0001": {"raw_hex": "01", "read_opcode": "0x02"},
+                            "0x0002": {"raw_hex": "02", "read_opcode": "0x06"},
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert "function splitInstancesByNamespace(instancesObj, fallbackNamespaceKey = null)" in html
+    assert "const splitNamespaces = splitInstancesByNamespace(groupObj.instances || {});" in html
+    assert "if (namespaceKeys.length > 1) {" in html
+    assert "${namespaceLabel(activeNamespace, activeNamespace)} Registers" in html
+    assert "if (namespaceKey) {" in html
+    assert "return null;" in html

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -190,3 +190,61 @@ def test_render_summary_namespace_totals_ignore_stale_namespace_labels(tmp_path:
     assert "namespaces local (0x02)=1, remote (0x06)=1" in text
     assert "remote (0x02)" not in text
     assert "local (0x06)" not in text
+
+
+def test_render_summary_namespace_totals_use_namespace_container_when_opcode_missing(
+    tmp_path: Path,
+) -> None:
+    artifact = {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+            "scan_duration_seconds": 1.0,
+        },
+        "groups": {
+            "0x09": {
+                "name": "Regulators",
+                "descriptor_observed": 1.0,
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "label": "remote",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {
+                                    "0x0001": {
+                                        "read_opcode_label": "remote",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    }
+                                },
+                            }
+                        },
+                    },
+                    "0x06": {
+                        "label": "local",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {
+                                    "0x0002": {
+                                        "read_opcode_label": "local",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    }
+                                },
+                            }
+                        },
+                    },
+                },
+            }
+        },
+    }
+
+    console = Console(record=True, width=140)
+    render_summary(console, artifact, output_path=tmp_path / "artifact.json")
+    text = console.export_text()
+    assert "namespaces local (0x02)=1, remote (0x06)=1" in text
+    assert "remote (0x02)" not in text
+    assert "local (0x06)" not in text

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -83,10 +83,10 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     render_summary(console, artifact, output_path=tmp_path / "artifact.json")
 
     text = console.export_text()
-    assert "namespaces 0x02=2, 0x06=1" in text
+    assert "namespaces local (0x02)=2, remote (0x06)=1" in text
     assert "flags_access volatile_ro=0, stable_ro=2, technical_rw=0, user_rw=1" in text
     assert "b555 reads=4 errors=1 programs=2" in text
-    assert "local=1, remote=1" in text
+    assert "local (0x02)=1, remote (0x06)=1" in text
     assert "Regulators" in text
     assert "2/2" not in text
 
@@ -132,3 +132,61 @@ def test_render_summary_shows_b516_stats(tmp_path: Path) -> None:
 
     text = console.export_text()
     assert "b516 reads=12 errors=2 entries=2 incomplete=true" in text
+
+
+def test_render_summary_namespace_totals_ignore_stale_namespace_labels(tmp_path: Path) -> None:
+    artifact = {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+            "scan_duration_seconds": 1.0,
+        },
+        "groups": {
+            "0x02": {
+                "name": "Heating Circuits",
+                "descriptor_observed": 1.0,
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "label": "remote",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {
+                                    "0x0001": {
+                                        "read_opcode": "0x02",
+                                        "read_opcode_label": "remote",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    }
+                                },
+                            }
+                        },
+                    },
+                    "0x06": {
+                        "label": "local",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {
+                                    "0x0002": {
+                                        "read_opcode": "0x06",
+                                        "read_opcode_label": "local",
+                                        "flags_access": "stable_ro",
+                                        "error": None,
+                                    }
+                                },
+                            }
+                        },
+                    },
+                },
+            }
+        },
+    }
+
+    console = Console(record=True, width=140)
+    render_summary(console, artifact, output_path=tmp_path / "artifact.json")
+    text = console.export_text()
+    assert "namespaces local (0x02)=1, remote (0x06)=1" in text
+    assert "remote (0x02)" not in text
+    assert "local (0x06)" not in text


### PR DESCRIPTION
## What
- isolate browse store namespace behavior for legacy mixed-opcode single-namespace artifacts
- canonicalize namespace display identity in browse, CLI summary, and HTML report (`Local (0x02)`, `Remote (0x06)`) from opcode key
- prevent HTML type-override fallback from crossing namespaces when a namespace-scoped section is rendered
- split HTML rendering for mixed legacy groups into per-namespace sections so local/remote rows are not interleaved
- add tests for browse namespace isolation, summary stale-label guardrails, and HTML namespace-isolation helper behavior
- document the namespace-qualified behavior in README

## Why
Issue #206 requires browse/summary/report behavior to be namespace-isolated and resistant to stale migrated labels so reverse-engineering outputs cannot mix local/remote state.

## Validation
- `PYTHONPATH=src uv run pytest -q tests/test_browse_store.py tests/test_summary.py tests/test_html_report.py`
- `uv run ruff check src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/summary.py src/helianthus_vrc_explorer/ui/html_report.py tests/test_browse_store.py tests/test_summary.py tests/test_html_report.py`

## Agent State
Status: Ready for review
Branch: issue/206-b524-split-browse-cli-summary-html-by-namespace
Last verified (lint/tests): PYTHONPATH=src uv run pytest -q tests/test_browse_store.py tests/test_summary.py tests/test_html_report.py; uv run ruff check src/helianthus_vrc_explorer/ui/browse_store.py src/helianthus_vrc_explorer/ui/summary.py src/helianthus_vrc_explorer/ui/html_report.py tests/test_browse_store.py tests/test_summary.py tests/test_html_report.py
How to reproduce: checkout branch, run the validation commands above
Next steps: CI + review feedback
Notes (no secrets, no private infra): local workspace includes unrelated unstaged files (AGENTS.md/.claude/.codex/.venv311/uv.lock); not part of this PR