### PR TITLE
Issue #224: scope seeded static constraints to opcode 0x02

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Transport note:
 Constraint note:
 - Normal scans use a bundled static BASV2 constraint catalog and flag values that fall outside it.
 - `--probe-constraints` is a separate live rescan path for opcode `0x01`; it can add hundreds of extra requests and should only be used when you need to confirm a mismatch or do research work.
-- Constraint scope decision: `gg_rr_invariant`. The opcode `0x01` probe frame (`01 GG RR`) does not carry register-read opcode (`0x02`/`0x06`) or instance, so constraints are treated as GG/RR-scoped invariants across local and remote namespaces.
+- Constraint scope decision: `opcode_0x02_default`. The bundled static catalog is seeded from opcode `0x01` probe evidence, but it is only applied to opcode `0x02` by default. Remote opcode `0x06` requires explicit scope or live confirmation via `--probe-constraints`.
 - Artifacts record this decision in `meta.constraint_scope` and per-entry fields (`constraint_scope`, `constraint_provenance`) so report/UI consumers do not guess scope semantics.
 - `--preset full` is intentionally expensive: it expands all instance slots and full RR ranges and can take hours on BASV2.
 

--- a/docs/b524-namespace-invariants.md
+++ b/docs/b524-namespace-invariants.md
@@ -22,10 +22,10 @@ behavior that is already stable in code/tests.
    - Semantic identity, namespace topology, and row identity are not derived from descriptor values.
    - **Ban:** GG discovery MUST NOT be used as semantic authority.
 
-3. Constraint scope is explicitly `gg_rr_invariant`.
-   - Decision: `gg_rr_invariant`.
-   - Rationale: `0x01` probe frame shape is `01 GG RR` and does not encode register-read opcode or instance.
-   - Outcome: static constraints are GG/RR-scoped across register-read namespaces.
+3. Constraint scope is explicitly `opcode_0x02_default`.
+   - Decision: `opcode_0x02_default`.
+   - Rationale: the bundled static catalog is seeded from `0x01` probe evidence, but it is only trusted for opcode `0x02` by default.
+   - Outcome: remote opcode `0x06` does not inherit seeded static constraints unless a constraint entry explicitly scopes into that namespace or a live probe confirms it.
 
 4. Artifact identity keys are namespace-aware.
    - Persisted topology authority: `groups[*].dual_namespace` plus `groups[*].namespaces` (when present).

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -17,8 +17,8 @@ from rich.console import Console
 from ..artifact_schema import CURRENT_ARTIFACT_SCHEMA_VERSION
 from ..protocol.b524 import RegisterOpcode, build_constraint_probe_payload
 from ..schema.b524_constraints import (
-    CONSTRAINT_SCOPE_DECISION,
     CONSTRAINT_SCOPE_PROTOCOL,
+    LIVE_PROBE_CONSTRAINT_SCOPE,
     StaticConstraintCatalog,
     StaticConstraintEntry,
     constraint_scope_metadata,
@@ -611,7 +611,7 @@ class ConstraintEntry:
     step_value: int | float
     raw_hex: str
     source: str = "opcode_0x01"
-    scope: str = CONSTRAINT_SCOPE_DECISION
+    scope: str = LIVE_PROBE_CONSTRAINT_SCOPE
     provenance: str = "live_probe_from_opcode_0x01"
 
 
@@ -1958,9 +1958,9 @@ def scan_b524(
             artifact["meta"]["constraint_rescan_recommended"] = True
             if observer is not None:
                 observer.log(
-                    "Observed register values outside the bundled static constraint catalog. "
-                    "Review meta.constraint_mismatches and rerun with --probe-constraints if "
-                    "you want live confirmation.",
+                    "Observed opcode 0x02 register values outside the bundled static "
+                    "constraint catalog. Review meta.constraint_mismatches and rerun with "
+                    "--probe-constraints if you want live confirmation.",
                     level="warn",
                 )
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -1958,9 +1958,9 @@ def scan_b524(
             artifact["meta"]["constraint_rescan_recommended"] = True
             if observer is not None:
                 observer.log(
-                    "Observed opcode 0x02 register values outside the bundled static "
-                    "constraint catalog. Review meta.constraint_mismatches and rerun with "
-                    "--probe-constraints if you want live confirmation.",
+                    "Observed register values outside the scoped bundled static "
+                    "constraint catalog. Review meta.constraint_mismatches and rerun "
+                    "with --probe-constraints if you want live confirmation.",
                     level="warn",
                 )
 

--- a/src/helianthus_vrc_explorer/schema/b524_constraints.py
+++ b/src/helianthus_vrc_explorer/schema/b524_constraints.py
@@ -14,13 +14,17 @@ _KIND_TO_TT = {
     "f32_range": 0x0F,
 }
 
-CONSTRAINT_SCOPE_DECISION = "gg_rr_invariant"
+_DEFAULT_STATIC_READ_OPCODES = (0x02,)
+
+CONSTRAINT_SCOPE_DECISION = "opcode_0x02_default"
 CONSTRAINT_SCOPE_PROTOCOL = "opcode_0x01"
-CONSTRAINT_SCOPE_APPLIES_TO = "all_register_read_namespaces"
+CONSTRAINT_SCOPE_APPLIES_TO = "opcode_0x02_by_default_unless_explicitly_scoped"
 CONSTRAINT_SCOPE_RATIONALE = (
-    "B524 constraint probe frames (01 GG RR) do not encode register-read opcode or "
-    "instance, so static constraints are treated as GG/RR-scoped invariants."
+    "The bundled static catalog is seeded from opcode-0x01 probe evidence, but it is "
+    "only applied to opcode 0x02 by default. Remote opcode 0x06 requires explicit scope "
+    "or live confirmation."
 )
+LIVE_PROBE_CONSTRAINT_SCOPE = "opcode_0x01_probe"
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,6 +37,7 @@ class StaticConstraintEntry:
     source: str = "static_catalog"
     scope: str = CONSTRAINT_SCOPE_DECISION
     provenance: str = "catalog_seeded_from_opcode_0x01"
+    read_opcodes: tuple[int, ...] = _DEFAULT_STATIC_READ_OPCODES
 
 
 type StaticConstraintCatalog = dict[int, dict[int, StaticConstraintEntry]]
@@ -80,6 +85,45 @@ def _parse_numeric(value: str) -> int | float:
     return parsed
 
 
+def _parse_constraint_read_opcodes(*, raw_scope: str, raw_opcodes: str) -> tuple[int, ...]:
+    scope = raw_scope.strip().lower()
+    if scope == "gg_rr_invariant":
+        return (0x02, 0x06)
+
+    value = raw_opcodes.strip().lower()
+    if not value:
+        return _DEFAULT_STATIC_READ_OPCODES
+    if value in {"all", "all_register_read_namespaces", "0x02+0x06"}:
+        return (0x02, 0x06)
+
+    normalized = value.replace("|", ",").replace("+", ",")
+    opcodes: list[int] = []
+    for token in normalized.split(","):
+        candidate = token.strip()
+        if not candidate:
+            continue
+        opcode = _parse_hex_u8(candidate)
+        if opcode not in {0x02, 0x06}:
+            raise ValueError(f"Unsupported constraint read opcode: {candidate!r}")
+        if opcode not in opcodes:
+            opcodes.append(opcode)
+    if not opcodes:
+        return _DEFAULT_STATIC_READ_OPCODES
+    return tuple(opcodes)
+
+
+def _constraint_scope_label(*, raw_scope: str, read_opcodes: tuple[int, ...]) -> str:
+    if raw_scope.strip():
+        return raw_scope.strip()
+    if read_opcodes == _DEFAULT_STATIC_READ_OPCODES:
+        return CONSTRAINT_SCOPE_DECISION
+    if read_opcodes == (0x06,):
+        return "opcode_0x06_only"
+    if read_opcodes == (0x02, 0x06):
+        return "explicit_opcode_0x02_0x06"
+    return "explicit_opcode_scope"
+
+
 def load_b524_constraints_catalog_from_path(path: Path) -> StaticConstraintCatalog:
     catalog: StaticConstraintCatalog = {}
 
@@ -94,6 +138,8 @@ def load_b524_constraints_catalog_from_path(path: Path) -> StaticConstraintCatal
             min_raw = (row.get("min") or "").strip()
             max_raw = (row.get("max") or "").strip()
             step_raw = (row.get("step") or "").strip()
+            scope_raw = (row.get("scope") or "").strip()
+            opcodes_raw = (row.get("read_opcodes") or "").strip()
             if not all((group_raw, register_raw, kind, min_raw, max_raw, step_raw)):
                 continue
             tt = _KIND_TO_TT.get(kind)
@@ -101,12 +147,21 @@ def load_b524_constraints_catalog_from_path(path: Path) -> StaticConstraintCatal
                 raise ValueError(f"Unsupported static constraint kind: {kind!r}")
             group = _parse_hex_u8(group_raw)
             register = _parse_hex_u16(register_raw)
+            read_opcodes = _parse_constraint_read_opcodes(
+                raw_scope=scope_raw,
+                raw_opcodes=opcodes_raw,
+            )
             entry = StaticConstraintEntry(
                 tt=tt,
                 kind=kind,
                 min_value=_parse_scalar(min_raw),
                 max_value=_parse_scalar(max_raw),
                 step_value=_parse_numeric(step_raw),
+                scope=_constraint_scope_label(
+                    raw_scope=scope_raw,
+                    read_opcodes=read_opcodes,
+                ),
+                read_opcodes=read_opcodes,
             )
             catalog.setdefault(group, {})
             if register in catalog[group]:
@@ -145,9 +200,14 @@ def lookup_static_constraint(
 ) -> StaticConstraintEntry | None:
     """Resolve the current static catalog using canonical register identity.
 
-    The static catalog remains GG/RR-scoped because the underlying opcode-0x01
-    constraint protocol does not encode opcode or instance.
+    The bundled static catalog is opcode-0x02-scoped by default. Individual rows
+    may opt into other namespaces via explicit read-opcode metadata.
     """
 
-    _opcode, group, _instance, register = identity
-    return catalog.get(group, {}).get(register)
+    opcode, group, _instance, register = identity
+    entry = catalog.get(group, {}).get(register)
+    if entry is None:
+        return None
+    if opcode not in entry.read_opcodes:
+        return None
+    return entry

--- a/tests/test_issue_208_namespace_anti_regression.py
+++ b/tests/test_issue_208_namespace_anti_regression.py
@@ -73,7 +73,7 @@ def test_issue_208_artifact_round_trip_stability_preserves_identity_set() -> Non
     assert _register_identity_set(migrated_once) == _register_identity_set(migrated_twice)
 
 
-def test_issue_208_constraint_scope_is_opcode_invariant_for_same_group_register(
+def test_issue_208_constraint_scope_defaults_to_opcode_0x02_only(
     tmp_path: Path,
 ) -> None:
     catalog_path = tmp_path / "constraints.csv"
@@ -101,8 +101,7 @@ def test_issue_208_constraint_scope_is_opcode_invariant_for_same_group_register(
     )
 
     assert local is not None
-    assert remote is not None
-    assert local == remote
+    assert remote is None
     assert local.scope == CONSTRAINT_SCOPE_DECISION
     assert local.kind == "f32_range"
     assert local.min_value == 15

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -599,7 +599,7 @@ def test_scan_b524_collects_constraint_dictionary_entries(tmp_path: Path) -> Non
     assert constraints["min"] == 0
     assert constraints["max"] == 4
     assert constraints["step"] == 1
-    assert constraints["scope"] == "gg_rr_invariant"
+    assert constraints["scope"] == "opcode_0x01_probe"
     assert constraints["provenance"] == "live_probe_from_opcode_0x01"
     assert transport.register_reads is not None
     scanned_registers = {
@@ -650,11 +650,11 @@ def test_scan_b524_skips_constraint_dictionary_by_default(tmp_path: Path) -> Non
     assert transport.constraint_requests == []
     assert artifact["meta"]["constraint_probe_enabled"] is False
     assert artifact["meta"]["constraint_dictionary"] == {}
-    assert artifact["meta"]["constraint_scope"]["decision"] == "gg_rr_invariant"
+    assert artifact["meta"]["constraint_scope"]["decision"] == "opcode_0x02_default"
     assert artifact["meta"]["constraint_scope"]["protocol"] == "opcode_0x01"
     entry = artifact["groups"]["0x02"]["instances"]["0x00"]["registers"]["0x0002"]
     assert entry["constraint_source"] == "static_catalog"
-    assert entry["constraint_scope"] == "gg_rr_invariant"
+    assert entry["constraint_scope"] == "opcode_0x02_default"
     assert entry["constraint_provenance"] == "catalog_seeded_from_opcode_0x01"
     assert entry["constraint_type"] == "u16_range"
     assert entry["constraint_min"] == 0
@@ -697,10 +697,62 @@ def test_scan_b524_flags_seeded_constraint_mismatch(tmp_path: Path) -> None:
     assert mismatches[0]["group"] == "0x02"
     assert mismatches[0]["register"] == "0x0002"
     assert mismatches[0]["value"] == 5
-    assert mismatches[0]["constraint_scope"] == "gg_rr_invariant"
+    assert mismatches[0]["constraint_scope"] == "opcode_0x02_default"
     assert mismatches[0]["constraint_provenance"] == "catalog_seeded_from_opcode_0x01"
     assert mismatches[0]["constraint_probe_protocol"] == "opcode_0x01"
     assert artifact["meta"]["constraint_rescan_recommended"] is True
+
+
+def test_scan_b524_does_not_flag_remote_seeded_static_constraint_mismatch(
+    tmp_path: Path,
+) -> None:
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x0a"}},
+        "groups": {
+            "0x09": {
+                "descriptor_type": 1.0,
+                "namespaces": {
+                    "0x02": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {"raw_hex": "34"},
+                                }
+                            }
+                        }
+                    },
+                    "0x06": {
+                        "instances": {
+                            "0x00": {
+                                "registers": {
+                                    "0x0001": {"raw_hex": "01"},
+                                    "0x0002": {"raw_hex": "15"},
+                                }
+                            }
+                        }
+                    },
+                },
+            },
+        },
+    }
+    fixture_path = tmp_path / "remote_constraint_scope.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    artifact = scan_b524(
+        DummyTransport(fixture_path),
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+    )
+
+    remote_entry = (
+        artifact["groups"]["0x09"]["namespaces"]["0x06"]["instances"]["0x00"]["registers"]["0x0002"]
+    )
+    assert remote_entry["value"] == 21
+    assert "constraint_source" not in remote_entry
+    assert "constraint_mismatch_reason" not in remote_entry
+    assert artifact["meta"].get("constraint_mismatches") is None
 
 
 def test_scan_b524_group_bounds_come_from_profile_defaults(tmp_path: Path) -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -746,9 +746,9 @@ def test_scan_b524_does_not_flag_remote_seeded_static_constraint_mismatch(
         planner_ui="classic",
     )
 
-    remote_entry = (
-        artifact["groups"]["0x09"]["namespaces"]["0x06"]["instances"]["0x00"]["registers"]["0x0002"]
-    )
+    remote_entry = artifact["groups"]["0x09"]["namespaces"]["0x06"]["instances"]["0x00"][
+        "registers"
+    ]["0x0002"]
     assert remote_entry["value"] == 21
     assert "constraint_source" not in remote_entry
     assert "constraint_mismatch_reason" not in remote_entry

--- a/tests/test_schema_b524_constraints.py
+++ b/tests/test_schema_b524_constraints.py
@@ -73,7 +73,7 @@ def test_lookup_static_constraint_accepts_explicit_read_opcode_scope(tmp_path: P
         "\n".join(
             (
                 "group,register,type,min,max,step,read_opcodes",
-                "0x03,0x0002,f32_range,15,30,0.5,\"0x02,0x06\"",
+                '0x03,0x0002,f32_range,15,30,0.5,"0x02,0x06"',
             )
         )
         + "\n",

--- a/tests/test_schema_b524_constraints.py
+++ b/tests/test_schema_b524_constraints.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from helianthus_vrc_explorer.scanner.identity import make_register_identity
 from helianthus_vrc_explorer.schema.b524_constraints import (
     constraint_scope_metadata,
+    load_b524_constraints_catalog_from_path,
     load_default_b524_constraints_catalog,
     lookup_static_constraint,
 )
@@ -20,8 +23,9 @@ def test_load_default_b524_constraints_catalog() -> None:
     assert hc_room_setpoint.max_value == 4
     assert hc_room_setpoint.step_value == 1
     assert hc_room_setpoint.source == "static_catalog"
-    assert hc_room_setpoint.scope == "gg_rr_invariant"
+    assert hc_room_setpoint.scope == "opcode_0x02_default"
     assert hc_room_setpoint.provenance == "catalog_seeded_from_opcode_0x01"
+    assert hc_room_setpoint.read_opcodes == (0x02,)
 
     zone_desired_temp = catalog[0x03][0x0002]
     assert zone_desired_temp.tt == 0x0F
@@ -31,13 +35,13 @@ def test_load_default_b524_constraints_catalog() -> None:
     assert zone_desired_temp.step_value == 0.5
 
 
-def test_lookup_static_constraint_accepts_canonical_register_identity() -> None:
+def test_lookup_static_constraint_defaults_to_opcode_0x02() -> None:
     catalog, _source = load_default_b524_constraints_catalog()
 
     entry = lookup_static_constraint(
         catalog,
         identity=make_register_identity(
-            opcode=0x06,
+            opcode=0x02,
             group=0x02,
             instance=0x00,
             register=0x0002,
@@ -48,34 +52,62 @@ def test_lookup_static_constraint_accepts_canonical_register_identity() -> None:
     assert entry.kind == "u16_range"
 
 
-def test_lookup_static_constraint_is_opcode_invariant_for_same_group_register() -> None:
+def test_lookup_static_constraint_skips_remote_opcode_by_default() -> None:
     catalog, _source = load_default_b524_constraints_catalog()
-    pairs = [(0x02, 0x0002), (0x03, 0x0002), (0x09, 0x0002)]
-    for group, register in pairs:
-        local = lookup_static_constraint(
-            catalog,
-            identity=make_register_identity(
-                opcode=0x02,
-                group=group,
-                instance=0x00,
-                register=register,
-            ),
-        )
-        remote = lookup_static_constraint(
-            catalog,
-            identity=make_register_identity(
-                opcode=0x06,
-                group=group,
-                instance=0x01,
-                register=register,
-            ),
-        )
-        assert local is not None
-        assert remote is not None
-        assert local == remote
+    remote = lookup_static_constraint(
+        catalog,
+        identity=make_register_identity(
+            opcode=0x06,
+            group=0x03,
+            instance=0x01,
+            register=0x0002,
+        ),
+    )
+
+    assert remote is None
 
 
-def test_constraint_scope_metadata_declares_gg_rr_invariant_policy() -> None:
+def test_lookup_static_constraint_accepts_explicit_read_opcode_scope(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "constraints.csv"
+    catalog_path.write_text(
+        "\n".join(
+            (
+                "group,register,type,min,max,step,read_opcodes",
+                "0x03,0x0002,f32_range,15,30,0.5,\"0x02,0x06\"",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    catalog = load_b524_constraints_catalog_from_path(catalog_path)
+
+    local = lookup_static_constraint(
+        catalog,
+        identity=make_register_identity(
+            opcode=0x02,
+            group=0x03,
+            instance=0x00,
+            register=0x0002,
+        ),
+    )
+    remote = lookup_static_constraint(
+        catalog,
+        identity=make_register_identity(
+            opcode=0x06,
+            group=0x03,
+            instance=0x01,
+            register=0x0002,
+        ),
+    )
+
+    assert local is not None
+    assert remote is not None
+    assert local == remote
+    assert local.scope == "explicit_opcode_0x02_0x06"
+    assert local.read_opcodes == (0x02, 0x06)
+
+
+def test_constraint_scope_metadata_declares_opcode_0x02_default_policy() -> None:
     metadata = constraint_scope_metadata()
-    assert metadata["decision"] == "gg_rr_invariant"
+    assert metadata["decision"] == "opcode_0x02_default"
     assert metadata["protocol"] == "opcode_0x01"


### PR DESCRIPTION
## Summary
- change bundled static B524 constraints to apply to opcode `0x02` by default instead of treating them as `GG/RR` invariant across `0x02` and `0x06`
- keep live opcode `0x01` probing available and label its entries explicitly as probe-scoped
- update regression tests and invariant docs so remote seeded mismatches no longer appear without explicit scope

## Test plan
- [x] `PYTHONPATH=src uv run --extra dev pytest tests/test_schema_b524_constraints.py tests/test_scanner_scan.py tests/test_issue_208_namespace_anti_regression.py`
- [x] `PYTHONPATH=src uv run --extra dev ruff check src/helianthus_vrc_explorer/schema/b524_constraints.py src/helianthus_vrc_explorer/scanner/scan.py tests/test_schema_b524_constraints.py tests/test_scanner_scan.py tests/test_issue_208_namespace_anti_regression.py README.md docs/b524-namespace-invariants.md`
- [x] `PYTHONPATH=src uv run --extra dev mypy src`
- [x] `PYTHONPATH=src uv run --extra dev python scripts/check_docs_sync.py`

Closes #224