### PR TITLE
Issue #230: add explicit research preset for non-core fallback scanning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,9 +629,10 @@ CI enforces this via `python scripts/check_docs_sync.py`.
 │                                                               classic.                                               │
 │                                                               [default: disabled]                                    │
 │ --preset                                             TEXT     Planner preset: conservative, recommended, full,       │
-│                                                               exhaustive, or custom. `full` scans every instance     │
-│                                                               slot and full RR ranges; `exhaustive` also injects all │
-│                                                               GG 0x00-0x11 groups. Expect very long runs.            │
+│                                                               research, or custom. `full` expands known groups to    │
+│                                                               full instance slots and RR ranges; `research` enables  │
+│                                                               broad non-core/underspecified fallback probing. Legacy │
+│                                                               aliases: aggressive->full, exhaustive->research.       │
 │                                                               [default: recommended]                                 │
 │ --no-tips                                                     Hide scan header tips in interactive terminal mode.    │
 │ --redact                                                      Redact device identity fields (e.g. serial number) in  │

--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -74,6 +74,8 @@ def _normalize_planner_preset(raw: str) -> str:
     normalized = raw.strip().lower()
     if normalized == "aggressive":
         return "full"
+    if normalized == "exhaustive":
+        return "research"
     return normalized
 
 
@@ -674,9 +676,10 @@ def scan(
         "recommended",
         "--preset",
         help=(
-            "Planner preset: conservative, recommended, full, exhaustive, or custom. "
-            "`full` scans every instance slot and full RR ranges; "
-            "`exhaustive` also injects all GG 0x00-0x11 groups. Expect very long runs."
+            "Planner preset: conservative, recommended, full, research, or custom. "
+            "`full` expands known groups to full instance slots and RR ranges; "
+            "`research` enables broad non-core/underspecified fallback probing. "
+            "Legacy aliases: aggressive->full, exhaustive->research."
         ),
     ),
     no_tips: bool = typer.Option(  # noqa: B008
@@ -733,11 +736,12 @@ def scan(
         )
         raise typer.Exit(2)
     preset_value = _normalize_planner_preset(preset)
-    valid_presets = {"conservative", "recommended", "full", "exhaustive", "custom"}
+    valid_presets = {"conservative", "recommended", "full", "research", "custom"}
     if preset_value not in valid_presets:
         typer.echo(
             "Invalid --preset value. Expected one of: "
-            "conservative, recommended, aggressive, exhaustive, custom.",
+            "conservative, recommended, full, research, custom "
+            "(aliases: aggressive, exhaustive).",
             err=True,
         )
         raise typer.Exit(2)

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -32,9 +32,9 @@ class GroupConfig(TypedDict):
     namespace_opcodes: NotRequired[list[int]]
     rr_max_by_opcode: NotRequired[dict[int, int]]
     ii_max_by_opcode: NotRequired[dict[int, int]]
-    # When True, this group is only included in the exhaustive preset.
-    # It will NOT appear in conservative/recommended/full presets even if
-    # discovered by the directory probe.
+    # Legacy key name preserved for compatibility.
+    # When True, this group is only included in the research preset
+    # (and legacy exhaustive alias), never in conservative/recommended/full.
     exhaustive_only: NotRequired[bool]
 
 

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -179,7 +179,7 @@ def namespace_availability_contract(
             probe_type_hint=None,
             positive_when="all configured slots are treated as present",
             description=(
-                "Exploratory exhaustive group without a verified namespace-specific heuristic."
+                "Exploratory research group without a verified namespace-specific heuristic."
             ),
         )
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -101,6 +101,8 @@ def _normalize_planner_preset(preset: str) -> PlannerPreset:
     normalized = preset.strip().lower()
     if normalized == "aggressive":
         normalized = "full"
+    if normalized == "exhaustive":
+        normalized = "research"
     return cast(PlannerPreset, normalized)
 
 
@@ -578,6 +580,7 @@ def _probe_unknown_present_instances(
     group: int,
     opcode: RegisterOpcode,
     observer: ScanObserver | None,
+    expand_fallback: bool,
 ) -> tuple[int, ...]:
     present_instances: list[int] = []
     probed: set[int] = set()
@@ -601,7 +604,7 @@ def _probe_unknown_present_instances(
         if observer is not None:
             observer.phase_advance("instance_discovery", advance=1)
 
-    if not should_expand:
+    if not should_expand or not expand_fallback:
         return tuple(present_instances)
 
     for ii in _UNKNOWN_GROUP_EXPANDED_INSTANCES:
@@ -1250,6 +1253,7 @@ def scan_b524(
     """
 
     planner_preset = _normalize_planner_preset(planner_preset)
+    research_mode = planner_preset == "research"
     start_perf = time.perf_counter()
     scan_timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     static_constraints, static_constraints_source = load_default_b524_constraints_catalog()
@@ -1287,8 +1291,14 @@ def scan_b524(
             observer.log(f"Starting scan dst={_hex_u8(dst)}", level="info")
             if planner_preset == "full":
                 observer.log(
-                    "Full preset selected: scan will expand all instance slots and full RR "
-                    "ranges. Expect multi-hour BASV2 runs.",
+                    "Full preset selected: scan will expand known groups to full instance "
+                    "slots and RR ranges.",
+                    level="warn",
+                )
+            if research_mode:
+                observer.log(
+                    "Research preset selected: scan enables broader non-core and "
+                    "underspecified fallback probing. Expect very long runs.",
                     level="warn",
                 )
             if probe_constraints:
@@ -1314,7 +1324,7 @@ def scan_b524(
 
         # Exhaustive mode: inject synthetic DiscoveredGroup entries for any GG in
         # 0x00..0x11 not already found by directory probing.
-        if planner_preset == "exhaustive":
+        if research_mode:
             discovered_ggs = {dg.group for dg in discovered}
             for gg in range(0x00, 0x12):
                 if gg not in discovered_ggs:
@@ -1480,7 +1490,12 @@ def scan_b524(
             meta = metadata_map[group.group]
             opcodes = resolved_group_opcodes.get(group.group, ())
             if GROUP_CONFIG.get(group.group) is None:
-                instance_total += len(_UNKNOWN_GROUP_EXPANDED_INSTANCES) * len(opcodes)
+                candidate_instances = (
+                    _UNKNOWN_GROUP_EXPANDED_INSTANCES
+                    if research_mode
+                    else _UNKNOWN_GROUP_INITIAL_INSTANCES
+                )
+                instance_total += len(candidate_instances) * len(opcodes)
                 continue
             for opcode in opcodes:
                 namespace_ii_max = _ii_max_for_opcode(
@@ -1502,7 +1517,7 @@ def scan_b524(
             opcodes = resolved_group_opcodes.get(group.group, ())
             dual_namespace = len(opcodes) > 1
             config = GROUP_CONFIG.get(group.group)
-            # NaN descriptors come from synthetic exhaustive-mode injection;
+            # NaN descriptors come from synthetic research-mode injection;
             # store as None to keep JSON-serializable and avoid polluting analytics.
             desc_for_artifact = None if math.isnan(group.descriptor) else group.descriptor
             discovery_advisory: dict[str, Any] = {
@@ -1568,6 +1583,7 @@ def scan_b524(
                         group=group.group,
                         opcode=opcode,
                         observer=observer,
+                        expand_fallback=research_mode,
                     )
                     _mark_present_instances(instances_obj, instances=present_instances)
                     namespace_probe_counts.append(

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -57,7 +57,14 @@ class PlannerGroup:
         return f"{_hex_u8(self.group)} ({self.namespace_label})"
 
 
-PlannerPreset = Literal["conservative", "recommended", "full", "exhaustive", "custom"]
+PlannerPreset = Literal[
+    "conservative",
+    "recommended",
+    "full",
+    "research",
+    "exhaustive",
+    "custom",
+]
 
 
 def _hex_u8(value: int) -> str:
@@ -161,10 +168,13 @@ def _instances_for_preset(group: PlannerGroup, preset: PlannerPreset) -> tuple[i
     return full_range
 
 
-def _instances_for_exhaustive(ii_max: int | None) -> tuple[int, ...]:
-    if ii_max is None:
+def _instances_for_research(group: PlannerGroup) -> tuple[int, ...]:
+    if group.ii_max is None:
         return (0x00,)
-    return tuple(range(0x00, ii_max + 1))
+    full_range = tuple(range(0x00, group.ii_max + 1))
+    if 0xFF in group.present_instances:
+        return full_range + (0xFF,)
+    return full_range
 
 
 def build_plan_from_preset(
@@ -172,30 +182,32 @@ def build_plan_from_preset(
     *,
     preset: PlannerPreset,
 ) -> dict[PlanKey, GroupScanPlan]:
+    normalized_preset: PlannerPreset = "research" if preset == "exhaustive" else preset
     selected: dict[PlanKey, GroupScanPlan] = {}
     for group in sorted(groups, key=lambda g: (g.group, g.opcode)):
-        if preset == "exhaustive":
-            # Exhaustive: include ALL groups with rr_max_full and all instances.
+        if normalized_preset == "research":
+            # Research mode: include all discovered groups with expanded
+            # instance/rr_max defaults for reverse-engineering workflows.
             selected[group.key] = GroupScanPlan(
                 group=group.group,
                 opcode=group.opcode,
                 rr_max=group.rr_max_full,
-                instances=_instances_for_exhaustive(group.ii_max),
+                instances=_instances_for_research(group),
             )
             continue
         if group.exhaustive_only:
-            # exhaustive_only groups (GG 0x06..0x11 experimental)
-            # are only included under --preset exhaustive.
+            # `exhaustive_only` is a legacy key name retained for compatibility.
+            # These groups are intentionally restricted to research mode.
             continue
-        if not group.known and preset != "full":
+        if not group.known:
             continue
-        if preset == "conservative" and not group.primary:
+        if normalized_preset == "conservative" and not group.primary:
             continue
         selected[group.key] = GroupScanPlan(
             group=group.group,
             opcode=group.opcode,
-            rr_max=(group.rr_max_full if preset == "full" else group.rr_max),
-            instances=_instances_for_preset(group, preset),
+            rr_max=(group.rr_max_full if normalized_preset == "full" else group.rr_max),
+            instances=_instances_for_preset(group, normalized_preset),
         )
     return selected
 
@@ -251,11 +263,12 @@ def _print_plan_breakdown(console: Console, plan: dict[PlanKey, GroupScanPlan]) 
 
 
 def _ask_preset(console: Console, *, default_preset: PlannerPreset) -> PlannerPreset:
-    preset_hint = "Preset: (1) conservative, (2) recommended, (3) full, (4) exhaustive, (5) custom"
+    preset_hint = "Preset: (1) conservative, (2) recommended, (3) full, (4) research, (5) custom"
     default_token = {
         "conservative": "1",
         "recommended": "2",
         "full": "3",
+        "research": "4",
         "exhaustive": "4",
         "custom": "5",
     }[default_preset]
@@ -267,8 +280,9 @@ def _ask_preset(console: Console, *, default_preset: PlannerPreset) -> PlannerPr
         "3": "full",
         "full": "full",
         "aggressive": "full",
-        "4": "exhaustive",
-        "exhaustive": "exhaustive",
+        "4": "research",
+        "research": "research",
+        "exhaustive": "research",
         "5": "custom",
         "custom": "custom",
     }
@@ -443,8 +457,13 @@ def prompt_scan_plan(
 
     if preset == "full":
         console.print(
-            "[bold yellow]Warning:[/bold yellow] full preset expands all instance slots and full "
-            "RR ranges. Expect large multi-hour live scans on BASV2.",
+            "[bold yellow]Warning:[/bold yellow] full preset expands known groups to full "
+            "instance slots and RR ranges.",
+        )
+    if preset in {"research", "exhaustive"}:
+        console.print(
+            "[bold yellow]Warning:[/bold yellow] research preset enables broader non-core "
+            "and underspecified fallback scanning. Expect very long reverse-engineering runs.",
         )
 
     if preset == "custom":

--- a/src/helianthus_vrc_explorer/ui/planner_textual.py
+++ b/src/helianthus_vrc_explorer/ui/planner_textual.py
@@ -173,7 +173,7 @@ def run_textual_scan_plan(
             Binding("1", "preset_conservative", "Preset 1"),
             Binding("2", "preset_recommended", "Preset 2"),
             Binding("3", "preset_full", "Preset 3"),
-            Binding("4", "preset_exhaustive", "Preset 4"),
+            Binding("4", "preset_research", "Preset 4"),
             Binding("s", "save", "Save"),
             Binding("q", "cancel", "Cancel"),
             Binding("question_mark", "show_help", "Help"),
@@ -411,8 +411,8 @@ def run_textual_scan_plan(
         def action_preset_full(self) -> None:
             self._apply_preset("full")
 
-        def action_preset_exhaustive(self) -> None:
-            self._apply_preset("exhaustive")
+        def action_preset_research(self) -> None:
+            self._apply_preset("research")
 
         def action_show_help(self) -> None:
             self._set_help("Space=toggle Enter=RR i=instances 1/2/3/4=presets s=save q=cancel")

--- a/tests/test_issue_208_namespace_anti_regression.py
+++ b/tests/test_issue_208_namespace_anti_regression.py
@@ -272,7 +272,7 @@ def test_issue_208_planner_opcode_fidelity_keeps_namespace_specific_keys() -> No
         ),
     ]
 
-    plan = build_plan_from_preset(groups, preset="full")
+    plan = build_plan_from_preset(groups, preset="research")
 
     local_key = make_plan_key(0x69, 0x02)
     remote_key = make_plan_key(0x69, 0x06)

--- a/tests/test_planner_unknown_groups.py
+++ b/tests/test_planner_unknown_groups.py
@@ -88,14 +88,7 @@ def test_prompt_scan_plan_accepts_legacy_aggressive_alias_as_full(monkeypatch) -
     ]
 
     plan = prompt_scan_plan(console, groups, request_rate_rps=None, default_plan=None)
-    assert plan == {
-        make_plan_key(0x69, 0x02): GroupScanPlan(
-            group=0x69,
-            opcode=0x02,
-            rr_max=0x30,
-            instances=tuple(range(0x0A + 1)),
-        )
-    }
+    assert plan == {}
 
 
 def test_build_plan_from_preset_recommended_skips_unknown_groups() -> None:
@@ -130,7 +123,7 @@ def test_build_plan_from_preset_recommended_skips_unknown_groups() -> None:
     assert plan[key].instances == (0x00, 0x01)
 
 
-def test_build_plan_from_preset_full_keeps_ff_when_present() -> None:
+def test_build_plan_from_preset_research_keeps_ff_when_present() -> None:
     groups = [
         PlannerGroup(
             group=0x69,
@@ -145,7 +138,7 @@ def test_build_plan_from_preset_full_keeps_ff_when_present() -> None:
         )
     ]
 
-    plan = build_plan_from_preset(groups, preset="full")
+    plan = build_plan_from_preset(groups, preset="research")
     assert plan[make_plan_key(0x69, 0x06)].instances == tuple(range(0x0A + 1)) + (0xFF,)
 
 

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -1387,19 +1387,59 @@ def test_scan_b524_normalizes_legacy_aggressive_preset_to_full_for_textual_defau
     assert captured["default_preset"] == "full"
     default_plan = captured["default_plan"]
     assert isinstance(default_plan, dict)
-    for key in (make_plan_key(0x69, 0x02), make_plan_key(0x69, 0x06)):
-        assert key in default_plan
-        group_plan = default_plan[key]
-        assert group_plan.rr_max == 0x30
-        assert group_plan.instances == tuple(range(0x0B))
+    assert make_plan_key(0x69, 0x02) not in default_plan
+    assert make_plan_key(0x69, 0x06) not in default_plan
 
 
-def test_scan_b524_applies_preset_in_non_interactive_mode(tmp_path: Path) -> None:
+def test_scan_b524_normalizes_exhaustive_preset_to_research_for_textual_default_plan(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    transport = DummyTransport(_write_fixture_unknown_group_69(tmp_path))
+    captured: dict[str, object] = {}
+
+    def fake_run_textual_scan_plan(
+        _groups,
+        *,
+        request_rate_rps,
+        default_plan,
+        default_preset,
+    ):
+        captured["default_preset"] = default_preset
+        captured["default_plan"] = default_plan
+        captured["request_rate_rps"] = request_rate_rps
+        return {}
+
+    monkeypatch.setattr(
+        "helianthus_vrc_explorer.ui.planner_textual.run_textual_scan_plan",
+        fake_run_textual_scan_plan,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="textual",
+        planner_preset="exhaustive",
+    )
+
+    assert captured["default_preset"] == "research"
+    default_plan = captured["default_plan"]
+    assert isinstance(default_plan, dict)
+    assert make_plan_key(0x69, 0x02) in default_plan
+    assert make_plan_key(0x69, 0x06) in default_plan
+
+
+def test_scan_b524_applies_research_preset_in_non_interactive_mode(tmp_path: Path) -> None:
     artifact = scan_b524(
         DummyTransport(_write_fixture_unknown_group_69(tmp_path)),
         dst=0x15,
         planner_ui="auto",
-        planner_preset="full",
+        planner_preset="research",
     )
 
     scan_plan = artifact["meta"]["scan_plan"]["groups"]
@@ -1417,6 +1457,17 @@ def test_scan_b524_applies_preset_in_non_interactive_mode(tmp_path: Path) -> Non
     assert set(group["namespaces"]) == {"0x02", "0x06"}
     assert group["namespaces"]["0x02"]["instances"]["0x00"]["present"] is True
     assert group["namespaces"]["0x06"]["instances"]["0x00"]["present"] is True
+
+
+def test_scan_b524_full_preset_keeps_unknown_groups_out_of_default_plan(tmp_path: Path) -> None:
+    artifact = scan_b524(
+        DummyTransport(_write_fixture_unknown_group_69(tmp_path)),
+        dst=0x15,
+        planner_ui="auto",
+        planner_preset="full",
+    )
+
+    assert "0x69" not in artifact["meta"]["scan_plan"]["groups"]
 
 
 def test_scan_b524_recommended_plan_keeps_namespace_rr_max(tmp_path: Path) -> None:
@@ -1532,7 +1583,7 @@ def test_scan_unknown_group_expands_to_instance_ff_after_readable_probe(tmp_path
         transport,
         dst=0x15,
         planner_ui="auto",
-        planner_preset="recommended",
+        planner_preset="research",
     )
 
     group = artifact["groups"]["0x69"]
@@ -1542,7 +1593,10 @@ def test_scan_unknown_group_expands_to_instance_ff_after_readable_probe(tmp_path
     assert remote_instances["0x00"]["present"] is True
     assert remote_instances["0xff"]["present"] is True
 
-    assert "0x69" not in artifact["meta"]["scan_plan"]["groups"]
+    assert "0x69" in artifact["meta"]["scan_plan"]["groups"]
+    plan_group = artifact["meta"]["scan_plan"]["groups"]["0x69"]
+    assert plan_group["rr_max"] == "0x0030"
+    assert plan_group["instances"][-1] == "0xff"
 
     advisory = group["discovery_advisory"]
     assert advisory["proven_register_opcodes"] == ["0x06"]


### PR DESCRIPTION
## Summary
- add an explicit `research` planner preset and treat legacy `exhaustive` as a compatibility alias to `research`
- keep `full` conservative by excluding unknown/non-core fallback groups from default plan selection
- gate expanded unknown-group fallback probing behind `research`, while keeping bounded opcode/initial-instance probing outside research
- update CLI/planner/Textual preset UX text and focused regression tests

## Validation
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/pytest -q` -> `399 passed`
- `/Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/ruff check .` -> `All checks passed!`
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/mypy src` -> `Success: no issues found in 50 source files`

Closes #230