### PR TITLE
Issue #235: split planner and summary by opcode namespace

### DIFF
--- a/src/helianthus_vrc_explorer/scanner/director.py
+++ b/src/helianthus_vrc_explorer/scanner/director.py
@@ -280,9 +280,8 @@ def discover_groups(
     """Phase A: Probe GG=0x00..0xFF via directory probe (opcode 0x00).
 
     Terminator logic: stop on the first NaN descriptor.
-    Directory descriptors are not semantic authority for group identity or namespace topology.
-    A descriptor of `0.0` is still used as a discovery-time negative hint for non-core groups,
-    while known core groups remain scan candidates.
+    Directory descriptors are not semantic authority for group identity, namespace topology,
+    or scan-plan inclusion. The only authoritative structural signal here is the NaN terminator.
     """
 
     discovered: list[DiscoveredGroup] = []
@@ -396,23 +395,6 @@ def discover_groups(
         if skip_group or descriptor is None:
             # Transport failures are not evidence of a NaN terminator; skip without advancing the
             # NaN streak.
-            continue
-
-        if descriptor == 0.0:
-            if gg in KNOWN_CORE_GROUPS:
-                discovered.append(DiscoveredGroup(group=gg, descriptor=descriptor))
-                if observer is not None:
-                    observer.log(
-                        f"GG=0x{gg:02X} descriptor=0.0 but known core group - included",
-                        level="info",
-                    )
-            elif observer is not None:
-                observer.log(
-                    "GG=0x"
-                    f"{gg:02X} descriptor=0.0, non-core group - skipped "
-                    "(discovery-time hint only; not semantic authority)",
-                    level="info",
-                )
             continue
 
         if math.isnan(descriptor):

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -116,12 +116,14 @@ def _group_opcodes(group: int) -> tuple[RegisterOpcode, ...]:
     return _sorted_namespace_opcodes(opcodes_for_group(group))
 
 
+def _namespace_opcode_sort_key(opcode: int) -> tuple[int, int]:
+    priority = 0 if opcode == 0x02 else 1 if opcode == 0x06 else 2
+    return priority, opcode
+
+
 def _sorted_namespace_opcodes(opcodes: list[int] | tuple[int, ...]) -> tuple[RegisterOpcode, ...]:
     unique = {int(opcode): cast(RegisterOpcode, opcode) for opcode in opcodes}
-    ordered = sorted(
-        unique,
-        key=lambda opcode: (0 if opcode == 0x02 else 1 if opcode == 0x06 else 2, opcode),
-    )
+    ordered = sorted(unique, key=_namespace_opcode_sort_key)
     return tuple(unique[opcode] for opcode in ordered)
 
 
@@ -1660,8 +1662,7 @@ def scan_b524(
             if not _is_instanced_group(namespace_ii_max):
                 _mark_present_instances(instances_obj, instances=(0x00,))
                 known_namespace_probe_counts.setdefault(group.group, []).append(
-                    f"{_group_name_for_opcode(group.group, opcode)} "
-                    f"[{opcode_label(opcode)}] 1/1"
+                    f"{_group_name_for_opcode(group.group, opcode)} [{opcode_label(opcode)}] 1/1"
                 )
                 continue
 

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -40,6 +40,8 @@ from .b516 import scan_b516
 from .b555 import scan_b555
 from .director import (
     GROUP_CONFIG,
+    KNOWN_CORE_GROUPS,
+    ClassifiedGroup,
     DiscoveredGroup,
     classify_groups,
     discover_groups,
@@ -111,7 +113,16 @@ def _planner_ii_max(ii_max: int | None) -> int | None:
 
 
 def _group_opcodes(group: int) -> tuple[RegisterOpcode, ...]:
-    return tuple(opcodes_for_group(group))
+    return _sorted_namespace_opcodes(opcodes_for_group(group))
+
+
+def _sorted_namespace_opcodes(opcodes: list[int] | tuple[int, ...]) -> tuple[RegisterOpcode, ...]:
+    unique = {int(opcode): cast(RegisterOpcode, opcode) for opcode in opcodes}
+    ordered = sorted(
+        unique,
+        key=lambda opcode: (0 if opcode == 0x02 else 1 if opcode == 0x06 else 2, opcode),
+    )
+    return tuple(unique[opcode] for opcode in ordered)
 
 
 def _planner_source_opcodes(group: int) -> tuple[RegisterOpcode, ...]:
@@ -121,7 +132,7 @@ def _planner_source_opcodes(group: int) -> tuple[RegisterOpcode, ...]:
     profiles = group_namespace_profiles(group)
     if not profiles:
         return _group_opcodes(group)
-    return tuple(cast(RegisterOpcode, opcode) for opcode in sorted(profiles))
+    return _sorted_namespace_opcodes(tuple(profiles))
 
 
 def _primary_opcode(group: int) -> RegisterOpcode:
@@ -130,6 +141,35 @@ def _primary_opcode(group: int) -> RegisterOpcode:
 
 def _is_dual_namespace_group(group: int) -> bool:
     return len(_group_opcodes(group)) > 1
+
+
+def _planner_group_is_recommended(*, group: int, opcode: RegisterOpcode) -> bool:
+    if group in KNOWN_CORE_GROUPS:
+        return True
+    config = GROUP_CONFIG.get(group)
+    if config is None or bool(config.get("exhaustive_only")):
+        return False
+    contract = namespace_availability_contract(group=group, opcode=opcode)
+    return contract.source == "heuristic_probe"
+
+
+def _instance_discovery_targets(
+    classified: list[ClassifiedGroup],
+    metadata_map: Mapping[int, GroupMetadata],
+    resolved_group_opcodes: Mapping[int, tuple[RegisterOpcode, ...]],
+) -> list[tuple[ClassifiedGroup, GroupMetadata, RegisterOpcode]]:
+    targets: list[tuple[ClassifiedGroup, GroupMetadata, RegisterOpcode]] = []
+    for opcode in (_LOCAL_REGISTER_OPCODE, _REMOTE_REGISTER_OPCODE):
+        for group in classified:
+            if opcode not in resolved_group_opcodes.get(group.group, ()):
+                continue
+            targets.append((group, metadata_map[group.group], opcode))
+    for group in classified:
+        for opcode in resolved_group_opcodes.get(group.group, ()):
+            if opcode in {_LOCAL_REGISTER_OPCODE, _REMOTE_REGISTER_OPCODE}:
+                continue
+            targets.append((group, metadata_map[group.group], opcode))
+    return targets
 
 
 def _group_name_for_opcode(group: int, opcode: RegisterOpcode) -> str:
@@ -1343,9 +1383,6 @@ def scan_b524(
             counting_transport.counters.send_calls - group_discovery_start_calls
         )
         classified = classify_groups(discovered, observer=observer)
-        unknown_groups = sorted(
-            group.group for group in classified if group.group not in GROUP_CONFIG
-        )
         unknown_descriptor_types = sorted(
             {
                 float(group.descriptor)
@@ -1354,13 +1391,6 @@ def scan_b524(
                 and float(group.descriptor) not in _KNOWN_DESCRIPTOR_TYPES
             }
         )
-        if unknown_groups and observer is not None:
-            unknown_text = ", ".join(f"0x{gg:02X}" for gg in unknown_groups)
-            observer.log(
-                f"Found {len(unknown_groups)} unknown groups ({unknown_text}); "
-                "deriving namespace coverage from opcode responsiveness probes.",
-                level="warn",
-            )
         if unknown_descriptor_types and observer is not None:
             descriptor_text = ", ".join(f"{value:g}" for value in unknown_descriptor_types)
             observer.log(
@@ -1368,17 +1398,6 @@ def scan_b524(
                 f"{descriptor_text}. Continue scan, then report with artifact JSON/HTML.",
                 level="warn",
             )
-        if unknown_groups or unknown_descriptor_types:
-            advisory: dict[str, Any] = {
-                "kind": "protocol_discovery",
-                "suggest_issue": True,
-                "attach_artifacts": ["scan_json", "scan_html"],
-            }
-            if unknown_groups:
-                advisory["unknown_groups"] = [f"0x{group:02X}" for group in unknown_groups]
-            if unknown_descriptor_types:
-                advisory["unknown_descriptor_types"] = unknown_descriptor_types
-            artifact["meta"]["issue_suggestion"] = advisory
         if observer is not None:
             observer.phase_finish("group_discovery")
             observer.log(f"Discovered {len(classified)} groups", level="info")
@@ -1483,40 +1502,36 @@ def scan_b524(
         group_dual_namespace_runtime: dict[int, bool] = {
             group: len(opcodes) > 1 for group, opcodes in resolved_group_opcodes.items()
         }
+        responsive_unknown_groups = sorted(
+            group.group
+            for group in classified
+            if group.group not in GROUP_CONFIG and resolved_group_opcodes.get(group.group, ())
+        )
+        if responsive_unknown_groups and observer is not None:
+            unknown_text = ", ".join(f"0x{gg:02X}" for gg in responsive_unknown_groups)
+            observer.log(
+                f"Found {len(responsive_unknown_groups)} unknown groups ({unknown_text}); "
+                "deriving namespace coverage from opcode responsiveness probes.",
+                level="warn",
+            )
+        if responsive_unknown_groups or unknown_descriptor_types:
+            advisory: dict[str, Any] = {
+                "kind": "protocol_discovery",
+                "suggest_issue": True,
+                "attach_artifacts": ["scan_json", "scan_html"],
+            }
+            if responsive_unknown_groups:
+                advisory["unknown_groups"] = [
+                    f"0x{group:02X}" for group in responsive_unknown_groups
+                ]
+            if unknown_descriptor_types:
+                advisory["unknown_descriptor_types"] = unknown_descriptor_types
+            artifact["meta"]["issue_suggestion"] = advisory
 
-        # Phase C: instance discovery (groups with ii_max > 0 only).
-        instance_total = 0
         for group in classified:
             meta = metadata_map[group.group]
-            opcodes = resolved_group_opcodes.get(group.group, ())
-            if GROUP_CONFIG.get(group.group) is None:
-                candidate_instances = (
-                    _UNKNOWN_GROUP_EXPANDED_INSTANCES
-                    if research_mode
-                    else _UNKNOWN_GROUP_INITIAL_INSTANCES
-                )
-                instance_total += len(candidate_instances) * len(opcodes)
-                continue
-            for opcode in opcodes:
-                namespace_ii_max = _ii_max_for_opcode(
-                    group=group.group,
-                    default_ii_max=meta.ii_max,
-                    opcode=opcode,
-                )
-                if _is_instanced_group(namespace_ii_max):
-                    assert namespace_ii_max is not None
-                    instance_total += namespace_ii_max + 1
-        if observer is not None:
-            observer.phase_start("instance_discovery", total=instance_total or 1)
-
-        instance_discovery_start = time.perf_counter()
-        instance_discovery_start_calls = counting_transport.counters.send_calls
-        for group in classified:
-            meta = metadata_map[group.group]
-            rr_max = meta.rr_max
             opcodes = resolved_group_opcodes.get(group.group, ())
             dual_namespace = len(opcodes) > 1
-            config = GROUP_CONFIG.get(group.group)
             # NaN descriptors come from synthetic research-mode injection;
             # store as None to keep JSON-serializable and avoid polluting analytics.
             desc_for_artifact = None if math.isnan(group.descriptor) else group.descriptor
@@ -1552,54 +1567,44 @@ def scan_b524(
                 discovery_advisory=discovery_advisory,
             )
 
-            if not opcodes:
+        instance_targets = _instance_discovery_targets(
+            classified,
+            metadata_map,
+            resolved_group_opcodes,
+        )
+
+        # Phase C: instance discovery (groups with ii_max > 0 only).
+        instance_total = 0
+        for group, meta, opcode in instance_targets:
+            if GROUP_CONFIG.get(group.group) is None:
+                candidate_instances = (
+                    _UNKNOWN_GROUP_EXPANDED_INSTANCES
+                    if research_mode
+                    else _UNKNOWN_GROUP_INITIAL_INSTANCES
+                )
+                instance_total += len(candidate_instances)
                 continue
+            namespace_ii_max = _ii_max_for_opcode(
+                group=group.group,
+                default_ii_max=meta.ii_max,
+                opcode=opcode,
+            )
+            if _is_instanced_group(namespace_ii_max):
+                assert namespace_ii_max is not None
+                instance_total += namespace_ii_max + 1
+        if observer is not None:
+            observer.phase_start("instance_discovery", total=instance_total or 1)
+
+        instance_discovery_start = time.perf_counter()
+        instance_discovery_start_calls = counting_transport.counters.send_calls
+        known_namespace_probe_counts: dict[int, list[str]] = {}
+        unknown_namespace_probe_counts: dict[int, list[str]] = {}
+        for group, meta, opcode in instance_targets:
+            rr_max = meta.rr_max
+            config = GROUP_CONFIG.get(group.group)
 
             if config is None:
-                namespace_probe_counts: list[str] = []
                 total_slots = len(_UNKNOWN_GROUP_EXPANDED_INSTANCES)
-                for opcode in opcodes:
-                    namespace_ii_max = _ii_max_for_opcode(
-                        group=group.group,
-                        default_ii_max=meta.ii_max,
-                        opcode=opcode,
-                    )
-                    _record_namespace_topology(
-                        artifact,
-                        group=group.group,
-                        opcode=opcode,
-                        ii_max=namespace_ii_max,
-                    )
-                    instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
-                    emit_trace_label(
-                        transport,
-                        "Exploring unknown group "
-                        f"0x{group.group:02X} ({opcode_label(opcode)}) "
-                        "across multiple instances",
-                    )
-                    present_instances = _probe_unknown_present_instances(
-                        transport,
-                        dst=dst,
-                        group=group.group,
-                        opcode=opcode,
-                        observer=observer,
-                        expand_fallback=research_mode,
-                    )
-                    _mark_present_instances(instances_obj, instances=present_instances)
-                    namespace_probe_counts.append(
-                        f"{opcode_label(opcode)} {len(present_instances)}/{total_slots}"
-                    )
-                if observer is not None:
-                    observer.log(
-                        f"GG=0x{group.group:02X} {group.name}: "
-                        f"{', '.join(namespace_probe_counts)} present (experimental), "
-                        f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
-                        level="info",
-                    )
-                continue
-
-            known_namespace_probe_counts: list[str] = []
-            for opcode in opcodes:
                 namespace_ii_max = _ii_max_for_opcode(
                     group=group.group,
                     default_ii_max=meta.ii_max,
@@ -1611,57 +1616,102 @@ def scan_b524(
                     opcode=opcode,
                     ii_max=namespace_ii_max,
                 )
-                contract = namespace_availability_contract(group=group.group, opcode=opcode)
                 instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
-                if _is_instanced_group(namespace_ii_max):
-                    _record_availability_contract(
-                        artifact,
-                        group=group.group,
-                        opcode=opcode,
-                        contract=contract,
-                    )
-                if not _is_instanced_group(namespace_ii_max):
-                    _mark_present_instances(instances_obj, instances=(0x00,))
-                    known_namespace_probe_counts.append(
-                        f"{_group_name_for_opcode(group.group, opcode)} "
-                        f"[{opcode_label(opcode)}] 1/1"
-                    )
-                    continue
-
-                assert namespace_ii_max is not None
                 emit_trace_label(
                     transport,
-                    f"Identifying instances in group 0x{group.group:02X} ({opcode_label(opcode)})",
+                    "Exploring unknown group "
+                    f"0x{group.group:02X} ({opcode_label(opcode)}) "
+                    "across multiple instances",
                 )
-                probes = _probe_present_instances(
+                present_instances = _probe_unknown_present_instances(
                     transport,
                     dst=dst,
                     group=group.group,
                     opcode=opcode,
-                    ii_max=namespace_ii_max,
                     observer=observer,
+                    expand_fallback=research_mode,
                 )
-                _record_availability_probes(
+                _mark_present_instances(instances_obj, instances=present_instances)
+                unknown_namespace_probe_counts.setdefault(group.group, []).append(
+                    f"{opcode_label(opcode)} {len(present_instances)}/{total_slots}"
+                )
+                continue
+
+            namespace_ii_max = _ii_max_for_opcode(
+                group=group.group,
+                default_ii_max=meta.ii_max,
+                opcode=opcode,
+            )
+            _record_namespace_topology(
+                artifact,
+                group=group.group,
+                opcode=opcode,
+                ii_max=namespace_ii_max,
+            )
+            contract = namespace_availability_contract(group=group.group, opcode=opcode)
+            instances_obj = _instances_object(artifact, group=group.group, opcode=opcode)
+            if _is_instanced_group(namespace_ii_max):
+                _record_availability_contract(
                     artifact,
                     group=group.group,
                     opcode=opcode,
-                    probes=probes,
+                    contract=contract,
                 )
-                present_instances = tuple(ii for ii, probe in probes.items() if probe.present)
-                _mark_present_instances(instances_obj, instances=present_instances)
-                known_namespace_probe_counts.append(
+            if not _is_instanced_group(namespace_ii_max):
+                _mark_present_instances(instances_obj, instances=(0x00,))
+                known_namespace_probe_counts.setdefault(group.group, []).append(
                     f"{_group_name_for_opcode(group.group, opcode)} "
-                    f"[{opcode_label(opcode)}] "
-                    f"{len(present_instances)}/{namespace_ii_max + 1}"
+                    f"[{opcode_label(opcode)}] 1/1"
                 )
+                continue
 
-            if observer is not None:
-                observer.log(
-                    f"GG=0x{group.group:02X}: "
-                    f"{', '.join(known_namespace_probe_counts)} present, "
-                    f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
-                    level="info",
-                )
+            assert namespace_ii_max is not None
+            emit_trace_label(
+                transport,
+                f"Identifying instances in group 0x{group.group:02X} ({opcode_label(opcode)})",
+            )
+            probes = _probe_present_instances(
+                transport,
+                dst=dst,
+                group=group.group,
+                opcode=opcode,
+                ii_max=namespace_ii_max,
+                observer=observer,
+            )
+            _record_availability_probes(
+                artifact,
+                group=group.group,
+                opcode=opcode,
+                probes=probes,
+            )
+            present_instances = tuple(ii for ii, probe in probes.items() if probe.present)
+            _mark_present_instances(instances_obj, instances=present_instances)
+            known_namespace_probe_counts.setdefault(group.group, []).append(
+                f"{_group_name_for_opcode(group.group, opcode)} "
+                f"[{opcode_label(opcode)}] "
+                f"{len(present_instances)}/{namespace_ii_max + 1}"
+            )
+
+        if observer is not None:
+            for group in classified:
+                rr_max = metadata_map[group.group].rr_max
+                unknown_counts = unknown_namespace_probe_counts.get(group.group)
+                if unknown_counts:
+                    observer.log(
+                        f"GG=0x{group.group:02X} {group.name}: "
+                        f"{', '.join(unknown_counts)} present (experimental), "
+                        f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
+                        level="info",
+                    )
+                    continue
+                known_counts = known_namespace_probe_counts.get(group.group)
+                if known_counts:
+                    observer.log(
+                        f"GG=0x{group.group:02X}: "
+                        f"{', '.join(known_counts)} present, "
+                        f"RR_max=0x{rr_max:04X} ({rr_max + 1} registers/instance)",
+                        level="info",
+                    )
 
         if observer is not None:
             observer.phase_finish("instance_discovery")
@@ -1762,6 +1812,10 @@ def scan_b524(
                         present_instances=present_instances,
                         namespace_label=(opcode_label(opcode) if dual_namespace else None),
                         primary=(opcode == primary_opcode),
+                        recommended=_planner_group_is_recommended(
+                            group=group.group,
+                            opcode=opcode,
+                        ),
                         exhaustive_only=bool(config and config.get("exhaustive_only")),
                     )
                 )

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -7,7 +7,7 @@ import struct
 import sys
 import time
 from collections import deque
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, cast
@@ -121,7 +121,7 @@ def _namespace_opcode_sort_key(opcode: int) -> tuple[int, int]:
     return priority, opcode
 
 
-def _sorted_namespace_opcodes(opcodes: list[int] | tuple[int, ...]) -> tuple[RegisterOpcode, ...]:
+def _sorted_namespace_opcodes(opcodes: Sequence[int]) -> tuple[RegisterOpcode, ...]:
     unique = {int(opcode): cast(RegisterOpcode, opcode) for opcode in opcodes}
     ordered = sorted(unique, key=_namespace_opcode_sort_key)
     return tuple(unique[opcode] for opcode in ordered)

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -36,6 +36,7 @@ class PlannerGroup:
     present_instances: tuple[int, ...]
     namespace_label: str | None = None
     primary: bool = True
+    recommended: bool = True
     exhaustive_only: bool = False
 
     @property
@@ -73,6 +74,39 @@ def _hex_u8(value: int) -> str:
 
 def _hex_u16(value: int) -> str:
     return f"0x{value:04x}"
+
+
+def _namespace_opcode_rank(opcode: int) -> tuple[int, int]:
+    if opcode == 0x02:
+        return (0, opcode)
+    if opcode == 0x06:
+        return (1, opcode)
+    return (2, opcode)
+
+
+def planner_group_sort_key(group: PlannerGroup) -> tuple[int, int, int]:
+    return (*_namespace_opcode_rank(group.opcode), group.group)
+
+
+def planner_namespace_title(opcode: int) -> str:
+    if opcode == 0x02:
+        return "Local Devices (0x02)"
+    if opcode == 0x06:
+        return "Remote Devices (0x06)"
+    return f"Other Namespace ({_hex_u8(opcode)})"
+
+
+def split_planner_groups_by_namespace(
+    groups: list[PlannerGroup],
+) -> list[tuple[str, list[PlannerGroup]]]:
+    buckets: dict[int, list[PlannerGroup]] = {}
+    for group in sorted(groups, key=planner_group_sort_key):
+        buckets.setdefault(group.opcode, []).append(group)
+    return [
+        (planner_namespace_title(opcode), buckets[opcode])
+        for opcode in sorted(buckets, key=_namespace_opcode_rank)
+        if buckets[opcode]
+    ]
 
 
 def _format_seconds(seconds: float) -> str:
@@ -135,6 +169,8 @@ def _ask_yes_no(console: Console, prompt: str, *, default: bool) -> bool:
 def _build_default_plan(
     eligible: dict[PlanKey, PlannerGroup],
     default_plan: dict[PlanKey, GroupScanPlan] | None,
+    *,
+    default_preset: PlannerPreset,
 ) -> dict[PlanKey, GroupScanPlan]:
     if default_plan is not None:
         selected: dict[PlanKey, GroupScanPlan] = {}
@@ -144,17 +180,10 @@ def _build_default_plan(
         if selected:
             return selected
 
-    defaults: dict[PlanKey, GroupScanPlan] = {}
-    for g in eligible.values():
-        if not g.known:
-            continue
-        defaults[g.key] = GroupScanPlan(
-            group=g.group,
-            opcode=g.opcode,
-            rr_max=g.rr_max,
-            instances=((0x00,) if g.ii_max is None else g.present_instances),
-        )
-    return defaults
+    return build_plan_from_preset(
+        sorted(eligible.values(), key=planner_group_sort_key),
+        preset=default_preset,
+    )
 
 
 def _instances_for_preset(group: PlannerGroup, preset: PlannerPreset) -> tuple[int, ...]:
@@ -184,7 +213,7 @@ def build_plan_from_preset(
 ) -> dict[PlanKey, GroupScanPlan]:
     normalized_preset: PlannerPreset = "research" if preset == "exhaustive" else preset
     selected: dict[PlanKey, GroupScanPlan] = {}
-    for group in sorted(groups, key=lambda g: (g.group, g.opcode)):
+    for group in sorted(groups, key=planner_group_sort_key):
         if normalized_preset == "research":
             # Research mode: include all discovered groups with expanded
             # instance/rr_max defaults for reverse-engineering workflows.
@@ -201,6 +230,10 @@ def build_plan_from_preset(
             continue
         if not group.known:
             continue
+        if normalized_preset == "recommended" and not group.recommended:
+            continue
+        if normalized_preset == "conservative" and not group.recommended:
+            continue
         if normalized_preset == "conservative" and not group.primary:
             continue
         selected[group.key] = GroupScanPlan(
@@ -215,32 +248,33 @@ def build_plan_from_preset(
 def _render_table(title: str, rows: list[PlannerGroup], *, unknown: bool, console: Console) -> None:
     if not rows:
         return
-    console.print(Rule(title, style="dim"))
-    table = Table(show_lines=False, header_style="bold dim")
-    table.add_column("GG", style="cyan", no_wrap=True)
-    table.add_column("Name", style="white")
-    table.add_column("Type", style="dim", justify="right", no_wrap=True)
-    table.add_column("Instances", style="dim", justify="right", no_wrap=True)
-    table.add_column("RR_max", style="magenta", justify="right", no_wrap=True)
-    for g in rows:
-        if g.ii_max is None:
-            instances = "singleton"
-        elif unknown:
-            instances = f"0/{g.ii_max + 1} (est.)"
-        else:
-            instances = f"{len(g.present_instances)}/{g.ii_max + 1}"
-        name = g.display_name if not unknown else f"{g.display_name} (experimental)"
-        rr_max = _hex_u16(g.rr_max_full)
-        if g.rr_max_full != g.rr_max:
-            rr_max = f"{_hex_u16(g.rr_max)} / {rr_max}"
-        table.add_row(
-            _hex_u8(g.group),
-            name,
-            f"{g.descriptor:.1f}",
-            instances,
-            rr_max,
-        )
-    console.print(table)
+    for namespace_title, namespace_rows in split_planner_groups_by_namespace(rows):
+        console.print(Rule(f"{title} - {namespace_title}", style="dim"))
+        table = Table(show_lines=False, header_style="bold dim")
+        table.add_column("GG", style="cyan", no_wrap=True)
+        table.add_column("Name", style="white")
+        table.add_column("Type", style="dim", justify="right", no_wrap=True)
+        table.add_column("Instances", style="dim", justify="right", no_wrap=True)
+        table.add_column("RR_max", style="magenta", justify="right", no_wrap=True)
+        for g in namespace_rows:
+            if g.ii_max is None:
+                instances = "singleton"
+            elif unknown:
+                instances = f"0/{g.ii_max + 1} (est.)"
+            else:
+                instances = f"{len(g.present_instances)}/{g.ii_max + 1}"
+            name = g.display_name if not unknown else f"{g.display_name} (experimental)"
+            rr_max = _hex_u16(g.rr_max_full)
+            if g.rr_max_full != g.rr_max:
+                rr_max = f"{_hex_u16(g.rr_max)} / {rr_max}"
+            table.add_row(
+                _hex_u8(g.group),
+                name,
+                f"{g.descriptor:.1f}",
+                instances,
+                rr_max,
+            )
+        console.print(table)
 
 
 def _print_plan_breakdown(console: Console, plan: dict[PlanKey, GroupScanPlan]) -> None:
@@ -417,7 +451,12 @@ def prompt_scan_plan(
     for group in groups:
         eligible_groups.setdefault(group.group, []).append(group)
 
-    default_selected_plan = _build_default_plan(eligible, default_plan)
+    default_selected_plan = _build_default_plan(
+        eligible,
+        default_plan,
+        default_preset=default_preset,
+    )
+
 
     console.print(Rule("Scan Planner", style="dim"))
     console.print(

--- a/src/helianthus_vrc_explorer/ui/planner.py
+++ b/src/helianthus_vrc_explorer/ui/planner.py
@@ -457,7 +457,6 @@ def prompt_scan_plan(
         default_preset=default_preset,
     )
 
-
     console.print(Rule("Scan Planner", style="dim"))
     console.print(
         Text(

--- a/src/helianthus_vrc_explorer/ui/planner_textual.py
+++ b/src/helianthus_vrc_explorer/ui/planner_textual.py
@@ -218,9 +218,7 @@ def run_textual_scan_plan(
             super().__init__()
             namespace_sections = split_planner_groups_by_namespace(groups)
             self._groups = [
-                group
-                for (_title, pane_groups) in namespace_sections
-                for group in pane_groups
+                group for (_title, pane_groups) in namespace_sections for group in pane_groups
             ]
             preset_plan = build_plan_from_preset(self._groups, preset=default_preset)
             initial_plan = default_plan if default_plan is not None else preset_plan
@@ -302,8 +300,7 @@ def run_textual_scan_plan(
                 "remote": self.query_one("#planner-table-remote", DataTable),
             }
             cursor_by_pane = {
-                pane: max(0, table.cursor_row)
-                for pane, table in table_by_pane.items()
+                pane: max(0, table.cursor_row) for pane, table in table_by_pane.items()
             }
             for table in table_by_pane.values():
                 table.clear(columns=False)

--- a/src/helianthus_vrc_explorer/ui/planner_textual.py
+++ b/src/helianthus_vrc_explorer/ui/planner_textual.py
@@ -12,7 +12,14 @@ from ..scanner.plan import (
     parse_int_set,
     parse_int_token,
 )
-from .planner import PlannerGroup, PlannerPreset, _format_seconds, build_plan_from_preset
+from .planner import (
+    PlannerGroup,
+    PlannerPreset,
+    _format_seconds,
+    build_plan_from_preset,
+    planner_namespace_title,
+    split_planner_groups_by_namespace,
+)
 
 
 @dataclass(slots=True)
@@ -102,6 +109,14 @@ def _estimate_footer(
     )
 
 
+def _planner_pane_id(opcode: int) -> str:
+    if opcode == 0x02:
+        return "local"
+    if opcode == 0x06:
+        return "remote"
+    return "other"
+
+
 def run_textual_scan_plan(
     groups: list[PlannerGroup],
     *,
@@ -116,7 +131,7 @@ def run_textual_scan_plan(
 
     from textual.app import App, ComposeResult
     from textual.binding import Binding
-    from textual.containers import Vertical
+    from textual.containers import Horizontal, Vertical
     from textual.events import Key
     from textual.screen import ModalScreen
     from textual.widgets import DataTable, Footer, Header, Input, Label, Static
@@ -201,11 +216,16 @@ def run_textual_scan_plan(
 
         def __init__(self) -> None:
             super().__init__()
-            self._groups = sorted(groups, key=lambda group: (group.group, group.opcode))
+            namespace_sections = split_planner_groups_by_namespace(groups)
+            self._groups = [
+                group
+                for (_title, pane_groups) in namespace_sections
+                for group in pane_groups
+            ]
             preset_plan = build_plan_from_preset(self._groups, preset=default_preset)
             initial_plan = default_plan if default_plan is not None else preset_plan
             self._states: dict[PlanKey, _EditableGroup] = {}
-            self._row_groups: list[PlanKey] = []
+            self._row_groups: dict[str, list[PlanKey]] = {"local": [], "remote": [], "other": []}
             self._editing_group: PlanKey | None = None
             for group in self._groups:
                 group_plan = initial_plan.get(group.key)
@@ -227,18 +247,34 @@ def run_textual_scan_plan(
 
         def compose(self) -> ComposeResult:
             yield Header(show_clock=False)
-            yield DataTable(id="planner-table")
+            yield Horizontal(
+                Vertical(
+                    Label(planner_namespace_title(0x02)),
+                    DataTable(id="planner-table-local"),
+                    id="planner-pane-local",
+                ),
+                Vertical(
+                    Label(planner_namespace_title(0x06)),
+                    DataTable(id="planner-table-remote"),
+                    id="planner-pane-remote",
+                ),
+                id="planner-panes",
+            )
             yield Static("", id="status")
             yield Static("", id="help")
             yield Footer()
 
         def on_mount(self) -> None:
-            table = self.query_one(DataTable)
-            table.cursor_type = "row"
-            table.add_columns("On", "GG", "Name", "Namespace", "Type", "Instances", "RR_max")
+            for table_id in ("planner-table-local", "planner-table-remote"):
+                table = self.query_one(f"#{table_id}", DataTable)
+                table.cursor_type = "row"
+                table.add_columns("On", "GG", "Name", "Namespace", "Type", "Instances", "RR_max")
             self._refresh_table()
             self._set_help("1/2/3/4 presets | Space toggle | Enter edit RR_max | i edit instances")
-            table.focus()
+            if self._row_groups["local"]:
+                self.query_one("#planner-table-local", DataTable).focus()
+            else:
+                self.query_one("#planner-table-remote", DataTable).focus()
 
         def _set_help(self, text: str) -> None:
             self.query_one("#help", Static).update(text)
@@ -249,29 +285,50 @@ def run_textual_scan_plan(
             )
 
         def _focused_group(self) -> PlanKey | None:
-            table = self.query_one(DataTable)
-            if not self._row_groups:
+            if not isinstance(self.focused, DataTable):
                 return None
-            row = table.cursor_row
-            if row < 0 or row >= len(self._row_groups):
+            pane_key = "local" if self.focused.id == "planner-table-local" else "remote"
+            row_groups = self._row_groups[pane_key]
+            if not row_groups:
                 return None
-            return self._row_groups[row]
+            row = self.focused.cursor_row
+            if row < 0 or row >= len(row_groups):
+                return None
+            return row_groups[row]
 
         def _refresh_table(self) -> None:
-            table = self.query_one(DataTable)
-            current = max(0, table.cursor_row)
-            table.clear(columns=False)
-            self._row_groups = []
+            table_by_pane = {
+                "local": self.query_one("#planner-table-local", DataTable),
+                "remote": self.query_one("#planner-table-remote", DataTable),
+            }
+            cursor_by_pane = {
+                pane: max(0, table.cursor_row)
+                for pane, table in table_by_pane.items()
+            }
+            for table in table_by_pane.values():
+                table.clear(columns=False)
+            self._row_groups = {"local": [], "remote": [], "other": []}
             for group in self._groups:
+                pane_key = _planner_pane_id(group.opcode)
+                if pane_key not in table_by_pane:
+                    continue
                 state = self._states[group.key]
-                table.add_row(*_table_row_values(state))
-                self._row_groups.append(group.key)
-            if self._row_groups:
-                table.move_cursor(row=min(current, len(self._row_groups) - 1))
+                table_by_pane[pane_key].add_row(*_table_row_values(state))
+                self._row_groups[pane_key].append(group.key)
+            for pane_key, table in table_by_pane.items():
+                row_groups = self._row_groups[pane_key]
+                if row_groups:
+                    table.move_cursor(row=min(cursor_by_pane[pane_key], len(row_groups) - 1))
             self._set_status()
 
         def _focus_table(self) -> None:
-            self.query_one(DataTable).focus()
+            if isinstance(self.focused, DataTable):
+                self.focused.focus()
+                return
+            if self._row_groups["local"]:
+                self.query_one("#planner-table-local", DataTable).focus()
+                return
+            self.query_one("#planner-table-remote", DataTable).focus()
 
         def _apply_preset(self, preset: PlannerPreset) -> None:
             preset_plan = build_plan_from_preset(self._groups, preset=preset)
@@ -335,11 +392,22 @@ def run_textual_scan_plan(
             self._focus_table()
 
         def action_focus_next(self) -> None:
-            table = self.query_one(DataTable)
-            if not self._row_groups:
+            tables = [
+                self.query_one("#planner-table-local", DataTable),
+                self.query_one("#planner-table-remote", DataTable),
+            ]
+            if not self._row_groups["local"] and not self._row_groups["remote"]:
                 return
-            next_row = (table.cursor_row + 1) % len(self._row_groups)
-            table.move_cursor(row=next_row)
+            if isinstance(self.focused, DataTable):
+                current_idx = 0 if self.focused.id == "planner-table-local" else 1
+            else:
+                current_idx = 0
+            for offset in range(1, len(tables) + 1):
+                candidate = tables[(current_idx + offset) % len(tables)]
+                pane_key = "local" if candidate.id == "planner-table-local" else "remote"
+                if self._row_groups[pane_key]:
+                    candidate.focus()
+                    return
 
         def on_key(self, event: Key) -> None:
             # Accept Enter/Return variants for row edit while avoiding modal interference.
@@ -347,7 +415,10 @@ def run_textual_scan_plan(
                 return
             if len(self.screen_stack) > 1:
                 return
-            if isinstance(self.focused, DataTable) and self.focused.id == "planner-table":
+            if isinstance(self.focused, DataTable) and self.focused.id in {
+                "planner-table-local",
+                "planner-table-remote",
+            }:
                 event.stop()
                 self.action_edit_rr_max()
 

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -12,16 +12,16 @@ from rich.text import Text
 
 
 @dataclass(frozen=True, slots=True)
-class _GroupStats:
+class _SummaryRow:
     group: str
     name: str
+    namespace_key: str | None
     descriptor: float
     instances_total: int
     instances_present: int
     instances_display: str
     registers_scanned: int
     registers_errors: int
-    namespace_registers: dict[str, int]
 
 
 def _iter_register_entries(artifact: dict[str, Any]) -> Iterable[dict[str, Any]]:
@@ -114,7 +114,7 @@ def _namespace_display_label(namespace_key: str, namespace_label: object = None)
     return namespace_key
 
 
-def _namespace_label_from_entry(
+def _namespace_key_from_entry(
     entry: dict[str, Any], *, fallback_namespace_key: str | None = None
 ) -> str | None:
     namespace_key = _normalize_namespace_key(entry.get("read_opcode"))
@@ -122,6 +122,16 @@ def _namespace_label_from_entry(
         namespace_key = _normalize_namespace_key(fallback_namespace_key)
     if namespace_key is None:
         namespace_key = _namespace_key_from_label(entry.get("read_opcode_label"))
+    return namespace_key
+
+
+def _namespace_label_from_entry(
+    entry: dict[str, Any], *, fallback_namespace_key: str | None = None
+) -> str | None:
+    namespace_key = _namespace_key_from_entry(
+        entry,
+        fallback_namespace_key=fallback_namespace_key,
+    )
     if namespace_key is None:
         return None
     return _namespace_display_label(namespace_key, entry.get("read_opcode_label"))
@@ -186,11 +196,81 @@ def _format_instance_summary(
     return f"{present}/{total}"
 
 
-def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
-    stats: list[_GroupStats] = []
+def _namespace_sort_key(namespace_key: str | None) -> tuple[int, int, str]:
+    if namespace_key is None:
+        return (3, 0, "")
+    parsed = _normalize_namespace_key(namespace_key)
+    if parsed == "0x02":
+        return (0, 0x02, parsed)
+    if parsed == "0x06":
+        return (1, 0x06, parsed)
+    if parsed is not None:
+        return (2, int(parsed, 0), parsed)
+    return (3, 0, str(namespace_key))
+
+
+def _scan_plan_namespace_keys(artifact: dict[str, Any], group_key: str) -> list[str]:
+    meta = artifact.get("meta")
+    if not isinstance(meta, dict):
+        return []
+    scan_plan = meta.get("scan_plan")
+    if not isinstance(scan_plan, dict):
+        return []
+    groups = scan_plan.get("groups")
+    if not isinstance(groups, dict):
+        return []
+    group_plan = groups.get(group_key)
+    if not isinstance(group_plan, dict):
+        return []
+    namespaces = group_plan.get("namespaces")
+    if isinstance(namespaces, dict) and namespaces:
+        return sorted(
+            (
+                namespace_key
+                for namespace_key in namespaces
+                if isinstance(namespace_key, str)
+            ),
+            key=_namespace_sort_key,
+        )
+    namespace_key = _normalize_namespace_key(group_plan.get("namespace_key"))
+    return [namespace_key] if namespace_key is not None else []
+
+
+def _infer_single_namespace_key(
+    artifact: dict[str, Any],
+    *,
+    group_key: str,
+    group_obj: dict[str, Any],
+) -> str | None:
+    planned_namespace_keys = _scan_plan_namespace_keys(artifact, group_key)
+    if len(planned_namespace_keys) == 1:
+        return planned_namespace_keys[0]
+    inferred_keys: set[str] = set()
+    instances = group_obj.get("instances", {})
+    if not isinstance(instances, dict):
+        return None
+    for instance_obj in instances.values():
+        if not isinstance(instance_obj, dict):
+            continue
+        registers = instance_obj.get("registers", {})
+        if not isinstance(registers, dict):
+            continue
+        for entry in registers.values():
+            if not isinstance(entry, dict):
+                continue
+            namespace_key = _namespace_key_from_entry(entry)
+            if namespace_key is not None:
+                inferred_keys.add(namespace_key)
+    if len(inferred_keys) == 1:
+        return next(iter(inferred_keys))
+    return None
+
+
+def _compute_summary_rows(artifact: dict[str, Any]) -> list[_SummaryRow]:
+    rows: list[_SummaryRow] = []
     groups = artifact.get("groups", {})
     if not isinstance(groups, dict):
-        return stats
+        return rows
 
     for group_key, group_obj in groups.items():
         if not isinstance(group_key, str) or not isinstance(group_obj, dict):
@@ -209,29 +289,25 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
         instances_display = "0"
         registers_scanned = 0
         registers_errors = 0
-        namespace_registers: dict[str, int] = {}
 
         if bool(group_obj.get("dual_namespace")):
             namespaces = group_obj.get("namespaces", {})
             if not isinstance(namespaces, dict):
                 namespaces = {}
-            namespace_instance_summaries: dict[str, str] = {}
-            known_totals = True
-            namespace_group_names: list[str] = []
-            for namespace_key, namespace_obj in namespaces.items():
+            for namespace_key in sorted(
+                (key for key in namespaces if isinstance(key, str)),
+                key=_namespace_sort_key,
+            ):
+                namespace_obj = namespaces.get(namespace_key)
                 if not isinstance(namespace_key, str) or not isinstance(namespace_obj, dict):
                     continue
                 namespace_group_name = namespace_obj.get("group_name")
-                if isinstance(namespace_group_name, str):
-                    cleaned_name = namespace_group_name.strip()
-                    if cleaned_name and cleaned_name not in namespace_group_names:
-                        namespace_group_names.append(cleaned_name)
-                namespace_key_norm = _normalize_namespace_key(namespace_key) or namespace_key
-                namespace_label = _namespace_display_label(
-                    namespace_key_norm,
-                    namespace_obj.get("label"),
+                namespace_name = (
+                    namespace_group_name.strip()
+                    if isinstance(namespace_group_name, str) and namespace_group_name.strip()
+                    else name
                 )
-                namespace_count = 0
+                namespace_key_norm = _normalize_namespace_key(namespace_key) or namespace_key
                 namespace_instances = namespace_obj.get("instances", {})
                 if not isinstance(namespace_instances, dict):
                     continue
@@ -239,8 +315,9 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 namespace_total = _topology_total_from_ii_max(namespace_obj.get("ii_max"))
                 topology_authoritative = namespace_total is not None
                 if namespace_total is None:
-                    known_totals = False
                     namespace_total = len(namespace_instances)
+                namespace_registers_scanned = 0
+                namespace_registers_errors = 0
                 for instance_key, instance_obj in namespace_instances.items():
                     if not isinstance(instance_obj, dict):
                         continue
@@ -249,41 +326,29 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                     registers = instance_obj.get("registers", {})
                     if not isinstance(registers, dict):
                         continue
-                    namespace_count += len(registers)
-                    registers_scanned += len(registers)
+                    namespace_registers_scanned += len(registers)
                     for entry in registers.values():
                         if not isinstance(entry, dict):
                             continue
                         if entry.get("error") is not None:
-                            registers_errors += 1
-                namespace_registers[namespace_label] = (
-                    namespace_registers.get(namespace_label, 0) + namespace_count
+                            namespace_registers_errors += 1
+                rows.append(
+                    _SummaryRow(
+                        group=group_key,
+                        name=namespace_name,
+                        namespace_key=namespace_key_norm,
+                        descriptor=descriptor,
+                        instances_total=namespace_total,
+                        instances_present=namespace_present,
+                        instances_display=_format_instance_summary(
+                            present=namespace_present,
+                            total=namespace_total,
+                            topology_authoritative=topology_authoritative,
+                        ),
+                        registers_scanned=namespace_registers_scanned,
+                        registers_errors=namespace_registers_errors,
+                    )
                 )
-                namespace_instance_summaries[namespace_label] = _format_instance_summary(
-                    present=namespace_present,
-                    total=namespace_total,
-                    topology_authoritative=topology_authoritative,
-                )
-                instances_total += namespace_total
-                instances_present += namespace_present
-            if namespace_group_names:
-                name = " / ".join(namespace_group_names)
-            if namespace_instance_summaries:
-                ordered_items = sorted(
-                    namespace_instance_summaries.items(),
-                    key=lambda item: _display_namespace_sort_key(item[0]),
-                )
-                instances_display = ", ".join(
-                    f"{label} {summary}" for (label, summary) in ordered_items
-                )
-            elif known_totals:
-                instances_display = _format_instance_summary(
-                    present=instances_present,
-                    total=instances_total,
-                    topology_authoritative=True,
-                )
-            else:
-                instances_display = str(instances_present)
         else:
             group_total = _topology_total_from_ii_max(group_obj.get("ii_max"))
             topology_authoritative = group_total is not None
@@ -301,11 +366,6 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 for entry in registers.values():
                     if not isinstance(entry, dict):
                         continue
-                    namespace_label_opt = _namespace_label_from_entry(entry)
-                    if namespace_label_opt is not None:
-                        namespace_registers[namespace_label_opt] = (
-                            namespace_registers.get(namespace_label_opt, 0) + 1
-                        )
                     if entry.get("error") is not None:
                         registers_errors += 1
             instances_total = group_total
@@ -314,23 +374,50 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 total=instances_total,
                 topology_authoritative=topology_authoritative,
             )
-
-        stats.append(
-            _GroupStats(
-                group=group_key,
-                name=name,
-                descriptor=descriptor,
-                instances_total=instances_total,
-                instances_present=instances_present,
-                instances_display=instances_display,
-                registers_scanned=registers_scanned,
-                registers_errors=registers_errors,
-                namespace_registers=_sorted_namespace_counts(namespace_registers),
+            rows.append(
+                _SummaryRow(
+                    group=group_key,
+                    name=name,
+                    namespace_key=_infer_single_namespace_key(
+                        artifact,
+                        group_key=group_key,
+                        group_obj=group_obj,
+                    ),
+                    descriptor=descriptor,
+                    instances_total=instances_total,
+                    instances_present=instances_present,
+                    instances_display=instances_display,
+                    registers_scanned=registers_scanned,
+                    registers_errors=registers_errors,
+                )
             )
-        )
 
-    stats.sort(key=lambda s: int(s.group, 0))
-    return stats
+    rows.sort(key=lambda row: (*_namespace_sort_key(row.namespace_key), int(row.group, 0)))
+    return rows
+
+
+def _render_summary_block(console: Console, *, title: str, rows: list[_SummaryRow]) -> None:
+    if not rows:
+        return
+    console.print()
+    console.print(Text(title, style="bold"))
+    table = Table(show_header=True, header_style="bold", box=None)
+    table.add_column("Group", style="cyan", no_wrap=True)
+    table.add_column("Name", style="white")
+    table.add_column("Type", style="white", justify="right", no_wrap=True)
+    table.add_column("Instances", style="white", justify="right", no_wrap=True)
+    table.add_column("Registers", style="white", justify="right", no_wrap=True)
+    table.add_column("Errors", style="white", justify="right", no_wrap=True)
+    for row in rows:
+        table.add_row(
+            row.group,
+            row.name,
+            f"{row.descriptor:g}",
+            row.instances_display,
+            str(row.registers_scanned),
+            str(row.registers_errors),
+        )
+    console.print(table)
 
 
 def _compute_namespace_totals(artifact: dict[str, Any]) -> dict[str, int]:
@@ -389,14 +476,19 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
             header += f" reason={incomplete_reason}"
     console.print(header, style="dim")
 
-    group_stats = _compute_group_stats(artifact)
-    total_regs = sum(s.registers_scanned for s in group_stats)
-    total_errs = sum(s.registers_errors for s in group_stats)
+    summary_rows = _compute_summary_rows(artifact)
+    group_count = sum(
+        1
+        for group_key, group_obj in artifact.get("groups", {}).items()
+        if isinstance(group_key, str) and isinstance(group_obj, dict)
+    )
+    total_regs = sum(row.registers_scanned for row in summary_rows)
+    total_errs = sum(row.registers_errors for row in summary_rows)
     namespace_totals = _compute_namespace_totals(artifact)
     flags_distribution = _compute_flags_distribution(artifact)
 
     console.print(
-        f"groups={len(group_stats)} registers={total_regs} errors={total_errs}", style="dim"
+        f"groups={group_count} registers={total_regs} errors={total_errs}", style="dim"
     )
     console.print(f"namespaces {_format_counts(namespace_totals)}", style="dim")
     console.print(f"flags_access {_format_counts(flags_distribution)}", style="dim")
@@ -455,27 +547,16 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
                 b516_txt += " incomplete=true"
             console.print(b516_txt, style="dim")
 
-    table = Table(show_header=True, header_style="bold", box=None)
-    table.add_column("Group", style="cyan", no_wrap=True)
-    table.add_column("Name", style="white")
-    table.add_column("Type", style="white", justify="right", no_wrap=True)
-    table.add_column("Instances", style="white", justify="right", no_wrap=True)
-    table.add_column("Namespaces", style="white")
-    table.add_column("Registers", style="white", justify="right", no_wrap=True)
-    table.add_column("Errors", style="white", justify="right", no_wrap=True)
-
-    for s in group_stats:
-        table.add_row(
-            s.group,
-            s.name,
-            f"{s.descriptor:g}",
-            s.instances_display,
-            _format_counts(s.namespace_registers),
-            str(s.registers_scanned),
-            str(s.registers_errors),
-        )
-
-    console.print(table)
+    local_rows = [row for row in summary_rows if row.namespace_key == "0x02"]
+    remote_rows = [row for row in summary_rows if row.namespace_key == "0x06"]
+    other_rows = [
+        row
+        for row in summary_rows
+        if row.namespace_key not in {"0x02", "0x06"}
+    ]
+    _render_summary_block(console, title="Local Devices (0x02)", rows=local_rows)
+    _render_summary_block(console, title="Remote Devices (0x06)", rows=remote_rows)
+    _render_summary_block(console, title="Other Namespaces", rows=other_rows)
     suggestion_obj = meta.get("issue_suggestion")
     if isinstance(suggestion_obj, dict) and suggestion_obj.get("suggest_issue") is True:
         groups_obj = suggestion_obj.get("unknown_groups")

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -225,11 +225,7 @@ def _scan_plan_namespace_keys(artifact: dict[str, Any], group_key: str) -> list[
     namespaces = group_plan.get("namespaces")
     if isinstance(namespaces, dict) and namespaces:
         return sorted(
-            (
-                namespace_key
-                for namespace_key in namespaces
-                if isinstance(namespace_key, str)
-            ),
+            (namespace_key for namespace_key in namespaces if isinstance(namespace_key, str)),
             key=_namespace_sort_key,
         )
     namespace_key = _normalize_namespace_key(group_plan.get("namespace_key"))
@@ -487,9 +483,7 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
     namespace_totals = _compute_namespace_totals(artifact)
     flags_distribution = _compute_flags_distribution(artifact)
 
-    console.print(
-        f"groups={group_count} registers={total_regs} errors={total_errs}", style="dim"
-    )
+    console.print(f"groups={group_count} registers={total_regs} errors={total_errs}", style="dim")
     console.print(f"namespaces {_format_counts(namespace_totals)}", style="dim")
     console.print(f"flags_access {_format_counts(flags_distribution)}", style="dim")
 
@@ -549,11 +543,7 @@ def render_summary(console: Console, artifact: dict[str, Any], *, output_path: P
 
     local_rows = [row for row in summary_rows if row.namespace_key == "0x02"]
     remote_rows = [row for row in summary_rows if row.namespace_key == "0x06"]
-    other_rows = [
-        row
-        for row in summary_rows
-        if row.namespace_key not in {"0x02", "0x06"}
-    ]
+    other_rows = [row for row in summary_rows if row.namespace_key not in {"0x02", "0x06"}]
     _render_summary_block(console, title="Local Devices (0x02)", rows=local_rows)
     _render_summary_block(console, title="Remote Devices (0x06)", rows=remote_rows)
     _render_summary_block(console, title="Other Namespaces", rows=other_rows)

--- a/tests/test_planner_textual.py
+++ b/tests/test_planner_textual.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from helianthus_vrc_explorer.ui.planner import PlannerGroup
+from helianthus_vrc_explorer.ui.planner import PlannerGroup, split_planner_groups_by_namespace
 from helianthus_vrc_explorer.ui.planner_textual import (
     _EditableGroup,
     _estimate_footer,
@@ -113,3 +113,40 @@ def test_table_row_values_show_explicit_namespace_column() -> None:
         "singleton",
         "0x00FF",
     )
+
+
+def test_split_planner_groups_by_namespace_prefers_local_then_remote() -> None:
+    local_group = PlannerGroup(
+        group=0x09,
+        opcode=0x02,
+        name="Unknown 0x09 (local)",
+        descriptor=1.0,
+        known=True,
+        ii_max=0x0A,
+        rr_max=0x000F,
+        rr_max_full=0x000F,
+        present_instances=(0x00,),
+        namespace_label="local",
+    )
+    remote_group = PlannerGroup(
+        group=0x01,
+        opcode=0x06,
+        name="Secondary Heating Sources",
+        descriptor=3.0,
+        known=True,
+        ii_max=None,
+        rr_max=0x0015,
+        rr_max_full=0x0015,
+        present_instances=(0x00,),
+        namespace_label="remote",
+        primary=False,
+    )
+
+    sections = split_planner_groups_by_namespace([remote_group, local_group])
+
+    assert [title for (title, _rows) in sections] == [
+        "Local Devices (0x02)",
+        "Remote Devices (0x06)",
+    ]
+    assert sections[0][1] == [local_group]
+    assert sections[1][1] == [remote_group]

--- a/tests/test_scanner_director.py
+++ b/tests/test_scanner_director.py
@@ -58,13 +58,14 @@ def _write_directory_fixture(
     return fixture_path
 
 
-def test_discover_groups_stops_after_first_nan_and_skips_holes(tmp_path: Path) -> None:
+def test_discover_groups_stops_after_first_nan_and_keeps_zero_descriptor_groups(
+    tmp_path: Path,
+) -> None:
     transport = RecordingTransport(DummyTransport(_write_directory_fixture(tmp_path)))
 
     discovered = discover_groups(transport, dst=0x15)
 
-    # Known core groups remain scan candidates even when descriptor==0.0.
-    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+    assert [group.group for group in discovered] == [0x00, 0x01, 0x02, 0x03, 0x04]
 
     # Terminator is triggered by the first NaN (GG=0x05), so probing stops there.
     assert transport.probed_groups == [0x00, 0x01, 0x02, 0x03, 0x04, 0x05]
@@ -84,10 +85,10 @@ def test_discover_groups_includes_core_with_zero_descriptor(tmp_path: Path) -> N
     discovered = discover_groups(transport, dst=0x15)
 
     assert frozenset({0x02, 0x03}) == KNOWN_CORE_GROUPS
-    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+    assert [group.group for group in discovered] == [0x00, 0x01, 0x02, 0x03]
 
 
-def test_discover_groups_uses_zero_descriptor_as_negative_hint_for_non_core_groups(
+def test_discover_groups_keeps_non_core_zero_descriptor_groups(
     tmp_path: Path,
 ) -> None:
     fixture_path = _write_directory_fixture(
@@ -102,12 +103,11 @@ def test_discover_groups_uses_zero_descriptor_as_negative_hint_for_non_core_grou
 
     discovered = discover_groups(transport, dst=0x15)
 
-    # Non-core groups still use a zero descriptor as a discovery-time negative hint.
-    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+    assert 0x09 in [group.group for group in discovered]
     assert 0x09 in transport.probed_groups
 
 
-def test_discover_groups_uses_zero_descriptor_as_negative_hint_for_unknown_groups(
+def test_discover_groups_keeps_zero_descriptor_unknown_groups_until_nan(
     tmp_path: Path,
 ) -> None:
     fixture_path = _write_directory_fixture(tmp_path, groups={}, terminator_group=None)
@@ -115,11 +115,11 @@ def test_discover_groups_uses_zero_descriptor_as_negative_hint_for_unknown_group
 
     discovered = discover_groups(transport, dst=0x15)
 
-    # Unknown groups are still filtered by the directory probe in Phase A.
-    assert [group.group for group in discovered] == [0x02, 0x03]
+    assert len(discovered) == 0x100
+    assert discovered[0].group == 0x00
+    assert discovered[-1].group == 0xFF
     assert transport.probed_groups[0] == 0x00
     assert transport.probed_groups[-1] == 0xFF
-    assert 0xFF not in [group.group for group in discovered]
 
 
 def test_discover_groups_still_terminates_on_nan(tmp_path: Path) -> None:
@@ -189,7 +189,7 @@ def test_discover_groups_does_not_terminate_on_transient_transport_failures(tmp_
 
     discovered = discover_groups(transport, dst=0x15)
 
-    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+    assert [group.group for group in discovered] == [0x00, 0x01, 0x02, 0x03, 0x07]
     # Failures at 0x04/0x05/0x06 must not terminate discovery early.
     assert transport.probed_groups[:4] == [0x00, 0x01, 0x02, 0x03]
     assert transport.probed_groups.count(0x04) == 3
@@ -205,7 +205,7 @@ def test_discover_groups_treats_status_only_gg00_as_transient(tmp_path: Path) ->
 
     discovered = discover_groups(transport, dst=0x15)
 
-    assert [group.group for group in discovered] == [0x02, 0x03]
+    assert [group.group for group in discovered] == [0x01, 0x02, 0x03, 0x04]
     assert transport.probed_groups.count(0x00) == 3
     assert transport.probed_groups[-5:] == [0x01, 0x02, 0x03, 0x04, 0x05]
 
@@ -217,7 +217,7 @@ def test_discover_groups_retries_known_group_after_single_timeout(tmp_path: Path
 
     discovered = discover_groups(transport, dst=0x15)
 
-    assert [group.group for group in discovered] == [0x00, 0x02, 0x03]
+    assert [group.group for group in discovered] == [0x00, 0x01, 0x02, 0x03, 0x04]
     assert transport.probed_groups.count(0x03) == 2
 
 

--- a/tests/test_scanner_plan.py
+++ b/tests/test_scanner_plan.py
@@ -175,3 +175,39 @@ def test_plan_key_is_opcode_first_namespace_identity() -> None:
 
     assert key == (0x06, 0x09)
     assert format_plan_key(key) == "0x09/0x06"
+
+
+def test_recommended_preset_skips_non_core_namespaces_without_verified_presence_contract() -> None:
+    groups = [
+        PlannerGroup(
+            group=0x01,
+            opcode=0x02,
+            name="Hot Water Circuit",
+            descriptor=3.0,
+            known=True,
+            ii_max=None,
+            rr_max=0x0013,
+            rr_max_full=0x0013,
+            present_instances=(0x00,),
+            recommended=False,
+        ),
+        PlannerGroup(
+            group=0x01,
+            opcode=0x06,
+            name="Secondary Heating Sources",
+            descriptor=3.0,
+            known=True,
+            ii_max=None,
+            rr_max=0x0015,
+            rr_max_full=0x0015,
+            present_instances=(0x00,),
+            namespace_label="remote",
+            primary=False,
+            recommended=False,
+        ),
+    ]
+
+    assert build_plan_from_preset(groups, preset="recommended") == {}
+
+    full = build_plan_from_preset(groups, preset="full")
+    assert sorted(full) == [make_plan_key(0x01, 0x02), make_plan_key(0x01, 0x06)]

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -910,16 +910,10 @@ def test_scan_singleton_group_nonzero_descriptor(tmp_path: Path) -> None:
     assert "descriptor_mismatch" not in group["discovery_advisory"]
     assert group["discovery_advisory"]["proven_register_opcodes"] == ["0x02"]
     assert set(group["instances"]) == {"0x00"}
-    plan = artifact["meta"]["scan_plan"]["groups"]["0x00"]
-    assert plan["instances"] == ["0x00"]
-    assert plan["dual_namespace"] is False
-    assert plan["namespace_key"] == "0x02"
-    assert plan["label"] == "local"
-    assert plan["namespace_identity_keys"] == "opcode_hex"
-    assert set(plan["namespaces"]) == {"0x02"}
+    assert "0x00" not in artifact["meta"]["scan_plan"]["groups"]
 
     scanned_instances = {ii for (_opcode, gg, ii, _rr) in transport.register_reads if gg == 0x00}
-    assert scanned_instances == {0x00}
+    assert scanned_instances == set()
 
 
 def test_artifact_schema_version(tmp_path: Path) -> None:
@@ -1485,6 +1479,70 @@ def test_scan_b524_recommended_plan_keeps_namespace_rr_max(tmp_path: Path) -> No
     assert artifact["meta"]["scan_plan"]["estimated_register_requests"] == 70
 
 
+def test_scan_b524_instance_discovery_runs_local_namespace_before_remote(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    import helianthus_vrc_explorer.scanner.scan as scan_mod
+    from helianthus_vrc_explorer.scanner.director import DiscoveredGroup
+
+    fixture = {
+        "meta": {"dummy_transport": {"directory_terminator_group": "0x0b"}},
+        "groups": {
+            "0x09": {
+                "descriptor_type": 1.0,
+                "namespaces": {
+                    "0x02": {"instances": {"0x00": {"registers": {"0x0001": {"raw_hex": "34"}}}}},
+                    "0x06": {"instances": {"0x00": {"registers": {"0x0001": {"raw_hex": "01"}}}}},
+                },
+            },
+            "0x0A": {
+                "descriptor_type": 1.0,
+                "namespaces": {
+                    "0x02": {"instances": {"0x00": {"registers": {"0x0001": {"raw_hex": "34"}}}}},
+                    "0x06": {"instances": {"0x00": {"registers": {"0x0001": {"raw_hex": "01"}}}}},
+                },
+            },
+        },
+    }
+    fixture_path = tmp_path / "fixture_group_09_0a_order.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    transport = RecordingTransport(DummyTransport(fixture_path))
+
+    monkeypatch.setattr(
+        scan_mod,
+        "discover_groups",
+        lambda *_args, **_kwargs: [
+            DiscoveredGroup(group=0x09, descriptor=1.0),
+            DiscoveredGroup(group=0x0A, descriptor=1.0),
+        ],
+    )
+    monkeypatch.setattr(scan_mod, "prompt_scan_plan", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    scan_b524(
+        transport,
+        dst=0x15,
+        observer=_NoopObserver(),
+        console=Console(force_terminal=True),
+        planner_ui="classic",
+    )
+
+    presence_reads = [
+        opcode
+        for (opcode, gg, _ii, rr) in transport.register_reads
+        if gg in {0x09, 0x0A} and rr == 0x0001
+    ]
+    first_remote_index = next(
+        index for index, opcode in enumerate(presence_reads) if opcode == 0x06
+    )
+    assert all(opcode == 0x02 for opcode in presence_reads[:first_remote_index])
+    assert all(opcode == 0x06 for opcode in presence_reads[first_remote_index:])
+
+
 def test_planner_source_opcodes_include_staged_group_01_remote_but_keep_group_00_local_only() -> (
     None
 ):
@@ -1694,8 +1752,9 @@ def test_scan_b524_textual_planner_receives_group_01_remote_and_keeps_group_00_l
 
     default_plan = captured["default_plan"]
     assert isinstance(default_plan, dict)
-    assert make_plan_key(0x01, 0x02) in default_plan
-    assert make_plan_key(0x01, 0x06) in default_plan
+    assert make_plan_key(0x00, 0x02) not in default_plan
+    assert make_plan_key(0x01, 0x02) not in default_plan
+    assert make_plan_key(0x01, 0x06) not in default_plan
     assert make_plan_key(0x00, 0x06) not in default_plan
     assert artifact["meta"]["scan_plan"]["estimated_register_requests"] == 0
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -88,9 +88,11 @@ def test_render_summary_shows_namespace_totals_and_flags_distribution(tmp_path: 
     assert "namespaces local (0x02)=2, remote (0x06)=1" in text
     assert "flags_access volatile_ro=0, stable_ro=2, technical_rw=0, user_rw=1" in text
     assert "b555 reads=4 errors=1 programs=2" in text
-    assert "local (0x02)=1, remote (0x06)=1" in text
-    assert "Unknown 0x09 (local) / Regulators" in text
-    assert "2/2" not in text
+    assert "Local Devices (0x02)" in text
+    assert "Remote Devices (0x06)" in text
+    assert "Unknown 0x09 (local)" in text
+    assert "Regulators" in text
+    assert "Unknown 0x09 (local) / Regulators" not in text
 
 
 def test_render_summary_shows_b516_stats(tmp_path: Path) -> None:
@@ -294,7 +296,10 @@ def test_render_summary_uses_namespace_specific_topology_for_instances(tmp_path:
     render_summary(console, artifact, output_path=tmp_path / "artifact.json")
     text = console.export_text()
 
-    assert "local (0x02) singleton, remote (0x06) 1/11" in text
+    assert "Local Devices (0x02)" in text
+    assert "Remote Devices (0x06)" in text
+    assert "singleton" in text
+    assert "1/11" in text
     assert "remote (0x06) singleton" not in text
 
 


### PR DESCRIPTION
## Summary
- split planner and summary presentation by opcode namespace and tighten namespace-specific planning defaults
- keep zero-descriptor groups through discovery until the NaN terminator, with instance discovery ordered local before remote
- cover the namespace split and discovery behavior with updated scanner, planner, and summary tests

## Validation
- `PYTHONPATH=src /Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/pytest tests/test_scanner_director.py tests/test_planner_textual.py tests/test_scanner_plan.py tests/test_scanner_scan.py tests/test_summary.py`
- `/Users/razvan/Desktop/Helianthus\ Project/helianthus-vrc-explorer/.venv/bin/ruff check src tests`

## Agent State
Status: ready for review
Branch: issue/235-b524-preui-opcode-namespace-split
Last verified (lint/tests): 2026-04-05; requested pytest subset and ruff check passed
How to reproduce: run the two commands in the Validation section from the repo root with `PYTHONPATH=src` for pytest
Next steps: wait for CI and review bot feedback, then address any requested changes
Notes (no secrets, no private infra): repo worktree needed explicit `PYTHONPATH=src`; branch pushes to `origin/issue/235-b524-preui-opcode-namespace-split`