### PR TITLE
docs: codify B524 namespace invariants and refresh user docs (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ python -m helianthus_vrc_explorer scan \
 
 `scan` auto-discovers the destination (`--dst auto`) by default. Use `--dst 0x..` to force an address.
 
+Namespace contract for implementers:
+- Stable B524 namespace invariants (identity, discovery authority, constraint scope, artifact keys, fixture compatibility): [`docs/b524-namespace-invariants.md`](docs/b524-namespace-invariants.md)
+- This README remains user-facing; invariant-level semantics are documented in the file above once implementation behavior is stable.
+
 Key scan UX flags:
 - `--planner-ui auto|textual|classic`
 - `--preset conservative|recommended|full|custom`
@@ -57,7 +61,7 @@ Transport note:
 - On shared live `ebusd-tcp` setups, the first B524 directory probe (`GG=0x00`) can transiently return a status-only `00`. The scanner treats this as transient noise and continues discovery instead of declaring B524 unsupported immediately.
 - On `ebusd-tcp`, `ERR: timeout`, `ERR: arbitration lost`, `ERR: SYN received`, and `ERR: wrong symbol received` now trigger a fixed 5-second quiet backoff before retry so the bus can settle.
 - On `ebusd-tcp`, `ERR: no signal` now triggers a fixed 15-second quiet backoff before retry so the eBUS side can recover instead of being polled aggressively.
-- Classic GG directory-probe results are retained as advisory metadata for semantic identity and namespace topology. They are useful evidence for reverse-engineering and debugging, but they do not define those semantics once a group is a scan candidate. A `descriptor_type == 0.0` result is still used as a discovery-time negative hint for non-core/unknown groups in Phase A.
+- Classic GG directory-probe results are retained as advisory metadata for semantic identity and namespace topology. They are useful evidence for reverse-engineering and debugging, but they do not define those semantics once a group is a scan candidate (see `docs/b524-namespace-invariants.md`). A `descriptor_type == 0.0` result is still used as a discovery-time negative hint for non-core/unknown groups in Phase A.
 - Instance availability is namespace-specific. Dual-namespace radio groups (`0x09`, `0x0A`) are discovered independently per opcode namespace instead of sharing remote results across local and remote.
 - Artifacts retain the availability contract plus raw per-slot probe evidence under `availability_contract` and `availability_probes`, including the opcode `0x06` `RR=0x0001` `device_connected` probe used for remote namespaces.
 - Unknown groups are namespace-classified from live opcode responsiveness evidence. There is no implicit unknown-group `[0x02, 0x06]` fallback.

--- a/docs/b524-namespace-invariants.md
+++ b/docs/b524-namespace-invariants.md
@@ -1,0 +1,49 @@
+# B524 Namespace Invariants
+
+This document is the implementation-facing contract for B524 namespace behavior.
+User-facing guidance in `README.md` should reference this document and only describe
+behavior that is already stable in code/tests.
+
+## Scope
+
+- Applies to scanner planning/discovery, artifact schema, browse/report identity, and fixture migration.
+- Covers register families (`0x02`, `0x06`) and the `0x01` constraint probe scope decision.
+- Uses `opcode` as canonical namespace identity; labels like `local`/`remote` are display metadata.
+
+## Invariants
+
+1. Opcode-first identity is mandatory.
+   - Namespace key: `<opcode>` (for example `0x02`, `0x06`).
+   - Canonical register identity tuple: `(opcode, group, instance, register)`.
+   - Any GG-first fallback that can merge/opacify namespaces is invalid.
+
+2. Discovery is advisory, not semantic authority.
+   - GG directory probe (`opcode 0x00`) results are evidence for discovery flow only.
+   - Semantic identity, namespace topology, and row identity are not derived from descriptor values.
+   - **Ban:** GG discovery MUST NOT be used as semantic authority.
+
+3. Constraint scope is explicitly `gg_rr_invariant`.
+   - Decision: `gg_rr_invariant`.
+   - Rationale: `0x01` probe frame shape is `01 GG RR` and does not encode register-read opcode or instance.
+   - Outcome: static constraints are GG/RR-scoped across register-read namespaces.
+
+4. Artifact identity keys are namespace-aware.
+   - Persisted topology authority: `groups[*].dual_namespace` plus `groups[*].namespaces` (when present).
+   - UI/report dedupe key contract: `<group>:<namespace>:<instance>:<register>`.
+   - Path contract: `B524/<group-name>/<namespace-display>/<instance>/<register-name>`.
+
+5. Fixture compatibility is migration-based, not semantic rewrite.
+   - Current artifact schema: `2.1`.
+   - Legacy unversioned/`2.0` fixtures are migrated in-memory with register-count preservation.
+   - Migration may normalize container shape, but must not drop register entries or collapse namespace identity.
+   - Legacy mixed-opcode single-group artifacts are rendered split-by-namespace in browse/report consumers.
+
+## Historical Context
+
+Issues #120 and #125 remain useful exploratory context (how we reached the namespace split), but they are not active semantic authority. The active authority is:
+
+- current code behavior in this repository,
+- tests/fixtures that validate it,
+- and this invariants contract.
+
+When historical notes conflict with current contract, follow current contract and open a corrective docs issue/PR.


### PR DESCRIPTION
## Summary
- add a concise B524 namespace invariants contract at `docs/b524-namespace-invariants.md`
- codify opcode-first identity, advisory discovery semantics, constraint-scope decision, artifact identity keys, and fixture compatibility strategy
- update README user docs to point implementers to the invariants contract and align discovery wording with the explicit contract

## Acceptance Criteria Mapping
- [x] A concise invariants document lands first and explains opcode-first identity, advisory discovery, constraint-scope choice, artifact identity keys, and fixture compatibility strategy.
- [x] User-facing docs are updated after behavior stabilized in #201-#206 by linking README guidance to the finalized invariants contract.
- [x] References to exploratory work #120 and #125 are framed as historical context, not active authority.
- [x] Documentation explicitly bans using GG discovery as semantic authority.

## Checks
- [x] `./venv/bin/python scripts/check_protocol_terminology.py`
- [x] `./venv/bin/python scripts/check_b524_namespace_guardrails.py`
- [x] `./venv/bin/python scripts/check_docs_sync.py`

## Agent State
Status: Ready for review
Branch: issue/207-docs-b524-namespace-invariants-and-user-docs
Last verified (lint/tests): 2026-04-04 — terminology/namespace-guardrails/docs-sync checks passing
How to reproduce: checkout branch, run the three commands in the Checks section
Next steps: review wording, confirm doc-gate, merge into integration branch
Notes (no secrets, no private infra): only docs files changed for #207

Closes #207