### PR TITLE
Issue #237: fix still-valid Codex review follow-ups

### DIFF
--- a/src/helianthus_vrc_explorer/schema/b524_constraints.py
+++ b/src/helianthus_vrc_explorer/schema/b524_constraints.py
@@ -85,13 +85,29 @@ def _parse_numeric(value: str) -> int | float:
     return parsed
 
 
-def _parse_constraint_read_opcodes(*, raw_scope: str, raw_opcodes: str) -> tuple[int, ...]:
+def _scope_derived_read_opcodes(raw_scope: str) -> tuple[int, ...] | None:
     scope = raw_scope.strip().lower()
-    if scope == "gg_rr_invariant":
+    if not scope:
+        return None
+    if scope in {CONSTRAINT_SCOPE_DECISION, "opcode_0x02_only"}:
+        return _DEFAULT_STATIC_READ_OPCODES
+    if scope == "opcode_0x06_only":
+        return (0x06,)
+    if scope in {"gg_rr_invariant", "explicit_opcode_0x02_0x06"}:
         return (0x02, 0x06)
+    return None
 
+
+def _parse_constraint_read_opcodes(*, raw_scope: str, raw_opcodes: str) -> tuple[int, ...]:
     value = raw_opcodes.strip().lower()
     if not value:
+        derived = _scope_derived_read_opcodes(raw_scope)
+        if derived is not None:
+            return derived
+        if raw_scope.strip():
+            raise ValueError(
+                f"Unsupported constraint scope without read_opcodes: {raw_scope!r}"
+            )
         return _DEFAULT_STATIC_READ_OPCODES
     if value in {"all", "all_register_read_namespaces", "0x02+0x06"}:
         return (0x02, 0x06)

--- a/src/helianthus_vrc_explorer/ui/summary.py
+++ b/src/helianthus_vrc_explorer/ui/summary.py
@@ -173,6 +173,13 @@ def _topology_total_from_ii_max(value: object) -> int | None:
     return ii_max + 1
 
 
+def _counts_toward_topology_total(instance_key: object, *, total: int) -> bool:
+    instance_id = _parse_u8_int(instance_key)
+    if instance_id is None:
+        return False
+    return instance_id < total
+
+
 def _format_instance_summary(
     *,
     present: int,
@@ -244,7 +251,13 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
                 for instance_key, instance_obj in namespace_instances.items():
                     if not isinstance(instance_obj, dict):
                         continue
-                    if instance_obj.get("present") is True and isinstance(instance_key, str):
+                    if instance_obj.get("present") is True and (
+                        not topology_authoritative
+                        or _counts_toward_topology_total(
+                            instance_key,
+                            total=namespace_total,
+                        )
+                    ):
                         namespace_present += 1
                     registers = instance_obj.get("registers", {})
                     if not isinstance(registers, dict):
@@ -289,10 +302,13 @@ def _compute_group_stats(artifact: dict[str, Any]) -> list[_GroupStats]:
             topology_authoritative = group_total is not None
             if group_total is None:
                 group_total = len(instances)
-            for instance_obj in instances.values():
+            for instance_key, instance_obj in instances.items():
                 if not isinstance(instance_obj, dict):
                     continue
-                if instance_obj.get("present") is True:
+                if instance_obj.get("present") is True and (
+                    not topology_authoritative
+                    or _counts_toward_topology_total(instance_key, total=group_total)
+                ):
                     instances_present += 1
                 registers = instance_obj.get("registers", {})
                 if not isinstance(registers, dict):

--- a/tests/test_schema_b524_constraints.py
+++ b/tests/test_schema_b524_constraints.py
@@ -107,6 +107,66 @@ def test_lookup_static_constraint_accepts_explicit_read_opcode_scope(tmp_path: P
     assert local.read_opcodes == (0x02, 0x06)
 
 
+def test_lookup_static_constraint_derives_scope_only_remote_opcode(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "constraints.csv"
+    catalog_path.write_text(
+        "\n".join(
+            (
+                "group,register,type,min,max,step,scope,read_opcodes",
+                "0x03,0x0002,f32_range,15,30,0.5,opcode_0x06_only,",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    catalog = load_b524_constraints_catalog_from_path(catalog_path)
+
+    local = lookup_static_constraint(
+        catalog,
+        identity=make_register_identity(
+            opcode=0x02,
+            group=0x03,
+            instance=0x00,
+            register=0x0002,
+        ),
+    )
+    remote = lookup_static_constraint(
+        catalog,
+        identity=make_register_identity(
+            opcode=0x06,
+            group=0x03,
+            instance=0x01,
+            register=0x0002,
+        ),
+    )
+
+    assert local is None
+    assert remote is not None
+    assert remote.scope == "opcode_0x06_only"
+    assert remote.read_opcodes == (0x06,)
+
+
+def test_load_constraints_rejects_unknown_scope_without_read_opcodes(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "constraints.csv"
+    catalog_path.write_text(
+        "\n".join(
+            (
+                "group,register,type,min,max,step,scope,read_opcodes",
+                "0x03,0x0002,f32_range,15,30,0.5,custom_scope,",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        load_b524_constraints_catalog_from_path(catalog_path)
+    except ValueError as exc:
+        assert "Unsupported constraint scope without read_opcodes" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for unsupported scope-only row")
+
+
 def test_constraint_scope_metadata_declares_opcode_0x02_default_policy() -> None:
     metadata = constraint_scope_metadata()
     assert metadata["decision"] == "opcode_0x02_default"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -329,3 +329,71 @@ def test_render_summary_does_not_infer_singleton_from_observed_remote_count(
     assert "Unknown 0x69" in text
     assert "1/11" in text
     assert "Unknown 0x69" in text and "singleton" not in text
+
+
+def test_render_summary_ignores_synthetic_instance_slots_in_topology_ratios(
+    tmp_path: Path,
+) -> None:
+    artifact = {
+        "meta": {
+            "destination_address": "0x15",
+            "scan_timestamp": "2026-02-11T12:00:00Z",
+            "scan_duration_seconds": 1.0,
+        },
+        "groups": {
+            "0x69": {
+                "name": "Unknown 0x69",
+                "descriptor_observed": 1.0,
+                "ii_max": "0x0a",
+                "instances": {
+                    "0x00": {
+                        "present": True,
+                        "registers": {"0x0000": {"read_opcode": "0x06", "error": None}},
+                    },
+                    "0xff": {
+                        "present": True,
+                        "registers": {"0x0001": {"read_opcode": "0x06", "error": None}},
+                    },
+                },
+            },
+            "0x08": {
+                "name": "Buffer / Solar Cylinder 2",
+                "descriptor_observed": 1.0,
+                "dual_namespace": True,
+                "namespaces": {
+                    "0x02": {
+                        "label": "local",
+                        "ii_max": "0x00",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {"0x0001": {"read_opcode": "0x02", "error": None}},
+                            }
+                        },
+                    },
+                    "0x06": {
+                        "label": "remote",
+                        "ii_max": "0x0a",
+                        "instances": {
+                            "0x00": {
+                                "present": True,
+                                "registers": {"0x0001": {"read_opcode": "0x06", "error": None}},
+                            },
+                            "0xff": {
+                                "present": True,
+                                "registers": {"0x0002": {"read_opcode": "0x06", "error": None}},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    console = Console(record=True, width=180)
+    render_summary(console, artifact, output_path=tmp_path / "artifact.json")
+    text = console.export_text()
+
+    assert "2/11" not in text
+    assert "Unknown 0x69" in text and "1/11" in text
+    assert "local (0x02) singleton, remote (0x06) 1/11" in text


### PR DESCRIPTION
## Summary
- derive constraint `read_opcodes` from supported explicit scope labels when `read_opcodes` is omitted, and fail loudly for unsupported scope-only rows
- exclude synthetic exploratory instance slots such as `0xFF` from present-count numerators when summary totals come from authoritative `ii_max`
- add regressions covering the two still-valid review findings validated against current `wip`

## Validation
- [x] `PYTHONPATH=src ./.venv/bin/python -m ruff check .`
- [x] `./.venv/bin/python scripts/check_docs_sync.py`
- [x] `PYTHONPATH=src ./.venv/bin/python -m pytest`

## Notes
- Implemented only the review comments still valid on current `wip/b524-opcode-namespace-split-integration`.
- `r3037039503` and `r3037039504` are already fixed in current `wip`.
- `r3037185467` and `r3037199603` do not apply to current `wip` because the referenced split-pane/textual-summary code is not on the branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
