### PR TITLE
b524: make topology + summary semantics namespace-specific (#228)

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -413,7 +413,7 @@ def _record_namespace_topology(
     if not isinstance(group_obj, dict):
         return
     if bool(group_obj.get("dual_namespace")):
-        _ensure_namespace_artifact(group_obj, opcode=opcode, ii_max=ii_max)
+        _ensure_namespace_artifact(group_obj, group=group, opcode=opcode, ii_max=ii_max)
         return
     if ii_max is not None:
         group_obj["ii_max"] = _hex_u8(ii_max)

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -262,6 +262,7 @@ def _ensure_group_artifact(
     name: str,
     descriptor_observed: float | None,
     dual_namespace: bool,
+    ii_max: int | None = None,
     discovery_advisory: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     group_key = _hex_u8(group)
@@ -270,6 +271,8 @@ def _ensure_group_artifact(
         "descriptor_observed": descriptor_observed,
         "dual_namespace": dual_namespace,
     }
+    if ii_max is not None:
+        default["ii_max"] = _hex_u8(ii_max)
     if dual_namespace:
         default["namespaces"] = {}
     else:
@@ -284,13 +287,21 @@ def _ensure_group_artifact(
     group_obj.setdefault("name", name)
     group_obj.setdefault("descriptor_observed", descriptor_observed)
     group_obj["dual_namespace"] = dual_namespace
+    if ii_max is not None:
+        group_obj["ii_max"] = _hex_u8(ii_max)
+    elif dual_namespace:
+        group_obj.pop("ii_max", None)
     if discovery_advisory is not None:
         group_obj["discovery_advisory"] = discovery_advisory
     return cast(dict[str, Any], group_obj)
 
 
 def _ensure_namespace_artifact(
-    group_obj: dict[str, Any], *, group: int, opcode: int
+    group_obj: dict[str, Any],
+    *,
+    group: int,
+    opcode: int,
+    ii_max: int | None = None,
 ) -> dict[str, Any]:
     namespaces = group_obj.setdefault("namespaces", {})
     namespace_key = _hex_u8(opcode)
@@ -307,6 +318,8 @@ def _ensure_namespace_artifact(
     if namespace_group_name is not None:
         namespace_obj.setdefault("group_name", namespace_group_name)
     namespace_obj.setdefault("instances", {})
+    if ii_max is not None:
+        namespace_obj["ii_max"] = _hex_u8(ii_max)
     return cast(dict[str, Any], namespace_obj)
 
 
@@ -389,6 +402,23 @@ def _record_availability_probes(
         probe_map[_hex_u8(instance)] = _serialize_availability_probe(probe)
 
 
+def _record_namespace_topology(
+    artifact: dict[str, Any],
+    *,
+    group: int,
+    opcode: int,
+    ii_max: int | None,
+) -> None:
+    group_obj = artifact["groups"].get(_hex_u8(group))
+    if not isinstance(group_obj, dict):
+        return
+    if bool(group_obj.get("dual_namespace")):
+        _ensure_namespace_artifact(group_obj, opcode=opcode, ii_max=ii_max)
+        return
+    if ii_max is not None:
+        group_obj["ii_max"] = _hex_u8(ii_max)
+
+
 def _promote_group_artifact_to_dual_namespace(
     artifact: dict[str, Any],
     *,
@@ -400,6 +430,7 @@ def _promote_group_artifact_to_dual_namespace(
         return
 
     flat_instances = group_obj.pop("instances", {})
+    flat_ii_max = group_obj.pop("ii_max", None)
     namespaces = group_obj.setdefault("namespaces", {})
     if not isinstance(namespaces, dict):
         namespaces = {}
@@ -423,6 +454,8 @@ def _promote_group_artifact_to_dual_namespace(
         namespaces[namespace_key] = namespace_obj
 
     namespace_obj.setdefault("label", opcode_label(primary_opcode))
+    if flat_ii_max is not None:
+        namespace_obj.setdefault("ii_max", flat_ii_max)
     namespace_obj.setdefault("group_name", _group_name_for_opcode(group, primary_opcode))
     if isinstance(flat_instances, dict) and flat_instances:
         namespace_obj["instances"] = flat_instances
@@ -1500,6 +1533,7 @@ def scan_b524(
                 name=artifact_group_name,
                 descriptor_observed=desc_for_artifact,
                 dual_namespace=dual_namespace,
+                ii_max=(meta.ii_max if not dual_namespace else None),
                 discovery_advisory=discovery_advisory,
             )
 
@@ -1510,6 +1544,17 @@ def scan_b524(
                 namespace_probe_counts: list[str] = []
                 total_slots = len(_UNKNOWN_GROUP_EXPANDED_INSTANCES)
                 for opcode in opcodes:
+                    namespace_ii_max = _ii_max_for_opcode(
+                        group=group.group,
+                        default_ii_max=meta.ii_max,
+                        opcode=opcode,
+                    )
+                    _record_namespace_topology(
+                        artifact,
+                        group=group.group,
+                        opcode=opcode,
+                        ii_max=namespace_ii_max,
+                    )
                     instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
                     emit_trace_label(
                         transport,
@@ -1543,6 +1588,12 @@ def scan_b524(
                     group=group.group,
                     default_ii_max=meta.ii_max,
                     opcode=opcode,
+                )
+                _record_namespace_topology(
+                    artifact,
+                    group=group.group,
+                    opcode=opcode,
+                    ii_max=namespace_ii_max,
                 )
                 contract = namespace_availability_contract(group=group.group, opcode=opcode)
                 instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
@@ -1978,6 +2029,18 @@ def scan_b524(
                     descriptor_observed=None,
                     dual_namespace=group_dual_namespace_effective.get(task.group, False),
                 )
+                task_group_meta = metadata_map.get(task.group)
+                if task_group_meta is not None:
+                    _record_namespace_topology(
+                        artifact,
+                        group=task.group,
+                        opcode=task.opcode,
+                        ii_max=_ii_max_for_opcode(
+                            group=task.group,
+                            default_ii_max=task_group_meta.ii_max,
+                            opcode=task.opcode,
+                        ),
+                    )
                 instances_obj = _instances_object(
                     artifact,
                     group=task.group,

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -238,8 +238,9 @@ def _print_plan_breakdown(console: Console, plan: dict[PlanKey, GroupScanPlan]) 
     console.print("[bold]Selected groups[/bold]")
     for key in sorted(plan.keys()):
         group_plan = plan[key]
-        instance_spec = "singleton"
-        if len(group_plan.instances) != 1 or group_plan.instances[0] != 0x00:
+        if not group_plan.instances:
+            instance_spec = "none"
+        else:
             instance_spec = format_int_set(list(group_plan.instances))
         console.print(
             "  • "

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -237,6 +237,7 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                     continue
                 namespace_present = 0
                 namespace_total = _topology_total_from_ii_max(namespace_obj.get("ii_max"))
+                topology_authoritative = namespace_total is not None
                 if namespace_total is None:
                     known_totals = False
                     namespace_total = len(namespace_instances)
@@ -258,16 +259,15 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 namespace_registers[namespace_label] = (
                     namespace_registers.get(namespace_label, 0) + namespace_count
                 )
-            if namespace_group_names:
-                name = " / ".join(namespace_group_names)
                 namespace_instance_summaries[namespace_label] = _format_instance_summary(
                     present=namespace_present,
                     total=namespace_total,
-                    topology_authoritative=_topology_total_from_ii_max(namespace_obj.get("ii_max"))
-                    is not None,
+                    topology_authoritative=topology_authoritative,
                 )
                 instances_total += namespace_total
                 instances_present += namespace_present
+            if namespace_group_names:
+                name = " / ".join(namespace_group_names)
             if namespace_instance_summaries:
                 ordered_items = sorted(
                     namespace_instance_summaries.items(),

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -18,6 +18,7 @@ class _GroupStats:
     descriptor: float
     instances_total: int
     instances_present: int
+    instances_display: str
     registers_scanned: int
     registers_errors: int
     namespace_registers: dict[str, int]
@@ -144,6 +145,47 @@ def _sorted_namespace_counts(counts: dict[str, int]) -> dict[str, int]:
     return dict(sorted(counts.items(), key=lambda item: _display_namespace_sort_key(item[0])))
 
 
+def _parse_u8_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        if 0 <= value <= 0xFF:
+            return value
+        return None
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw, 0)
+    except ValueError:
+        return None
+    if 0 <= parsed <= 0xFF:
+        return parsed
+    return None
+
+
+def _topology_total_from_ii_max(value: object) -> int | None:
+    ii_max = _parse_u8_int(value)
+    if ii_max is None:
+        return None
+    return ii_max + 1
+
+
+def _format_instance_summary(
+    *,
+    present: int,
+    total: int,
+    topology_authoritative: bool,
+) -> str:
+    if total <= 0:
+        return str(present)
+    if topology_authoritative and total == 1:
+        return "singleton"
+    return f"{present}/{total}"
+
+
 def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
     stats: list[_GroupStats] = []
     groups = artifact.get("groups", {})
@@ -162,8 +204,9 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
         if not isinstance(instances, dict):
             instances = {}
 
-        instances_total = len(instances)
+        instances_total = 0
         instances_present = 0
+        instances_display = "0"
         registers_scanned = 0
         registers_errors = 0
         namespace_registers: dict[str, int] = {}
@@ -172,9 +215,9 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
             namespaces = group_obj.get("namespaces", {})
             if not isinstance(namespaces, dict):
                 namespaces = {}
+            namespace_instance_summaries: dict[str, str] = {}
+            known_totals = True
             namespace_group_names: list[str] = []
-            instance_ids_total: set[str] = set()
-            instance_ids_present: set[str] = set()
             for namespace_key, namespace_obj in namespaces.items():
                 if not isinstance(namespace_key, str) or not isinstance(namespace_obj, dict):
                     continue
@@ -192,13 +235,16 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 namespace_instances = namespace_obj.get("instances", {})
                 if not isinstance(namespace_instances, dict):
                     continue
+                namespace_present = 0
+                namespace_total = _topology_total_from_ii_max(namespace_obj.get("ii_max"))
+                if namespace_total is None:
+                    known_totals = False
+                    namespace_total = len(namespace_instances)
                 for instance_key, instance_obj in namespace_instances.items():
-                    if isinstance(instance_key, str):
-                        instance_ids_total.add(instance_key)
                     if not isinstance(instance_obj, dict):
                         continue
                     if instance_obj.get("present") is True and isinstance(instance_key, str):
-                        instance_ids_present.add(instance_key)
+                        namespace_present += 1
                     registers = instance_obj.get("registers", {})
                     if not isinstance(registers, dict):
                         continue
@@ -214,9 +260,35 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 )
             if namespace_group_names:
                 name = " / ".join(namespace_group_names)
-            instances_total = len(instance_ids_total)
-            instances_present = len(instance_ids_present)
+                namespace_instance_summaries[namespace_label] = _format_instance_summary(
+                    present=namespace_present,
+                    total=namespace_total,
+                    topology_authoritative=_topology_total_from_ii_max(namespace_obj.get("ii_max"))
+                    is not None,
+                )
+                instances_total += namespace_total
+                instances_present += namespace_present
+            if namespace_instance_summaries:
+                ordered_items = sorted(
+                    namespace_instance_summaries.items(),
+                    key=lambda item: _display_namespace_sort_key(item[0]),
+                )
+                instances_display = ", ".join(
+                    f"{label} {summary}" for (label, summary) in ordered_items
+                )
+            elif known_totals:
+                instances_display = _format_instance_summary(
+                    present=instances_present,
+                    total=instances_total,
+                    topology_authoritative=True,
+                )
+            else:
+                instances_display = str(instances_present)
         else:
+            group_total = _topology_total_from_ii_max(group_obj.get("ii_max"))
+            topology_authoritative = group_total is not None
+            if group_total is None:
+                group_total = len(instances)
             for instance_obj in instances.values():
                 if not isinstance(instance_obj, dict):
                     continue
@@ -236,6 +308,12 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                         )
                     if entry.get("error") is not None:
                         registers_errors += 1
+            instances_total = group_total
+            instances_display = _format_instance_summary(
+                present=instances_present,
+                total=instances_total,
+                topology_authoritative=topology_authoritative,
+            )
 
         stats.append(
             _GroupStats(
@@ -244,6 +322,7 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 descriptor=descriptor,
                 instances_total=instances_total,
                 instances_present=instances_present,
+                instances_display=instances_display,
                 registers_scanned=registers_scanned,
                 registers_errors=registers_errors,
                 namespace_registers=_sorted_namespace_counts(namespace_registers),
@@ -386,17 +465,11 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
     table.add_column("Errors", style="white", justify="right", no_wrap=True)
 
     for s in group_stats:
-        if s.instances_total == 1 and s.instances_present == 1:
-            instances = "singleton"
-        elif s.instances_total > 0:
-            instances = f"{s.instances_present}/{s.instances_total}"
-        else:
-            instances = str(s.instances_present)
         table.add_row(
             s.group,
             s.name,
             f"{s.descriptor:g}",
-            instances,
+            s.instances_display,
             _format_counts(s.namespace_registers),
             str(s.registers_scanned),
             str(s.registers_errors),

--- a/tests/test_planner_unknown_groups.py
+++ b/tests/test_planner_unknown_groups.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from helianthus_vrc_explorer.scanner.plan import GroupScanPlan, make_plan_key
 from helianthus_vrc_explorer.ui.planner import (
     PlannerGroup,
+    _print_plan_breakdown,
     build_plan_from_preset,
     prompt_scan_plan,
 )
@@ -146,3 +147,22 @@ def test_build_plan_from_preset_full_keeps_ff_when_present() -> None:
 
     plan = build_plan_from_preset(groups, preset="full")
     assert plan[make_plan_key(0x69, 0x06)].instances == tuple(range(0x0A + 1)) + (0xFF,)
+
+
+def test_print_plan_breakdown_does_not_infer_singleton_from_selected_instance() -> None:
+    console = Console(record=True, width=120)
+    _print_plan_breakdown(
+        console,
+        {
+            make_plan_key(0x09, 0x06): GroupScanPlan(
+                group=0x09,
+                opcode=0x06,
+                rr_max=0x0035,
+                instances=(0x00,),
+            )
+        },
+    )
+
+    text = console.export_text()
+    assert "instances=0" in text
+    assert "instances=singleton" not in text

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -983,6 +983,8 @@ def test_artifact_dual_namespace_structure(monkeypatch, tmp_path: Path) -> None:
     assert remote_ns["label"] == "remote"
     assert local_ns["group_name"] == "Unknown 0x09 (local)"
     assert remote_ns["group_name"] == "Regulators"
+    assert local_ns["ii_max"] == "0x0a"
+    assert remote_ns["ii_max"] == "0x0a"
     assert (
         group["discovery_advisory"]["instance_discovery_decision"]["decision"]
         == "independent_per_namespace"
@@ -1072,6 +1074,7 @@ def test_artifact_single_namespace_unchanged(tmp_path: Path) -> None:
     group = artifact["groups"]["0x02"]
     assert group["dual_namespace"] is False
     assert "namespaces" not in group
+    assert group["ii_max"] == "0x0a"
     assert set(group["instances"]) >= {"0x00"}
 
 
@@ -1146,6 +1149,8 @@ def test_group_08_remote_namespace_only_marks_present_instances(
 
     group = artifact["groups"]["0x08"]
     assert group["dual_namespace"] is True
+    assert group["namespaces"]["0x02"]["ii_max"] == "0x00"
+    assert group["namespaces"]["0x06"]["ii_max"] == "0x0a"
     assert set(group["namespaces"]["0x02"]["instances"]) == {"0x00"}
     assert set(group["namespaces"]["0x06"]["instances"]) == {"0x00"}
 
@@ -1532,6 +1537,7 @@ def test_scan_unknown_group_expands_to_instance_ff_after_readable_probe(tmp_path
 
     group = artifact["groups"]["0x69"]
     assert group["dual_namespace"] is False
+    assert group["ii_max"] == "0x0a"
     remote_instances = group["instances"]
     assert remote_instances["0x00"]["present"] is True
     assert remote_instances["0xff"]["present"] is True

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -250,3 +250,82 @@ def test_render_summary_namespace_totals_use_namespace_container_when_opcode_mis
     assert "namespaces local (0x02)=1, remote (0x06)=1" in text
     assert "remote (0x02)" not in text
     assert "local (0x06)" not in text
+
+
+def test_render_summary_uses_namespace_specific_topology_for_instances(tmp_path: Path) -> None:
+    artifact = {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+            "scan_duration_seconds": 1.0,
+        },
+        "groups": {
+            "0x08": {
+                "name": "Buffer / Solar Cylinder 2",
+                "descriptor_observed": 1.0,
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "label": "local",
+                        "ii_max": "0x00",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {"0x0001": {"read_opcode": "0x02", "error": None}},
+                            }
+                        },
+                    },
+                    "0x06": {
+                        "label": "remote",
+                        "ii_max": "0x0a",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {"0x0001": {"read_opcode": "0x06", "error": None}},
+                            }
+                        },
+                    },
+                },
+            }
+        },
+    }
+
+    console = Console(record=True, width=180)
+    render_summary(console, artifact, output_path=tmp_path / "artifact.json")
+    text = console.export_text()
+
+    assert "local (0x02) singleton, remote (0x06) 1/11" in text
+    assert "remote (0x06) singleton" not in text
+
+
+def test_render_summary_does_not_infer_singleton_from_observed_remote_count(
+    tmp_path: Path,
+) -> None:
+    artifact = {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+            "scan_duration_seconds": 1.0,
+        },
+        "groups": {
+            "0x69": {
+                "name": "Unknown 0x69",
+                "descriptor_observed": 1.0,
+                "ii_max": "0x0a",
+                "instances": {
+                    "0x00": {
+                        "present": True,
+                        "registers": {"0x0000": {"read_opcode": "0x06", "error": None}},
+                    }
+                },
+            }
+        },
+    }
+
+    console = Console(record=True, width=160)
+    render_summary(console, artifact, output_path=tmp_path / "artifact.json")
+    text = console.export_text()
+
+    assert "Unknown 0x69" in text
+    assert "1/11" in text
+    assert "Unknown 0x69" in text and "singleton" not in text


### PR DESCRIPTION
## What
Implement issue #228 by making B524 instance topology and summary semantics namespace-specific.

## Why
Current summary/planner semantics could infer `singleton` from observed counts (for example one seen instance), which is incorrect when the namespace model allows multiple instances. Topology also needed to be persisted per namespace so unknown/remote namespaces do not inherit local topology assumptions.

## Changes
- Persist namespace/topology metadata in scan artifacts:
  - Store `ii_max` at group level for single-namespace groups.
  - Store `ii_max` per namespace for dual-namespace groups.
  - Preserve topology on namespace promotion and avoid stale flat `ii_max` leakage.
- Update summary rendering:
  - Use authoritative `ii_max` topology (when present) instead of inferring singleton from observed counts.
  - Render dual-namespace instance summaries per namespace (e.g. `local (0x02) singleton, remote (0x06) 1/11`).
  - Keep singleton label only when topology explicitly defines one slot.
- Update planner classic breakdown output:
  - Stop labeling `instances=(0x00,)` as `singleton` without topology context.
- Add focused tests for:
  - Persisted namespace-specific `ii_max` topology.
  - Single-namespace and dual-namespace summary semantics.
  - Planner breakdown non-inferential instance display.

## Validation
- `PYTHONPATH=src ./.venv/bin/pytest -q` (395 passed)
- `./.venv/bin/ruff check .` (passed)
- `PYTHONPATH=src ./.venv/bin/mypy src` (passed)

Closes #228.