### PR TITLE
Issue #226: split group naming semantics by opcode namespace

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -26,6 +26,7 @@ class GroupConfig(TypedDict):
     ii_max: int
     rr_max: int
     opcodes: list[int]
+    name_by_opcode: NotRequired[dict[int, str]]
     # Namespace-capable opcode families known for this group. This can include
     # future namespaces even when active scanning still uses a conservative subset.
     namespace_opcodes: NotRequired[list[int]]
@@ -102,6 +103,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "ii_max": 0x0A,
         "rr_max": 0x0035,
         "opcodes": [0x02, 0x06],
+        "name_by_opcode": {0x02: "Unknown 0x09 (local)", 0x06: "Regulators"},
         "rr_max_by_opcode": {0x02: 0x000F, 0x06: 0x0035},
     },
     0x0A: {
@@ -110,6 +112,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "ii_max": 0x0A,
         "rr_max": 0x004D,
         "opcodes": [0x02, 0x06],
+        "name_by_opcode": {0x02: "Unknown 0x0A (local)", 0x06: "Thermostats"},
         "rr_max_by_opcode": {0x02: 0x004D, 0x06: 0x0035},
     },
     0x0C: {
@@ -182,6 +185,7 @@ KNOWN_CORE_GROUPS: Final[frozenset[int]] = frozenset({0x02, 0x03})
 @dataclass(frozen=True, slots=True)
 class NamespaceProfile:
     opcode: int
+    name: str
     ii_max: int
     rr_max: int
 
@@ -200,6 +204,8 @@ def group_namespace_profiles(group: int) -> dict[int, NamespaceProfile]:
     namespace_opcodes = config.get("namespace_opcodes", config["opcodes"])
     rr_overrides = config.get("rr_max_by_opcode", {})
     ii_overrides = config.get("ii_max_by_opcode", {})
+    name_overrides = config.get("name_by_opcode", {})
+    default_name = str(config["name"])
     default_rr = int(config["rr_max"])
     default_ii = int(config["ii_max"])
 
@@ -208,10 +214,22 @@ def group_namespace_profiles(group: int) -> dict[int, NamespaceProfile]:
         op = int(opcode)
         profiles[op] = NamespaceProfile(
             opcode=op,
+            name=str(name_overrides.get(op, default_name)),
             ii_max=int(ii_overrides.get(op, default_ii)),
             rr_max=int(rr_overrides.get(op, default_rr)),
         )
     return profiles
+
+
+def group_name_for_opcode(group: int, opcode: int) -> str:
+    profiles = group_namespace_profiles(group)
+    profile = profiles.get(int(opcode))
+    if profile is not None:
+        return profile.name
+    config = GROUP_CONFIG.get(group)
+    if config is None:
+        return f"Unknown 0x{group:02X}"
+    return str(config["name"])
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -43,6 +43,7 @@ from .director import (
     DiscoveredGroup,
     classify_groups,
     discover_groups,
+    group_name_for_opcode,
     group_namespace_profiles,
 )
 from .identity import make_register_identity, opcode_label
@@ -127,6 +128,23 @@ def _primary_opcode(group: int) -> RegisterOpcode:
 
 def _is_dual_namespace_group(group: int) -> bool:
     return len(_group_opcodes(group)) > 1
+
+
+def _group_name_for_opcode(group: int, opcode: RegisterOpcode) -> str:
+    return group_name_for_opcode(group, int(opcode))
+
+
+def _group_display_name_for_opcodes(
+    *, group: int, opcodes: tuple[RegisterOpcode, ...], fallback: str
+) -> str:
+    if not opcodes:
+        return fallback
+    names = [_group_name_for_opcode(group, opcode) for opcode in opcodes]
+    unique_names: list[str] = []
+    for name in names:
+        if name not in unique_names:
+            unique_names.append(name)
+    return " / ".join(unique_names) if unique_names else fallback
 
 
 def _rr_max_for_opcode(*, group: int, default_rr_max: int, opcode: int) -> int:
@@ -271,17 +289,23 @@ def _ensure_group_artifact(
     return cast(dict[str, Any], group_obj)
 
 
-def _ensure_namespace_artifact(group_obj: dict[str, Any], *, opcode: int) -> dict[str, Any]:
+def _ensure_namespace_artifact(
+    group_obj: dict[str, Any], *, group: int, opcode: int
+) -> dict[str, Any]:
     namespaces = group_obj.setdefault("namespaces", {})
     namespace_key = _hex_u8(opcode)
+    namespace_group_name = _group_name_for_opcode(group, cast(RegisterOpcode, opcode))
     namespace_obj = namespaces.setdefault(
         namespace_key,
         {
             "label": opcode_label(opcode),
+            "group_name": namespace_group_name,
             "instances": {},
         },
     )
     namespace_obj.setdefault("label", opcode_label(opcode))
+    if namespace_group_name is not None:
+        namespace_obj.setdefault("group_name", namespace_group_name)
     namespace_obj.setdefault("instances", {})
     return cast(dict[str, Any], namespace_obj)
 
@@ -294,7 +318,7 @@ def _instances_object(
 ) -> dict[str, Any]:
     group_obj = artifact["groups"][_hex_u8(group)]
     if bool(group_obj.get("dual_namespace")):
-        namespace_obj = _ensure_namespace_artifact(group_obj, opcode=opcode)
+        namespace_obj = _ensure_namespace_artifact(group_obj, group=group, opcode=opcode)
         return cast(dict[str, Any], namespace_obj.setdefault("instances", {}))
     return cast(dict[str, Any], group_obj.setdefault("instances", {}))
 
@@ -307,7 +331,7 @@ def _availability_object(
 ) -> dict[str, Any]:
     group_obj = artifact["groups"][_hex_u8(group)]
     if bool(group_obj.get("dual_namespace")):
-        return _ensure_namespace_artifact(group_obj, opcode=opcode)
+        return _ensure_namespace_artifact(group_obj, group=group, opcode=opcode)
     return cast(dict[str, Any], group_obj)
 
 
@@ -386,17 +410,20 @@ def _promote_group_artifact_to_dual_namespace(
         namespace_key,
         {
             "label": opcode_label(primary_opcode),
+            "group_name": _group_name_for_opcode(group, primary_opcode),
             "instances": {},
         },
     )
     if not isinstance(namespace_obj, dict):
         namespace_obj = {
             "label": opcode_label(primary_opcode),
+            "group_name": _group_name_for_opcode(group, primary_opcode),
             "instances": {},
         }
         namespaces[namespace_key] = namespace_obj
 
     namespace_obj.setdefault("label", opcode_label(primary_opcode))
+    namespace_obj.setdefault("group_name", _group_name_for_opcode(group, primary_opcode))
     if isinstance(flat_instances, dict) and flat_instances:
         namespace_obj["instances"] = flat_instances
     else:
@@ -1462,10 +1489,15 @@ def scan_b524(
                 discovery_advisory["descriptor_expected"] = group.expected_descriptor
             if group.descriptor_mismatch:
                 discovery_advisory["descriptor_mismatch"] = True
+            artifact_group_name = _group_display_name_for_opcodes(
+                group=group.group,
+                opcodes=opcodes,
+                fallback=group.name,
+            )
             _ensure_group_artifact(
                 artifact,
                 group=group.group,
-                name=group.name,
+                name=artifact_group_name,
                 descriptor_observed=desc_for_artifact,
                 dual_namespace=dual_namespace,
                 discovery_advisory=discovery_advisory,
@@ -1523,7 +1555,10 @@ def scan_b524(
                     )
                 if not _is_instanced_group(namespace_ii_max):
                     _mark_present_instances(instances_obj, instances=(0x00,))
-                    known_namespace_probe_counts.append(f"{opcode_label(opcode)} 1/1")
+                    known_namespace_probe_counts.append(
+                        f"{_group_name_for_opcode(group.group, opcode)} "
+                        f"[{opcode_label(opcode)}] 1/1"
+                    )
                     continue
 
                 assert namespace_ii_max is not None
@@ -1548,12 +1583,14 @@ def scan_b524(
                 present_instances = tuple(ii for ii, probe in probes.items() if probe.present)
                 _mark_present_instances(instances_obj, instances=present_instances)
                 known_namespace_probe_counts.append(
-                    f"{opcode_label(opcode)} {len(present_instances)}/{namespace_ii_max + 1}"
+                    f"{_group_name_for_opcode(group.group, opcode)} "
+                    f"[{opcode_label(opcode)}] "
+                    f"{len(present_instances)}/{namespace_ii_max + 1}"
                 )
 
             if observer is not None:
                 observer.log(
-                    f"GG=0x{group.group:02X} {group.name}: "
+                    f"GG=0x{group.group:02X}: "
                     f"{', '.join(known_namespace_probe_counts)} present, "
                     f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
                     level="info",
@@ -1641,7 +1678,7 @@ def scan_b524(
                     PlannerGroup(
                         group=group.group,
                         opcode=opcode,
-                        name=group.name,
+                        name=_group_name_for_opcode(group.group, opcode),
                         descriptor=group.descriptor,
                         known=config is not None,
                         ii_max=planner_ii_max,

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -46,6 +46,8 @@ class PlannerGroup:
     def display_name(self) -> str:
         if self.namespace_label is None:
             return self.name
+        if self.name.lower().endswith(f"({self.namespace_label.lower()})"):
+            return self.name
         return f"{self.name} ({self.namespace_label})"
 
     @property

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -172,11 +172,17 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
             namespaces = group_obj.get("namespaces", {})
             if not isinstance(namespaces, dict):
                 namespaces = {}
+            namespace_group_names: list[str] = []
             instance_ids_total: set[str] = set()
             instance_ids_present: set[str] = set()
             for namespace_key, namespace_obj in namespaces.items():
                 if not isinstance(namespace_key, str) or not isinstance(namespace_obj, dict):
                     continue
+                namespace_group_name = namespace_obj.get("group_name")
+                if isinstance(namespace_group_name, str):
+                    cleaned_name = namespace_group_name.strip()
+                    if cleaned_name and cleaned_name not in namespace_group_names:
+                        namespace_group_names.append(cleaned_name)
                 namespace_key_norm = _normalize_namespace_key(namespace_key) or namespace_key
                 namespace_label = _namespace_display_label(
                     namespace_key_norm,
@@ -206,6 +212,8 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 namespace_registers[namespace_label] = (
                     namespace_registers.get(namespace_label, 0) + namespace_count
                 )
+            if namespace_group_names:
+                name = " / ".join(namespace_group_names)
             instances_total = len(instance_ids_total)
             instances_present = len(instance_ids_present)
         else:

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -12,6 +12,7 @@ from helianthus_vrc_explorer.scanner.director import (
     DiscoveredGroup,
     classify_groups,
     discover_groups,
+    group_name_for_opcode,
     group_namespace_profiles,
 )
 from helianthus_vrc_explorer.transport.base import (
@@ -288,6 +289,8 @@ def test_group_config_completeness() -> None:
 def test_group_namespace_profiles_support_opcode_first_identity() -> None:
     hw = group_namespace_profiles(0x01)
     hc = group_namespace_profiles(0x02)
+    regulators = group_namespace_profiles(0x09)
+    thermostats = group_namespace_profiles(0x0A)
 
     assert sorted(hw) == [0x02, 0x06]
     assert hw[0x02].rr_max == 0x0013
@@ -296,6 +299,17 @@ def test_group_namespace_profiles_support_opcode_first_identity() -> None:
     assert sorted(hc) == [0x02, 0x06]
     assert hc[0x02].ii_max == 0x0A
     assert hc[0x06].ii_max == 0x0A
+    assert regulators[0x02].name == "Unknown 0x09 (local)"
+    assert regulators[0x06].name == "Regulators"
+    assert thermostats[0x02].name == "Unknown 0x0A (local)"
+    assert thermostats[0x06].name == "Thermostats"
+
+
+def test_group_name_for_opcode_uses_namespace_owned_labels_for_09_and_0a() -> None:
+    assert group_name_for_opcode(0x09, 0x02) == "Unknown 0x09 (local)"
+    assert group_name_for_opcode(0x09, 0x06) == "Regulators"
+    assert group_name_for_opcode(0x0A, 0x02) == "Unknown 0x0A (local)"
+    assert group_name_for_opcode(0x0A, 0x06) == "Thermostats"
 
 
 def test_classify_groups_missing_desc() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -972,6 +972,7 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     )
 
     group = artifact["groups"]["0x09"]
+    assert group["name"] == "Unknown 0x09 (local) / Regulators"
     assert group["dual_namespace"] is True
     assert "instances" not in group
     assert set(group["namespaces"]) == {"0x02", "0x06"}
@@ -980,6 +981,8 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     remote_ns = group["namespaces"]["0x06"]
     assert local_ns["label"] == "local"
     assert remote_ns["label"] == "remote"
+    assert local_ns["group_name"] == "Unknown 0x09 (local)"
+    assert remote_ns["group_name"] == "Regulators"
     assert (
         group["discovery_advisory"]["instance_discovery_decision"]["decision"]
         == "independent_per_namespace"
@@ -1624,12 +1627,55 @@ def test_scan_b524_textual_planner_receives_group_01_remote_and_keeps_group_00_l
     assert (0x01, 0x02) in planner_keys
     assert (0x01, 0x06) in planner_keys
 
+    name_by_key = {(group.group, group.opcode): group.name for group in planner_groups}
+    assert name_by_key[(0x00, 0x02)] == "Regulator Parameters"
+    assert name_by_key[(0x01, 0x02)] == "Hot Water Circuit"
+    assert name_by_key[(0x01, 0x06)] == "Hot Water Circuit"
+
     default_plan = captured["default_plan"]
     assert isinstance(default_plan, dict)
     assert make_plan_key(0x01, 0x02) in default_plan
     assert make_plan_key(0x01, 0x06) in default_plan
     assert make_plan_key(0x00, 0x06) not in default_plan
     assert artifact["meta"]["scan_plan"]["estimated_register_requests"] == 0
+
+
+def test_scan_b524_textual_planner_uses_namespace_owned_labels_for_groups_09_and_0a(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    captured: dict[str, object] = {}
+
+    def fake_run_textual_scan_plan(groups, **kwargs):
+        captured["groups"] = groups
+        captured["default_plan"] = kwargs["default_plan"]
+        return {}
+
+    monkeypatch.setattr(
+        "helianthus_vrc_explorer.ui.planner_textual.run_textual_scan_plan",
+        fake_run_textual_scan_plan,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    artifact = scan_b524(
+        DummyTransport(_write_fixture_group_09(tmp_path)),
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="textual",
+        planner_preset="recommended",
+    )
+
+    planner_groups = captured["groups"]
+    assert isinstance(planner_groups, list)
+    planner_label_map = {
+        (group.group, group.opcode): (group.name, group.namespace_label) for group in planner_groups
+    }
+    assert planner_label_map[(0x09, 0x02)] == ("Unknown 0x09 (local)", "local")
+    assert planner_label_map[(0x09, 0x06)] == ("Regulators", "remote")
+    assert artifact["groups"]["0x09"]["name"] == "Unknown 0x09 (local) / Regulators"
 
 
 def test_scan_b524_textual_failure_raises_in_forced_textual_mode(

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -39,6 +39,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
                 "namespaces": {
                     "0x02": {
                         "label": "local",
+                        "group_name": "Unknown 0x09 (local)",
                         "instances": {
                             "0x00": {
                                 "present": True,
@@ -55,6 +56,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
                     },
                     "0x06": {
                         "label": "remote",
+                        "group_name": "Regulators",
                         "instances": {
                             "0x00": {
                                 "present": True,
@@ -87,7 +89,7 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     assert "flags_access volatile_ro=0, stable_ro=2, technical_rw=0, user_rw=1" in text
     assert "b555 reads=4 errors=1 programs=2" in text
     assert "local (0x02)=1, remote (0x06)=1" in text
-    assert "Regulators" in text
+    assert "Unknown 0x09 (local) / Regulators" in text
     assert "2/2" not in text
 
 


### PR DESCRIPTION
## Summary
- add namespace-owned group labels to B524 config/profiles for opcode-specific display semantics
- apply locked labels for GG=0x09 and GG=0x0A (`0x02` local unknown labels, `0x06` remote canonical labels)
- propagate namespace-owned names into planner groups, artifact namespace metadata, and summary rendering while preserving opcode-first identity keys
- keep `GG=0x00` remote unexposed (no new 0x06 namespace support for group 0x00)

## Test plan
- `PYTHONPATH=src uv run --extra dev pytest tests/test_scanner_director.py tests/test_scanner_scan.py tests/test_planner_textual.py tests/test_summary.py`
- `PYTHONPATH=src uv run --extra dev ruff check src/helianthus_vrc_explorer/scanner/director.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/ui/planner.py src/helianthus_vrc_explorer/ui/summary.py tests/test_scanner_director.py tests/test_scanner_scan.py tests/test_summary.py`
- `PYTHONPATH=src uv run --extra dev ruff format --check src/helianthus_vrc_explorer/scanner/director.py src/helianthus_vrc_explorer/scanner/scan.py src/helianthus_vrc_explorer/ui/planner.py src/helianthus_vrc_explorer/ui/summary.py tests/test_scanner_director.py tests/test_scanner_scan.py tests/test_summary.py`
- `PYTHONPATH=src uv run --extra dev mypy src`

Closes #226