### PR TITLE
Issue #233: finalize OP=0x06 heating-source relabeling and audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,8 +461,8 @@ def parse_b524_id(id_hex: str) -> dict:
 **Known groups (hardcoded reference, validated against CSV):**
 
     GROUP_CONFIG = {
-        0x00: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x00FF, "opcodes": [0x02]},
-        0x01: {"desc": 3.0, "name": "Hot Water Circuit", "ii_max": 0x00, "rr_max": 0x13, "opcodes": [0x02]},
+        0x00: {"desc": 3.0, "name": "Regulator Parameters", "ii_max": 0x00, "rr_max": 0x00FF, "opcodes": [0x02], "name_by_opcode": {0x02: "Regulator Parameters", 0x06: "Primary Heating Sources"}},
+        0x01: {"desc": 3.0, "name": "Hot Water Circuit", "ii_max": 0x00, "rr_max": 0x13, "opcodes": [0x02], "name_by_opcode": {0x02: "Hot Water Circuit", 0x06: "Secondary Heating Sources"}, "namespace_opcodes": [0x02, 0x06], "rr_max_by_opcode": {0x02: 0x13, 0x06: 0x15}, "ii_max_by_opcode": {0x02: 0x00, 0x06: 0x00}},
         0x02: {"desc": 1.0, "name": "Heating Circuits", "ii_max": 0x0A, "rr_max": 0x25, "opcodes": [0x02]},
         0x03: {"desc": 1.0, "name": "Zones", "ii_max": 0x0A, "rr_max": 0x2E, "opcodes": [0x02]},
         0x04: {"desc": 6.0, "name": "Solar Circuit", "ii_max": 0x00, "rr_max": 0x0B, "opcodes": [0x02]},
@@ -477,8 +477,8 @@ def parse_b524_id(id_hex: str) -> dict:
 
     Group  | Opcode Family | Notes
     -------|---------------|-----------------------------------------------
-    0x00   | 0x02 (local)  | Regulator parameters (singleton)
-    0x01   | 0x02 (local)  | Singleton (no instances)
+    0x00   | 0x02 (local)  | Local namespace: Regulator parameters (singleton)
+    0x01   | 0x02 + 0x06   | 0x02: Hot Water Circuit, 0x06: Secondary Heating Sources
     0x02   | 0x02 (local)  | Heating circuits (instanced)
     0x03   | 0x02 (local)  | Zones (instanced)
     0x04   | 0x02 (local)  | Solar circuit (special Type 6 format)

--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -47,6 +47,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "ii_max": 0x00,
         "rr_max": 0x00FF,
         "opcodes": [0x02],
+        "name_by_opcode": {0x02: "Regulator Parameters", 0x06: "Primary Heating Sources"},
     },
     0x01: {
         "desc": 3.0,
@@ -54,6 +55,7 @@ GROUP_CONFIG: Final[dict[int, GroupConfig]] = {
         "ii_max": 0x00,
         "rr_max": 0x0013,
         "opcodes": [0x02],
+        "name_by_opcode": {0x02: "Hot Water Circuit", 0x06: "Secondary Heating Sources"},
         "namespace_opcodes": [0x02, 0x06],
         "rr_max_by_opcode": {0x02: 0x0013, 0x06: 0x0015},
         "ii_max_by_opcode": {0x02: 0x00, 0x06: 0x00},
@@ -222,13 +224,18 @@ def group_namespace_profiles(group: int) -> dict[int, NamespaceProfile]:
 
 
 def group_name_for_opcode(group: int, opcode: int) -> str:
+    config = GROUP_CONFIG.get(group)
+    if config is None:
+        return f"Unknown 0x{group:02X}"
+    name_overrides = config.get("name_by_opcode")
+    if isinstance(name_overrides, dict):
+        override = name_overrides.get(int(opcode))
+        if isinstance(override, str) and override.strip():
+            return override
     profiles = group_namespace_profiles(group)
     profile = profiles.get(int(opcode))
     if profile is not None:
         return profile.name
-    config = GROUP_CONFIG.get(group)
-    if config is None:
-        return f"Unknown 0x{group:02X}"
     return str(config["name"])
 
 

--- a/tests/test_planner_textual.py
+++ b/tests/test_planner_textual.py
@@ -56,7 +56,7 @@ def test_table_row_values_show_explicit_namespace_column() -> None:
     remote_group = PlannerGroup(
         group=0x01,
         opcode=0x06,
-        name="Hot Water Circuit",
+        name="Secondary Heating Sources",
         descriptor=3.0,
         known=True,
         ii_max=None,
@@ -95,7 +95,15 @@ def test_table_row_values_show_explicit_namespace_column() -> None:
         )
     )
 
-    assert remote_row == ("✓", "0x01", "Hot Water Circuit", "remote", "3.0", "singleton", "0x0015")
+    assert remote_row == (
+        "✓",
+        "0x01",
+        "Secondary Heating Sources",
+        "remote",
+        "3.0",
+        "singleton",
+        "0x0015",
+    )
     assert local_row == (
         " ",
         "0x00",

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -306,6 +306,10 @@ def test_group_namespace_profiles_support_opcode_first_identity() -> None:
 
 
 def test_group_name_for_opcode_uses_namespace_owned_labels_for_09_and_0a() -> None:
+    assert group_name_for_opcode(0x00, 0x02) == "Regulator Parameters"
+    assert group_name_for_opcode(0x00, 0x06) == "Primary Heating Sources"
+    assert group_name_for_opcode(0x01, 0x02) == "Hot Water Circuit"
+    assert group_name_for_opcode(0x01, 0x06) == "Secondary Heating Sources"
     assert group_name_for_opcode(0x09, 0x02) == "Unknown 0x09 (local)"
     assert group_name_for_opcode(0x09, 0x06) == "Regulators"
     assert group_name_for_opcode(0x0A, 0x02) == "Unknown 0x0A (local)"

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -1690,7 +1690,7 @@ def test_scan_b524_textual_planner_receives_group_01_remote_and_keeps_group_00_l
     name_by_key = {(group.group, group.opcode): group.name for group in planner_groups}
     assert name_by_key[(0x00, 0x02)] == "Regulator Parameters"
     assert name_by_key[(0x01, 0x02)] == "Hot Water Circuit"
-    assert name_by_key[(0x01, 0x06)] == "Hot Water Circuit"
+    assert name_by_key[(0x01, 0x06)] == "Secondary Heating Sources"
 
     default_plan = captured["default_plan"]
     assert isinstance(default_plan, dict)


### PR DESCRIPTION
## Summary
- finalize deferred OP=0x06 semantic relabeling for B524 GG=0x00 and GG=0x01
- keep OP=0x06 GG=0x02 unresolved/unknown (no new semantic claim in this slice)
- run and apply branch-wide stale-interpretation audit across scanner/planner/docs/tests for 0x06 GG=0x00/0x01 naming

## Changes
- add namespace-owned label overrides:
  - 0x00/0x06 -> Primary Heating Sources
  - 0x01/0x06 -> Secondary Heating Sources
- make `group_name_for_opcode()` honor opcode-specific overrides even when the opcode is not active in current scan defaults
- update planner/scanner director expectations and AGENTS.md config snippet to align with the final reinterpretation

## Validation
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/pytest -q` -> `399 passed`
- `/Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/ruff check .` -> `All checks passed!`
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/mypy src` -> `Success: no issues found in 50 source files`
- `/Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/python scripts/check_docs_sync.py` -> exit `0`

Closes #233