### PR TITLE
Issue #222: fix planner namespace labels for GG 0x01

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -38,7 +38,13 @@ from ..ui.planner import PlannerGroup, PlannerPreset, build_plan_from_preset, pr
 from .b509 import scan_b509
 from .b516 import scan_b516
 from .b555 import scan_b555
-from .director import GROUP_CONFIG, DiscoveredGroup, classify_groups, discover_groups
+from .director import (
+    GROUP_CONFIG,
+    DiscoveredGroup,
+    classify_groups,
+    discover_groups,
+    group_namespace_profiles,
+)
 from .identity import make_register_identity, opcode_label
 from .observer import ScanObserver
 from .plan import (
@@ -103,6 +109,16 @@ def _planner_ii_max(ii_max: int | None) -> int | None:
 
 def _group_opcodes(group: int) -> tuple[RegisterOpcode, ...]:
     return tuple(opcodes_for_group(group))
+
+
+def _planner_source_opcodes(group: int) -> tuple[RegisterOpcode, ...]:
+    if group != 0x01:
+        return _group_opcodes(group)
+
+    profiles = group_namespace_profiles(group)
+    if not profiles:
+        return _group_opcodes(group)
+    return tuple(cast(RegisterOpcode, opcode) for opcode in sorted(profiles))
 
 
 def _primary_opcode(group: int) -> RegisterOpcode:
@@ -347,6 +363,45 @@ def _record_availability_probes(
     probe_map = cast(dict[str, Any], target.setdefault("availability_probes", {}))
     for instance, probe in sorted(probes.items()):
         probe_map[_hex_u8(instance)] = _serialize_availability_probe(probe)
+
+
+def _promote_group_artifact_to_dual_namespace(
+    artifact: dict[str, Any],
+    *,
+    group: int,
+    primary_opcode: RegisterOpcode,
+) -> None:
+    group_obj = artifact["groups"].get(_hex_u8(group))
+    if not isinstance(group_obj, dict) or bool(group_obj.get("dual_namespace")):
+        return
+
+    flat_instances = group_obj.pop("instances", {})
+    namespaces = group_obj.setdefault("namespaces", {})
+    if not isinstance(namespaces, dict):
+        namespaces = {}
+        group_obj["namespaces"] = namespaces
+
+    namespace_key = _hex_u8(primary_opcode)
+    namespace_obj = namespaces.setdefault(
+        namespace_key,
+        {
+            "label": opcode_label(primary_opcode),
+            "instances": {},
+        },
+    )
+    if not isinstance(namespace_obj, dict):
+        namespace_obj = {
+            "label": opcode_label(primary_opcode),
+            "instances": {},
+        }
+        namespaces[namespace_key] = namespace_obj
+
+    namespace_obj.setdefault("label", opcode_label(primary_opcode))
+    if isinstance(flat_instances, dict) and flat_instances:
+        namespace_obj["instances"] = flat_instances
+    else:
+        namespace_obj.setdefault("instances", {})
+    group_obj["dual_namespace"] = True
 
 
 def _present_instances_for_opcode(
@@ -1531,6 +1586,8 @@ def scan_b524(
             config = GROUP_CONFIG.get(group.group)
             group_meta = metadata_map[group.group]
             opcodes = resolved_group_opcodes.get(group.group, ())
+            if planner_mode != "disabled" and config is not None:
+                opcodes = _planner_source_opcodes(group.group)
             if not opcodes:
                 continue
             primary_opcode = opcodes[0]
@@ -1627,6 +1684,24 @@ def scan_b524(
                         default_plan=planner_default_plan,
                         default_preset=planner_preset,
                     )
+
+        group_dual_namespace_effective = dict(group_dual_namespace_runtime)
+        planned_opcodes_by_group: dict[int, set[int]] = {}
+        for group_plan in plan.values():
+            planned_opcodes_by_group.setdefault(group_plan.group, set()).add(group_plan.opcode)
+        for group, opcodes in planned_opcodes_by_group.items():
+            if len(opcodes) > 1:
+                group_dual_namespace_effective[group] = True
+                primary_opcode = (
+                    _primary_opcode(group)
+                    if group in GROUP_CONFIG
+                    else cast(RegisterOpcode, min(opcodes))
+                )
+                _promote_group_artifact_to_dual_namespace(
+                    artifact,
+                    group=group,
+                    primary_opcode=primary_opcode,
+                )
 
         artifact["meta"]["scan_plan"] = {
             "groups": _scan_plan_meta_groups(plan),
@@ -1841,7 +1916,7 @@ def scan_b524(
                     group=task.group,
                     name="Unknown",
                     descriptor_observed=None,
-                    dual_namespace=group_dual_namespace_runtime.get(task.group, False),
+                    dual_namespace=group_dual_namespace_effective.get(task.group, False),
                 )
                 instances_obj = _instances_object(
                     artifact,

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -404,6 +404,36 @@ def _promote_group_artifact_to_dual_namespace(
     group_obj["dual_namespace"] = True
 
 
+def _apply_effective_namespace_topology(
+    artifact: dict[str, Any],
+    *,
+    group_dual_namespace_runtime: Mapping[int, bool],
+    plan: Mapping[PlanKey, GroupScanPlan],
+) -> dict[int, bool]:
+    effective = dict(group_dual_namespace_runtime)
+    planned_opcodes_by_group: dict[int, set[RegisterOpcode]] = {}
+    for group_plan in plan.values():
+        group_id = group_plan.group
+        planned_opcodes = planned_opcodes_by_group.setdefault(group_id, set())
+        planned_opcodes.add(group_plan.opcode)
+
+    for group_id, planned_opcodes in planned_opcodes_by_group.items():
+        if len(planned_opcodes) <= 1:
+            continue
+        effective[group_id] = True
+        primary_opcode = (
+            _primary_opcode(group_id)
+            if group_id in GROUP_CONFIG
+            else cast(RegisterOpcode, min(planned_opcodes))
+        )
+        _promote_group_artifact_to_dual_namespace(
+            artifact,
+            group=group_id,
+            primary_opcode=primary_opcode,
+        )
+    return effective
+
+
 def _present_instances_for_opcode(
     artifact: dict[str, Any],
     *,
@@ -1685,23 +1715,11 @@ def scan_b524(
                         default_preset=planner_preset,
                     )
 
-        group_dual_namespace_effective = dict(group_dual_namespace_runtime)
-        planned_opcodes_by_group: dict[int, set[int]] = {}
-        for group_plan in plan.values():
-            planned_opcodes_by_group.setdefault(group_plan.group, set()).add(group_plan.opcode)
-        for group, opcodes in planned_opcodes_by_group.items():
-            if len(opcodes) > 1:
-                group_dual_namespace_effective[group] = True
-                primary_opcode = (
-                    _primary_opcode(group)
-                    if group in GROUP_CONFIG
-                    else cast(RegisterOpcode, min(opcodes))
-                )
-                _promote_group_artifact_to_dual_namespace(
-                    artifact,
-                    group=group,
-                    primary_opcode=primary_opcode,
-                )
+        group_dual_namespace_effective = _apply_effective_namespace_topology(
+            artifact,
+            group_dual_namespace_runtime=group_dual_namespace_runtime,
+            plan=plan,
+        )
 
         artifact["meta"]["scan_plan"] = {
             "groups": _scan_plan_meta_groups(plan),
@@ -1778,6 +1796,11 @@ def scan_b524(
                                 default_plan=plan,
                                 default_preset=planner_preset,
                             )
+                    group_dual_namespace_effective = _apply_effective_namespace_topology(
+                        artifact,
+                        group_dual_namespace_runtime=group_dual_namespace_runtime,
+                        plan=plan,
+                    )
                     artifact["meta"]["scan_plan"]["groups"] = _scan_plan_meta_groups(plan)
                     artifact["meta"]["scan_plan"]["estimated_register_requests"] = (
                         estimate_register_requests(plan)

--- a/src/helianthus_vrc_explorer/ui/planner_textual.py
+++ b/src/helianthus_vrc_explorer/ui/planner_textual.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..scanner.identity import opcode_label
 from ..scanner.plan import (
     GroupScanPlan,
     PlanKey,
@@ -20,6 +21,25 @@ class _EditableGroup:
     enabled: bool
     rr_max: int
     instances: tuple[int, ...]
+
+
+def _namespace_text(group: PlannerGroup) -> str:
+    return group.namespace_label or opcode_label(group.opcode)
+
+
+def _table_row_values(state: _EditableGroup) -> tuple[str, str, str, str, str, str, str]:
+    group = state.group
+    mark = "✓" if state.enabled else " "
+    name = group.name if group.known else f"{group.name} (experimental)"
+    return (
+        mark,
+        f"0x{group.group:02X}",
+        name,
+        _namespace_text(group),
+        f"{group.descriptor:.1f}",
+        _format_instances(group, state.instances, enabled=state.enabled),
+        f"0x{state.rr_max:04X}",
+    )
 
 
 def _format_instances(group: PlannerGroup, instances: tuple[int, ...], *, enabled: bool) -> str:
@@ -215,7 +235,7 @@ def run_textual_scan_plan(
         def on_mount(self) -> None:
             table = self.query_one(DataTable)
             table.cursor_type = "row"
-            table.add_columns("On", "GG", "Name", "Type", "Instances", "RR_max")
+            table.add_columns("On", "GG", "Name", "Namespace", "Type", "Instances", "RR_max")
             self._refresh_table()
             self._set_help("1/2/3/4 presets | Space toggle | Enter edit RR_max | i edit instances")
             table.focus()
@@ -244,16 +264,7 @@ def run_textual_scan_plan(
             self._row_groups = []
             for group in self._groups:
                 state = self._states[group.key]
-                mark = "✓" if state.enabled else " "
-                name = group.display_name if group.known else f"{group.display_name} (experimental)"
-                table.add_row(
-                    mark,
-                    f"0x{group.group:02X}",
-                    name,
-                    f"{group.descriptor:.1f}",
-                    _format_instances(group, state.instances, enabled=state.enabled),
-                    f"0x{state.rr_max:04X}",
-                )
+                table.add_row(*_table_row_values(state))
                 self._row_groups.append(group.key)
             if self._row_groups:
                 table.move_cursor(row=min(current, len(self._row_groups) - 1))

--- a/tests/test_planner_textual.py
+++ b/tests/test_planner_textual.py
@@ -5,6 +5,7 @@ from helianthus_vrc_explorer.ui.planner_textual import (
     _EditableGroup,
     _estimate_footer,
     _parse_instances_spec,
+    _table_row_values,
 )
 
 
@@ -49,3 +50,58 @@ def test_estimate_footer_reports_requests_and_eta() -> None:
     assert "Plan: 6 requests" in footer
     assert "ETA:" in footer
     assert "1 plan entries selected" in footer
+
+
+def test_table_row_values_show_explicit_namespace_column() -> None:
+    remote_group = PlannerGroup(
+        group=0x01,
+        opcode=0x06,
+        name="Hot Water Circuit",
+        descriptor=3.0,
+        known=True,
+        ii_max=None,
+        rr_max=0x0015,
+        rr_max_full=0x0015,
+        present_instances=(0x00,),
+        namespace_label="remote",
+        primary=False,
+    )
+    local_only_group = PlannerGroup(
+        group=0x00,
+        opcode=0x02,
+        name="Regulator Parameters",
+        descriptor=3.0,
+        known=True,
+        ii_max=None,
+        rr_max=0x00FF,
+        rr_max_full=0x00FF,
+        present_instances=(0x00,),
+    )
+
+    remote_row = _table_row_values(
+        _EditableGroup(
+            group=remote_group,
+            enabled=True,
+            rr_max=0x0015,
+            instances=(0x00,),
+        )
+    )
+    local_row = _table_row_values(
+        _EditableGroup(
+            group=local_only_group,
+            enabled=False,
+            rr_max=0x00FF,
+            instances=(0x00,),
+        )
+    )
+
+    assert remote_row == ("✓", "0x01", "Hot Water Circuit", "remote", "3.0", "singleton", "0x0015")
+    assert local_row == (
+        " ",
+        "0x00",
+        "Regulator Parameters",
+        "local",
+        "3.0",
+        "singleton",
+        "0x00FF",
+    )

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -182,6 +182,40 @@ def _write_fixture_groups_00_and_01(tmp_path: Path) -> Path:
     return path
 
 
+def _write_fixture_group_01_namespaces(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x02"}},
+        "groups": {
+            "0x01": {
+                "descriptor_type": 3.0,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "02"},
+                                }
+                            }
+                        }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "06"},
+                                }
+                            }
+                        }
+                    },
+                },
+            }
+        },
+    }
+    path = tmp_path / "fixture_group_01_namespaces.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
 def _write_fixture_unknown_group_69(tmp_path: Path) -> Path:
     fixture = {
         "meta": {"dummy_transport": {"directory_terminator_group": "0x6a"}},
@@ -1340,8 +1374,9 @@ def test_scan_b524_recommended_plan_keeps_namespace_rr_max(tmp_path: Path) -> No
     assert artifact["meta"]["scan_plan"]["estimated_register_requests"] == 70
 
 
-def test_planner_source_opcodes_include_staged_group_01_remote_but_keep_group_00_local_only(
-) -> None:
+def test_planner_source_opcodes_include_staged_group_01_remote_but_keep_group_00_local_only() -> (
+    None
+):
     assert _planner_source_opcodes(0x00) == (0x02,)
     assert _planner_source_opcodes(0x01) == (0x02, 0x06)
 
@@ -1622,6 +1657,93 @@ def test_scan_b524_replan_before_first_completed_task_does_not_divide_by_zero(
     )
 
     assert artifact["meta"]["incomplete"] is False
+
+
+def test_scan_b524_replan_promotes_group_01_to_dual_namespace_before_queue_rebuild(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+    from contextlib import contextmanager
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+
+    class _FakeHotkeys:
+        def __init__(self, *, enabled: bool) -> None:
+            self._enabled = enabled
+            self._poll_calls = 0
+
+        def __enter__(self) -> _FakeHotkeys:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def poll(self) -> bool:
+            if not self._enabled:
+                return False
+            self._poll_calls += 1
+            return self._poll_calls == 2
+
+        @contextmanager
+        def suspend(self):
+            yield None
+
+    transport = RecordingTransport(DummyTransport(_write_fixture_group_01_namespaces(tmp_path)))
+    planner_calls = {"count": 0}
+
+    def fake_prompt_scan_plan(*_args, **_kwargs):
+        planner_calls["count"] += 1
+        if planner_calls["count"] == 1:
+            return {
+                make_plan_key(0x01, 0x02): GroupScanPlan(
+                    group=0x01,
+                    opcode=0x02,
+                    rr_max=0x0001,
+                    instances=(0x00,),
+                )
+            }
+        return {
+            make_plan_key(0x01, 0x02): GroupScanPlan(
+                group=0x01,
+                opcode=0x02,
+                rr_max=0x0001,
+                instances=(0x00,),
+            ),
+            make_plan_key(0x01, 0x06): GroupScanPlan(
+                group=0x01,
+                opcode=0x06,
+                rr_max=0x0000,
+                instances=(0x00,),
+            ),
+        }
+
+    monkeypatch.setattr(scan_mod, "_PlannerHotkeyReader", _FakeHotkeys)
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", fake_prompt_scan_plan)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+    )
+
+    group = artifact["groups"]["0x01"]
+    assert group["dual_namespace"] is True
+    assert "instances" not in group
+    assert (
+        group["namespaces"]["0x02"]["instances"]["0x00"]["registers"]["0x0000"]["raw_hex"] == "02"
+    )
+    assert (
+        group["namespaces"]["0x06"]["instances"]["0x00"]["registers"]["0x0000"]["raw_hex"] == "06"
+    )
+
+    scan_plan = artifact["meta"]["scan_plan"]["groups"]["0x01"]
+    assert scan_plan["dual_namespace"] is True
+    assert set(scan_plan["namespaces"]) == {"0x02", "0x06"}
+    assert (0x06, 0x01, 0x00, 0x0000) in transport.register_reads
 
 
 def test_scan_b524_replan_textual_failure_prompts_classic_immediately(

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -11,6 +11,7 @@ from helianthus_vrc_explorer.scanner.observer import ScanObserver
 from helianthus_vrc_explorer.scanner.plan import GroupScanPlan, make_plan_key
 from helianthus_vrc_explorer.scanner.scan import (
     _apply_contextual_enum_annotations,
+    _planner_source_opcodes,
     _probe_unknown_group_opcodes,
     scan_b524,
 )
@@ -133,6 +134,50 @@ def _write_fixture_group_00(tmp_path: Path) -> Path:
         },
     }
     path = tmp_path / "fixture_group_00.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    return path
+
+
+def _write_fixture_groups_00_and_01(tmp_path: Path) -> Path:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x02"}},
+        "groups": {
+            "0x00": {
+                "descriptor_type": 3.0,
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0000": {"raw_hex": "00"},
+                        }
+                    }
+                },
+            },
+            "0x01": {
+                "descriptor_type": 3.0,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                }
+                            }
+                        }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0000": {"raw_hex": "00"},
+                                }
+                            }
+                        }
+                    },
+                },
+            },
+        },
+    }
+    path = tmp_path / "fixture_groups_00_and_01.json"
     path.write_text(json.dumps(fixture), encoding="utf-8")
     return path
 
@@ -1295,6 +1340,12 @@ def test_scan_b524_recommended_plan_keeps_namespace_rr_max(tmp_path: Path) -> No
     assert artifact["meta"]["scan_plan"]["estimated_register_requests"] == 70
 
 
+def test_planner_source_opcodes_include_staged_group_01_remote_but_keep_group_00_local_only(
+) -> None:
+    assert _planner_source_opcodes(0x00) == (0x02,)
+    assert _planner_source_opcodes(0x01) == (0x02, 0x06)
+
+
 def test_scan_b524_disabled_planner_skips_interactive_planner_even_on_tty(
     monkeypatch,
     tmp_path: Path,
@@ -1448,6 +1499,50 @@ def test_scan_b524_textual_failure_falls_back_to_classic_in_auto_mode(
 
     assert artifact["meta"]["incomplete"] is False
     assert classic_called["count"] >= 1
+
+
+def test_scan_b524_textual_planner_receives_group_01_remote_and_keeps_group_00_local_only(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    captured: dict[str, object] = {}
+
+    def fake_run_textual_scan_plan(groups, **kwargs):
+        captured["groups"] = groups
+        captured["default_plan"] = kwargs["default_plan"]
+        return {}
+
+    monkeypatch.setattr(
+        "helianthus_vrc_explorer.ui.planner_textual.run_textual_scan_plan",
+        fake_run_textual_scan_plan,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        DummyTransport(_write_fixture_groups_00_and_01(tmp_path)),
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="textual",
+        planner_preset="recommended",
+    )
+
+    planner_groups = captured["groups"]
+    assert isinstance(planner_groups, list)
+    planner_keys = {(group.group, group.opcode) for group in planner_groups}
+    assert (0x00, 0x02) in planner_keys
+    assert (0x00, 0x06) not in planner_keys
+    assert (0x01, 0x02) in planner_keys
+    assert (0x01, 0x06) in planner_keys
+
+    default_plan = captured["default_plan"]
+    assert isinstance(default_plan, dict)
+    assert make_plan_key(0x01, 0x02) in default_plan
+    assert make_plan_key(0x01, 0x06) in default_plan
+    assert make_plan_key(0x00, 0x06) not in default_plan
+    assert artifact["meta"]["scan_plan"]["estimated_register_requests"] == 0
 
 
 def test_scan_b524_textual_failure_raises_in_forced_textual_mode(


### PR DESCRIPTION
## Summary
- expose GG=0x01 remote from the planner-only namespace-aware source while leaving GG=0x00 remote unexposed
- add an explicit Namespace column to the Textual planner so local vs remote rows are unambiguous
- add regression coverage for planner candidate generation and Textual namespace labeling

## Test plan
- [x] `PYTHONPATH=src uv run --extra dev ruff check src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/ui/planner_textual.py tests/test_planner_textual.py tests/test_scanner_scan.py`
- [x] `PYTHONPATH=src uv run --extra dev pytest tests/test_planner_textual.py tests/test_scanner_scan.py tests/test_scanner_director.py tests/test_scanner_register.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)