### PR TITLE
Issue #240: OP=0x06 generic header, dormant replies, and sentinel annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Transport note:
 - Classic GG directory-probe results are retained as advisory metadata for semantic identity and namespace topology. They are useful evidence for reverse-engineering and debugging, but they do not define those semantics once a group is a scan candidate (see `docs/b524-namespace-invariants.md`). A `descriptor_type == 0.0` result is still used as a discovery-time negative hint for non-core/unknown groups in Phase A.
 - Instance availability is namespace-specific. Dual-namespace radio groups (`0x09`, `0x0A`) are discovered independently per opcode namespace instead of sharing remote results across local and remote.
 - Artifacts retain the availability contract plus raw per-slot probe evidence under `availability_contract` and `availability_probes`, including the opcode `0x06` `RR=0x0001` `device_connected` probe used for remote namespaces.
+- Empty ACK / 0-byte B524 register replies are preserved as `flags_access="dormant"` (feature inactive) rather than treated as generic decode errors.
+- OP `0x06` register-map fallbacks now include a generic device header for `RR=0x0001..0x0004`; group-specific rows still override wildcard rows.
+- GG `0x09` is intentionally dual-use: local/control semantics on `0x02`, remote radio-device semantics on `0x06`.
+- Scanner annotations include the integer sentinel `0x7FFFFFFF` as `value_display="sentinel_invalid_i32 (0x7FFFFFFF)"` when decoded in integer contexts.
 - Unknown groups are namespace-classified from live opcode responsiveness evidence. There is no implicit unknown-group `[0x02, 0x06]` fallback.
 - Contextual enum annotations are local-namespace scoped: group `0x02` local (`0x02`) register context never relabels remote (`0x06`) entries.
 - Canonical namespace identity is always an opcode hex key (`0x02`, `0x06`, ...). Labels like `local`/`remote` are presentation metadata only.

--- a/data/myvaillant_register_map.csv
+++ b/data/myvaillant_register_map.csv
@@ -11,6 +11,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x0012,continuous_heating_room_setpoint,,config,,
 0x00,0x00,0x0014,adaptive_heating_curve,AdaptHeatCurve,config,,
 0x00,0x00,0x0015,parallel_tank_loading_allowed,HwcParallelLoading,config,,
+0x00,0x00,0x0016,system_quick_mode_active,,state,BOOL,0x02
 0x00,0x00,0x0017,dhw_maximum_loading_time,MaxCylinderChargeTime,config,,
 0x00,0x00,0x0018,hwc_lock_time,HwcLockTime,config,,
 0x00,0x00,0x0019,solar_flow_rate_quantity,,config,,

--- a/data/myvaillant_register_map.csv
+++ b/data/myvaillant_register_map.csv
@@ -3,6 +3,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x0002,continuous_heating_start_setpoint,ContinuousHeating,config,,
 0x00,0x00,0x0003,frost_override_time,FrostOverRideTime,config,,
 0x00,0x00,0x0004,maximum_preheating_time,,config,,
+0x00,0x00,0x0006,manual_cooling_days,,state,UCH,0x02
 0x00,0x00,0x0007,system_off,SysOff,config,,
 0x00,0x00,0x0008,temporary_allow_backup_heater,,config,,
 0x00,0x00,0x0009,external_energy_management_activation,,config,,
@@ -38,7 +39,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x003E,environmental_yield_total,YieldTotal,state,U32,
 0x00,0x00,0x0045,esco_block_function,,config,,
 0x00,0x00,0x0046,hwc_max_flow_temp_desired,HwcMaxFlowTempDesired,config,,
-0x00,0x00,0x0048,unknown_0048,,state,UIN,0x02
+0x00,0x00,0x0048,system_status_bitmask,,state,UIN,0x02
 0x00,0x00,0x004B,system_flow_temperature,FlowTemp,,,
 0x00,0x00,0x004D,multi_relay_setting,MultiRelaySetting,config,,
 0x00,0x00,0x004E,fuel_consumption_heating_this_month,PrFuelSumHcThisMonth,state,U32,
@@ -62,6 +63,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x006F,installer_phone_1,PhoneNumber1,state,,
 0x00,0x00,0x0070,installer_phone_2,PhoneNumber2,state,,
 0x00,0x00,0x0073,outdoor_temperature,OutdoorTemp,,,
+0x00,0x00,0x0074,system_quick_mode_value,,state,UCH,0x02
 0x00,0x00,0x0076,installer_menu_code,KeyCodeforConfigMenu,state,,
 0x00,0x00,0x0081,smart_photovoltaic_buffer_offset,,state,,
 0x00,0x00,0x0095,outdoor_temperature_avg_24h,OutsideTempAvg,state,,
@@ -82,8 +84,8 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x00CA,fuel_heating_last_month_mirror,,state,U32,
 0x00,0x00,0x00CB,gas_total_combined,,state,U32,
 0x00,0x00,0x00CD,gas_total_combined_dup,,state,U32,
-0x00,0x00,0x00DA,unknown_00da_date,,config,HDA:3,0x02
-0x00,0x00,0x00DB,unknown_00db_date,,config,HDA:3,0x02
+0x00,0x00,0x00DA,manual_cooling_date_start,,config,HDA:3,0x02
+0x00,0x00,0x00DB,manual_cooling_date_end,,config,HDA:3,0x02
 0x00,0x00,0x00DD,heating_curve_day_1,,config,,
 0x00,0x00,0x00DE,heating_curve_day_2,,config,,
 0x00,0x00,0x00DF,heating_curve_day_3,,config,,

--- a/data/myvaillant_register_map.csv
+++ b/data/myvaillant_register_map.csv
@@ -237,3 +237,6 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x0C,*,0x0004,device_firmware_version,,state,FW,0x06
 0x0C,*,0x0012,device_status,,state,,0x06
 *,*,0x0001,device_connected,,state,BOOL,0x06
+*,*,0x0002,device_class_address,,state,UCH,0x06
+*,*,0x0003,device_error_code,,state,UCH,0x06
+*,*,0x0004,device_firmware_version,,state,FW,0x06

--- a/docs/b524-namespace-invariants.md
+++ b/docs/b524-namespace-invariants.md
@@ -47,3 +47,25 @@ Issues #120 and #125 remain useful exploratory context (how we reached the names
 - and this invariants contract.
 
 When historical notes conflict with current contract, follow current contract and open a corrective docs issue/PR.
+
+## Protocol Notes Implemented In Explorer
+
+These notes are scanner/register-map behaviors implemented in this repository only.
+They are observational and do not replace the opcode-first identity contract above.
+
+1. OP `0x06` generic device-header registers (`RR=0x0001..0x0004`) are mapped experimentally.
+   - Generic rows are provided for `device_connected`, `device_class_address`, `device_error_code`, and `device_firmware_version`.
+   - Group-specific rows (for example GG `0x09`/`0x0A` radio fields) remain authoritative when present; wildcard header rows are fallback only.
+
+2. GG `0x09` is dual-use by opcode namespace.
+   - OP `0x02`: local control/write-path style registers (for example quick-mode related control path).
+   - OP `0x06`: remote radio-device inventory/status registers.
+   - GG identity must never be merged across opcodes.
+
+3. Empty ACK/0-byte replies are treated as `dormant` in scanner artifacts.
+   - Meaning: register exists but feature is currently inactive (not an absent-register NACK/timeout class).
+   - This status is rendered distinctly from `absent` in explorer UI/report consumers.
+
+4. Sentinel `0x7FFFFFFF` is annotated when decoded as integer payload.
+   - Artifact entries expose `value_display="sentinel_invalid_i32 (0x7FFFFFFF)"` for this case.
+   - This is scanner-layer annotation only; semantic/runtime policy outside explorer belongs to gateway/poller repos.

--- a/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
+++ b/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
@@ -11,6 +11,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x0012,continuous_heating_room_setpoint,,config,,
 0x00,0x00,0x0014,adaptive_heating_curve,AdaptHeatCurve,config,,
 0x00,0x00,0x0015,parallel_tank_loading_allowed,HwcParallelLoading,config,,
+0x00,0x00,0x0016,system_quick_mode_active,,state,BOOL,0x02
 0x00,0x00,0x0017,dhw_maximum_loading_time,MaxCylinderChargeTime,config,,
 0x00,0x00,0x0018,hwc_lock_time,HwcLockTime,config,,
 0x00,0x00,0x0019,solar_flow_rate_quantity,,config,,

--- a/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
+++ b/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
@@ -3,6 +3,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x0002,continuous_heating_start_setpoint,ContinuousHeating,config,,
 0x00,0x00,0x0003,frost_override_time,FrostOverRideTime,config,,
 0x00,0x00,0x0004,maximum_preheating_time,,config,,
+0x00,0x00,0x0006,manual_cooling_days,,state,UCH,0x02
 0x00,0x00,0x0007,system_off,SysOff,config,,
 0x00,0x00,0x0008,temporary_allow_backup_heater,,config,,
 0x00,0x00,0x0009,external_energy_management_activation,,config,,
@@ -38,7 +39,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x003E,environmental_yield_total,YieldTotal,state,U32,
 0x00,0x00,0x0045,esco_block_function,,config,,
 0x00,0x00,0x0046,hwc_max_flow_temp_desired,HwcMaxFlowTempDesired,config,,
-0x00,0x00,0x0048,unknown_0048,,state,UIN,0x02
+0x00,0x00,0x0048,system_status_bitmask,,state,UIN,0x02
 0x00,0x00,0x004B,system_flow_temperature,FlowTemp,,,
 0x00,0x00,0x004D,multi_relay_setting,MultiRelaySetting,config,,
 0x00,0x00,0x004E,fuel_consumption_heating_this_month,PrFuelSumHcThisMonth,state,U32,
@@ -62,6 +63,7 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x006F,installer_phone_1,PhoneNumber1,state,,
 0x00,0x00,0x0070,installer_phone_2,PhoneNumber2,state,,
 0x00,0x00,0x0073,outdoor_temperature,OutdoorTemp,,,
+0x00,0x00,0x0074,system_quick_mode_value,,state,UCH,0x02
 0x00,0x00,0x0076,installer_menu_code,KeyCodeforConfigMenu,state,,
 0x00,0x00,0x0081,smart_photovoltaic_buffer_offset,,state,,
 0x00,0x00,0x0095,outdoor_temperature_avg_24h,OutsideTempAvg,state,,
@@ -82,8 +84,8 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x00,0x00,0x00CA,fuel_heating_last_month_mirror,,state,U32,
 0x00,0x00,0x00CB,gas_total_combined,,state,U32,
 0x00,0x00,0x00CD,gas_total_combined_dup,,state,U32,
-0x00,0x00,0x00DA,unknown_00da_date,,config,HDA:3,0x02
-0x00,0x00,0x00DB,unknown_00db_date,,config,HDA:3,0x02
+0x00,0x00,0x00DA,manual_cooling_date_start,,config,HDA:3,0x02
+0x00,0x00,0x00DB,manual_cooling_date_end,,config,HDA:3,0x02
 0x00,0x00,0x00DD,heating_curve_day_1,,config,,
 0x00,0x00,0x00DE,heating_curve_day_2,,config,,
 0x00,0x00,0x00DF,heating_curve_day_3,,config,,

--- a/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
+++ b/src/helianthus_vrc_explorer/data/myvaillant_register_map.csv
@@ -237,3 +237,6 @@ group,instance,register,leaf,ebusd_name,register_class,type_hint,opcode
 0x0C,*,0x0004,device_firmware_version,,state,FW,0x06
 0x0C,*,0x0012,device_status,,state,,0x06
 *,*,0x0001,device_connected,,state,BOOL,0x06
+*,*,0x0002,device_class_address,,state,UCH,0x06
+*,*,0x0003,device_error_code,,state,UCH,0x06
+*,*,0x0004,device_firmware_version,,state,FW,0x06

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -19,6 +19,9 @@ from .identity import make_register_identity, opcode_label
 logger = logging.getLogger(__name__)
 
 _PRINTABLE_LATIN1: Final[set[int]] = set(range(0x20, 0x7F)) | set(range(0xA0, 0x100))
+_EMPTY_REPLY_FLAGS_ACCESS: Final[str] = "dormant"
+_I32_INVALID_SENTINEL: Final[int] = 0x7FFFFFFF
+_I32_INVALID_SENTINEL_RAW_HEX: Final[str] = "ffffff7f"
 
 
 class RegisterEntry(TypedDict):
@@ -328,6 +331,16 @@ def _parse_inferred_value(value_bytes: bytes) -> tuple[str | None, object | None
     return _hex_fallback()
 
 
+def _sentinel_value_display(*, value: object | None, raw_hex: str | None) -> str | None:
+    if raw_hex != _I32_INVALID_SENTINEL_RAW_HEX:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value == _I32_INVALID_SENTINEL:
+        return "sentinel_invalid_i32 (0x7FFFFFFF)"
+    return None
+
+
 def read_register(
     transport: TransportInterface,
     dst: int,
@@ -386,6 +399,21 @@ def read_register(
             "error": f"transport_error: {exc}",
         }
 
+    if len(response) == 0:
+        return {
+            "read_opcode": read_opcode,
+            "read_opcode_label": read_opcode_label,
+            "reply_hex": "",
+            "flags": None,
+            "flags_access": _EMPTY_REPLY_FLAGS_ACCESS,
+            "ebusd_name": None,
+            "myvaillant_name": None,
+            "raw_hex": None,
+            "type": None,
+            "value": None,
+            "error": None,
+        }
+
     reply_hex = response.hex()
     flags: int | None = response[0] if response else None
     flags_access: str | None = (
@@ -430,7 +458,7 @@ def read_register(
     if type_hint is not None:
         try:
             value = parse_typed_value(type_hint, value_bytes)
-            return {
+            entry: RegisterEntry = {
                 "read_opcode": read_opcode,
                 "read_opcode_label": read_opcode_label,
                 "reply_hex": reply_hex,
@@ -443,6 +471,10 @@ def read_register(
                 "value": value,
                 "error": None,
             }
+            sentinel_display = _sentinel_value_display(value=value, raw_hex=raw_hex)
+            if sentinel_display is not None:
+                entry["value_display"] = sentinel_display
+            return entry
         except ValueParseError as exc:
             return {
                 "read_opcode": read_opcode,
@@ -459,7 +491,7 @@ def read_register(
             }
 
     inferred_type, inferred_value, inferred_error = _parse_inferred_value(value_bytes)
-    return {
+    entry: RegisterEntry = {
         "read_opcode": read_opcode,
         "read_opcode_label": read_opcode_label,
         "reply_hex": reply_hex,
@@ -472,6 +504,10 @@ def read_register(
         "value": inferred_value,
         "error": inferred_error,
     }
+    sentinel_display = _sentinel_value_display(value=inferred_value, raw_hex=raw_hex)
+    if sentinel_display is not None:
+        entry["value_display"] = sentinel_display
+    return entry
 
 
 def probe_instance_availability(

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -342,7 +342,11 @@ def _parse_inferred_value(value_bytes: bytes) -> tuple[str | None, object | None
     return _hex_fallback()
 
 
-def _sentinel_value_display(*, value: object | None, raw_hex: str | None) -> str | None:
+def _sentinel_value_display(
+    *, value: object | None, raw_hex: str | None, value_type: str | None
+) -> str | None:
+    if value_type != "I32":
+        return None
     if raw_hex != _I32_INVALID_SENTINEL_RAW_HEX:
         return None
     if isinstance(value, bool):
@@ -505,7 +509,11 @@ def read_register(
                 "value": value,
                 "error": None,
             }
-            sentinel_display = _sentinel_value_display(value=value, raw_hex=raw_hex)
+            sentinel_display = _sentinel_value_display(
+                value=value,
+                raw_hex=raw_hex,
+                value_type=type_hint,
+            )
             if sentinel_display is not None:
                 entry["value_display"] = sentinel_display
             return entry
@@ -538,7 +546,11 @@ def read_register(
         "value": inferred_value,
         "error": inferred_error,
     }
-    sentinel_display = _sentinel_value_display(value=inferred_value, raw_hex=raw_hex)
+    sentinel_display = _sentinel_value_display(
+        value=inferred_value,
+        raw_hex=raw_hex,
+        value_type=inferred_type,
+    )
     if sentinel_display is not None:
         entry["value_display"] = sentinel_display
     return entry

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -22,6 +22,17 @@ _PRINTABLE_LATIN1: Final[set[int]] = set(range(0x20, 0x7F)) | set(range(0xA0, 0x
 _EMPTY_REPLY_FLAGS_ACCESS: Final[str] = "dormant"
 _I32_INVALID_SENTINEL: Final[int] = 0x7FFFFFFF
 _I32_INVALID_SENTINEL_RAW_HEX: Final[str] = "ffffff7f"
+_KNOWN_DORMANT_EMPTY_REPLY_KEYS: Final[frozenset[tuple[int, int, int]]] = frozenset(
+    {
+        # OP=0x02 / GG=0x00 registers that are known to ACK with zero-length payloads
+        # while the related feature is inactive.
+        (0x02, 0x00, 0x0006),  # manual_cooling_days
+        (0x02, 0x00, 0x0016),  # system_quick_mode_active
+        (0x02, 0x00, 0x0074),  # system_quick_mode_value
+        (0x02, 0x00, 0x00DA),  # manual_cooling_date_start
+        (0x02, 0x00, 0x00DB),  # manual_cooling_date_end
+    }
+)
 
 
 class RegisterEntry(TypedDict):
@@ -341,6 +352,15 @@ def _sentinel_value_display(*, value: object | None, raw_hex: str | None) -> str
     return None
 
 
+def _is_known_dormant_empty_reply(
+    *,
+    opcode: RegisterOpcode,
+    group: int,
+    register: int,
+) -> bool:
+    return (opcode, group, register) in _KNOWN_DORMANT_EMPTY_REPLY_KEYS
+
+
 def read_register(
     transport: TransportInterface,
     dst: int,
@@ -400,18 +420,32 @@ def read_register(
         }
 
     if len(response) == 0:
+        if _is_known_dormant_empty_reply(opcode=opcode, group=group, register=register):
+            return {
+                "read_opcode": read_opcode,
+                "read_opcode_label": read_opcode_label,
+                "reply_hex": "",
+                "flags": None,
+                "flags_access": _EMPTY_REPLY_FLAGS_ACCESS,
+                "ebusd_name": None,
+                "myvaillant_name": None,
+                "raw_hex": None,
+                "type": None,
+                "value": None,
+                "error": None,
+            }
         return {
             "read_opcode": read_opcode,
             "read_opcode_label": read_opcode_label,
-            "reply_hex": "",
+            "reply_hex": None,
             "flags": None,
-            "flags_access": _EMPTY_REPLY_FLAGS_ACCESS,
+            "flags_access": None,
             "ebusd_name": None,
             "myvaillant_name": None,
             "raw_hex": None,
             "type": None,
             "value": None,
-            "error": None,
+            "error": "transport_error: no_response",
         }
 
     reply_hex = response.hex()

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -258,6 +258,12 @@ _TEMPLATE = """<!doctype html>
         border-color: rgba(255, 207, 110, 0.28);
       }
 
+      .status-dormant {
+        color: #bfe9ff;
+        background: rgba(122, 196, 255, 0.16);
+        border-color: rgba(122, 196, 255, 0.32);
+      }
+
       .status-transport {
         color: #ffb3b3;
         background: rgba(255, 122, 122, 0.16);
@@ -814,6 +820,7 @@ __ARTIFACT_JSON__
         }
         const access = typeof entry.flags_access === "string" ? entry.flags_access.trim().toLowerCase() : "";
         if (access === "absent") return "absent";
+        if (access === "dormant") return "dormant";
         const replyHex = typeof entry.reply_hex === "string" ? entry.reply_hex.trim().toLowerCase() : "";
         if (replyHex === "00") return "absent";
         return "ok";
@@ -822,6 +829,7 @@ __ARTIFACT_JSON__
       function entryStatusLabel(entry) {
         const kind = entryStatusKind(entry);
         if (kind === "absent") return "Absent / no data";
+        if (kind === "dormant") return "Dormant (feature inactive)";
         if (kind === "transport_failure") return "Transport failure";
         if (kind === "decode_error") return "Decode error";
         if (kind === "error") return "Error";
@@ -830,6 +838,7 @@ __ARTIFACT_JSON__
 
       function statusChipClass(kind) {
         if (kind === "absent") return "status-chip status-absent";
+        if (kind === "dormant") return "status-chip status-dormant";
         if (kind === "transport_failure") return "status-chip status-transport";
         if (kind === "decode_error") return "status-chip status-decode";
         return "status-chip status-error";
@@ -1608,10 +1617,12 @@ __ARTIFACT_JSON__
                 ? parseTypedValue(selectedType, valueBytes)
                 : { value: displayValue, error: null };
 
-              const valueTxt = statusKind === "absent" ? "absent" : formatValue(decoded.value);
+              const valueTxt = (statusKind === "absent" || statusKind === "dormant")
+                ? statusKind
+                : formatValue(decoded.value);
               const valueEl = document.createElement("div");
               valueEl.className = "cell-value";
-              if (statusKind === "absent") valueEl.classList.add("cell-value-muted");
+              if (statusKind === "absent" || statusKind === "dormant") valueEl.classList.add("cell-value-muted");
               valueEl.textContent = valueTxt;
               td.appendChild(valueEl);
 

--- a/src/helianthus_vrc_explorer/ui/register_semantics.py
+++ b/src/helianthus_vrc_explorer/ui/register_semantics.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Literal
 
-RegisterStatusKind = Literal["ok", "absent", "transport_failure", "decode_error", "error"]
+RegisterStatusKind = Literal[
+    "ok", "absent", "dormant", "transport_failure", "decode_error", "error"
+]
 
 
 def _sorted_hex_keys(keys: Iterable[str]) -> list[str]:
@@ -39,6 +41,8 @@ def entry_status_kind(entry: dict[str, Any] | None) -> RegisterStatusKind:
     flags_access = entry.get("flags_access")
     if isinstance(flags_access, str) and flags_access.strip().lower() == "absent":
         return "absent"
+    if isinstance(flags_access, str) and flags_access.strip().lower() == "dormant":
+        return "dormant"
 
     reply_hex = entry.get("reply_hex")
     if isinstance(reply_hex, str) and reply_hex.strip().lower() == "00":
@@ -51,6 +55,8 @@ def entry_status_label(entry: dict[str, Any] | None) -> str:
     match entry_status_kind(entry):
         case "absent":
             return "Absent / no data"
+        case "dormant":
+            return "Dormant (feature inactive)"
         case "transport_failure":
             return "Transport failure"
         case "decode_error":
@@ -65,6 +71,8 @@ def entry_display_value_text(entry: dict[str, Any]) -> str:
     status = entry_status_kind(entry)
     if status == "absent":
         return "absent"
+    if status == "dormant":
+        return "dormant"
     if status == "transport_failure":
         return "transport failure"
     if status == "decode_error":

--- a/src/helianthus_vrc_explorer/ui/viewer.py
+++ b/src/helianthus_vrc_explorer/ui/viewer.py
@@ -335,7 +335,7 @@ def _cell_text(entry: dict[str, Any] | None, *, selected: bool) -> Text:
 
     status_kind = entry_status_kind(entry)
     status_label = entry_status_label(entry)
-    val_txt = status_label.lower() if status_kind == "absent" else _format_value(value)
+    val_txt = status_label.lower() if status_kind in {"absent", "dormant"} else _format_value(value)
     raw_txt = raw_hex if isinstance(raw_hex, str) else ""
     raw_short = raw_txt[:16] + ("…" if len(raw_txt) > 16 else "")
 
@@ -343,7 +343,7 @@ def _cell_text(entry: dict[str, Any] | None, *, selected: bool) -> Text:
     err_short = err_txt.split(":", 1)[0] if err_txt else ""
 
     line2 = raw_short
-    if status_kind == "absent":
+    if status_kind in {"absent", "dormant"}:
         line2 = "valid no-data"
     elif err_short:
         line2 = f"{raw_short} !{err_short}"
@@ -351,6 +351,8 @@ def _cell_text(entry: dict[str, Any] | None, *, selected: bool) -> Text:
     style = "white"
     if status_kind == "absent":
         style = "yellow"
+    elif status_kind == "dormant":
+        style = "cyan"
     elif err_txt:
         style = "red"
 

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -97,6 +97,38 @@ def test_html_report_supports_b555_tab() -> None:
     assert '"hc":"0x00"' in html
 
 
+def test_html_report_includes_dormant_status_rendering_logic() -> None:
+    artifact = {
+        "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},
+        "groups": {
+            "0x00": {
+                "name": "Regulator Parameters",
+                "instances": {
+                    "0x00": {
+                        "registers": {
+                            "0x0006": {
+                                "raw_hex": None,
+                                "type": None,
+                                "value": None,
+                                "error": None,
+                                "flags_access": "dormant",
+                                "reply_hex": "",
+                                "read_opcode": "0x02",
+                            }
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    html = render_html_report(artifact, title="test")
+
+    assert "status-dormant" in html
+    assert 'if (access === "dormant") return "dormant";' in html
+    assert "Dormant (feature inactive)" in html
+
+
 def test_html_report_supports_b516_tab() -> None:
     artifact = {
         "meta": {"destination_address": "0x15", "scan_timestamp": "2026-02-11T00:00:00Z"},

--- a/tests/test_register_semantics.py
+++ b/tests/test_register_semantics.py
@@ -13,8 +13,7 @@ def test_entry_status_kind_distinguishes_absent_dormant_transport_and_decode() -
         entry_status_kind({"reply_hex": "00", "flags_access": "absent", "error": None}) == "absent"
     )
     assert (
-        entry_status_kind({"reply_hex": "", "flags_access": "dormant", "error": None})
-        == "dormant"
+        entry_status_kind({"reply_hex": "", "flags_access": "dormant", "error": None}) == "dormant"
     )
     assert entry_status_kind({"error": "timeout"}) == "transport_failure"
     assert (

--- a/tests/test_register_semantics.py
+++ b/tests/test_register_semantics.py
@@ -8,9 +8,13 @@ from helianthus_vrc_explorer.ui.register_semantics import (
 )
 
 
-def test_entry_status_kind_distinguishes_absent_transport_and_decode() -> None:
+def test_entry_status_kind_distinguishes_absent_dormant_transport_and_decode() -> None:
     assert (
         entry_status_kind({"reply_hex": "00", "flags_access": "absent", "error": None}) == "absent"
+    )
+    assert (
+        entry_status_kind({"reply_hex": "", "flags_access": "dormant", "error": None})
+        == "dormant"
     )
     assert entry_status_kind({"error": "timeout"}) == "transport_failure"
     assert (
@@ -29,10 +33,18 @@ def test_entry_display_value_text_uses_semantic_labels_for_absent_and_transport(
         entry_display_value_text({"error": "transport_error: ERR: arbitration lost"})
         == "transport failure"
     )
+    assert (
+        entry_display_value_text({"reply_hex": "", "flags_access": "dormant", "error": None})
+        == "dormant"
+    )
     assert entry_display_value_text({"value": 38.0, "raw_hex": "00001842", "error": None}) == "38"
     assert (
         entry_status_label({"reply_hex": "00", "flags_access": "absent", "error": None})
         == "Absent / no data"
+    )
+    assert (
+        entry_status_label({"reply_hex": "", "flags_access": "dormant", "error": None})
+        == "Dormant (feature inactive)"
     )
 
 

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -254,6 +254,24 @@ def test_read_register_i32_sentinel_adds_value_display_annotation() -> None:
     assert entry["value_display"] == "sentinel_invalid_i32 (0x7FFFFFFF)"
 
 
+def test_read_register_u32_max_does_not_add_i32_sentinel_annotation() -> None:
+    transport = _I32SentinelTransport()
+
+    entry = read_register(
+        transport,
+        0x15,
+        0x02,
+        group=0x00,
+        instance=0x00,
+        register=0x0048,
+        type_hint="U32",
+    )
+
+    assert entry["raw_hex"] == "ffffff7f"
+    assert entry["value"] == 0x7FFFFFFF
+    assert "value_display" not in entry
+
+
 def test_flags_interpretation_single_byte() -> None:
     assert _interpret_flags(0x00, response_len=1) == "absent"
 

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -153,6 +153,18 @@ class _StatusOnlyTransport(TransportInterface):
         return b"\x00"
 
 
+class _EmptyResponseTransport(TransportInterface):
+    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+        return b""
+
+
+class _I32SentinelTransport(TransportInterface):
+    def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+        group = payload[2]
+        rr = payload[4:6]
+        return bytes((0x01, group)) + rr + b"\xFF\xFF\xFF\x7F"
+
+
 class _UnparseableU24Transport(TransportInterface):
     def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
         group = payload[2]
@@ -180,6 +192,45 @@ def test_read_register_status_only_response_is_not_decode_error() -> None:
     assert entry["type"] is None
     assert entry["value"] is None
     assert entry["error"] is None
+
+
+def test_read_register_empty_response_is_dormant_not_decode_error() -> None:
+    transport = _EmptyResponseTransport()
+
+    entry = read_register(
+        transport,
+        0x15,
+        0x02,
+        group=0x00,
+        instance=0x00,
+        register=0x0000,
+    )
+
+    assert entry["reply_hex"] == ""
+    assert entry["flags"] is None
+    assert entry["flags_access"] == "dormant"
+    assert entry["raw_hex"] is None
+    assert entry["type"] is None
+    assert entry["value"] is None
+    assert entry["error"] is None
+
+
+def test_read_register_i32_sentinel_adds_value_display_annotation() -> None:
+    transport = _I32SentinelTransport()
+
+    entry = read_register(
+        transport,
+        0x15,
+        0x02,
+        group=0x00,
+        instance=0x00,
+        register=0x0048,
+        type_hint="I32",
+    )
+
+    assert entry["raw_hex"] == "ffffff7f"
+    assert entry["value"] == 0x7FFFFFFF
+    assert entry["value_display"] == "sentinel_invalid_i32 (0x7FFFFFFF)"
 
 
 def test_flags_interpretation_single_byte() -> None:

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -162,7 +162,7 @@ class _I32SentinelTransport(TransportInterface):
     def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
         group = payload[2]
         rr = payload[4:6]
-        return bytes((0x01, group)) + rr + b"\xFF\xFF\xFF\x7F"
+        return bytes((0x01, group)) + rr + b"\xff\xff\xff\x7f"
 
 
 class _UnparseableU24Transport(TransportInterface):

--- a/tests/test_scanner_register.py
+++ b/tests/test_scanner_register.py
@@ -203,7 +203,7 @@ def test_read_register_empty_response_is_dormant_not_decode_error() -> None:
         0x02,
         group=0x00,
         instance=0x00,
-        register=0x0000,
+        register=0x0016,
     )
 
     assert entry["reply_hex"] == ""
@@ -213,6 +213,27 @@ def test_read_register_empty_response_is_dormant_not_decode_error() -> None:
     assert entry["type"] is None
     assert entry["value"] is None
     assert entry["error"] is None
+
+
+def test_read_register_empty_response_without_dormant_identity_is_transport_no_response() -> None:
+    transport = _EmptyResponseTransport()
+
+    entry = read_register(
+        transport,
+        0x15,
+        0x02,
+        group=0x00,
+        instance=0x00,
+        register=0x0000,
+    )
+
+    assert entry["reply_hex"] is None
+    assert entry["flags"] is None
+    assert entry["flags_access"] is None
+    assert entry["raw_hex"] is None
+    assert entry["type"] is None
+    assert entry["value"] is None
+    assert entry["error"] == "transport_error: no_response"
 
 
 def test_read_register_i32_sentinel_adds_value_display_annotation() -> None:

--- a/tests/test_scanner_scan.py
+++ b/tests/test_scanner_scan.py
@@ -1751,6 +1751,29 @@ def test_probe_unknown_group_opcodes_ignores_absent_flags_access() -> None:
     assert probe_summary["candidates"]["0x02"]["responsive"] is False
 
 
+def test_probe_unknown_group_opcodes_ignores_empty_transport_no_response() -> None:
+    class _NoResponseProbeTransport(TransportInterface):
+        def send(self, dst: int, payload: bytes) -> bytes:  # noqa: ARG002
+            if payload == bytes((0x02, 0x00, 0x69, 0x00, 0x00, 0x00)):
+                return b""
+            if payload == bytes((0x06, 0x00, 0x69, 0x00, 0x00, 0x00)):
+                return b"\x01\x69\x00\x00\x01"
+            raise AssertionError(f"unexpected probe payload: {payload.hex()}")
+
+    opcodes, probe_summary = _probe_unknown_group_opcodes(
+        _NoResponseProbeTransport(),
+        dst=0x15,
+        group=0x69,
+        observer=None,
+    )
+
+    assert opcodes == (0x06,)
+    assert probe_summary["responsive_opcodes"] == ["0x06"]
+    assert probe_summary["candidates"]["0x02"]["error"] == "transport_error: no_response"
+    assert probe_summary["candidates"]["0x02"]["flags_access"] is None
+    assert probe_summary["candidates"]["0x02"]["responsive"] is False
+
+
 def test_scan_unknown_group_expands_to_instance_ff_after_readable_probe(tmp_path: Path) -> None:
     transport = RecordingTransport(
         DummyTransport(_write_fixture_unknown_group_69_with_ff(tmp_path))

--- a/tests/test_schema_myvaillant_map.py
+++ b/tests/test_schema_myvaillant_map.py
@@ -294,7 +294,13 @@ def test_namespace_owned_required_tuple_rows_are_resolvable() -> None:
     remote_presence = schema.lookup(group=0x08, instance=0x00, register=0x0001, opcode=0x06)
     remote_gg01_rr0012 = schema.lookup(group=0x01, instance=0x00, register=0x0012, opcode=0x06)
     remote_gg01_rr0015 = schema.lookup(group=0x01, instance=0x00, register=0x0015, opcode=0x06)
+    remote_gg00_rr0002 = schema.lookup(group=0x00, instance=0x00, register=0x0002, opcode=0x06)
+    remote_gg00_rr0003 = schema.lookup(group=0x00, instance=0x00, register=0x0003, opcode=0x06)
+    remote_gg00_rr0004 = schema.lookup(group=0x00, instance=0x00, register=0x0004, opcode=0x06)
+    local_gg00_rr0006 = schema.lookup(group=0x00, instance=0x00, register=0x0006, opcode=0x02)
+    local_gg00_rr0016 = schema.lookup(group=0x00, instance=0x00, register=0x0016, opcode=0x02)
     local_gg00_rr0048 = schema.lookup(group=0x00, instance=0x00, register=0x0048, opcode=0x02)
+    local_gg00_rr0074 = schema.lookup(group=0x00, instance=0x00, register=0x0074, opcode=0x02)
     local_gg00_rr00da = schema.lookup(group=0x00, instance=0x00, register=0x00DA, opcode=0x02)
     local_gg00_rr00db = schema.lookup(group=0x00, instance=0x00, register=0x00DB, opcode=0x02)
 
@@ -307,14 +313,32 @@ def test_namespace_owned_required_tuple_rows_are_resolvable() -> None:
     assert remote_gg01_rr0015 is not None
     assert remote_gg01_rr0015.leaf == "unknown_0015"
     assert remote_gg01_rr0015.type_hint == "UIN"
+    assert remote_gg00_rr0002 is not None
+    assert remote_gg00_rr0002.leaf == "device_class_address"
+    assert remote_gg00_rr0002.type_hint == "UCH"
+    assert remote_gg00_rr0003 is not None
+    assert remote_gg00_rr0003.leaf == "device_error_code"
+    assert remote_gg00_rr0003.type_hint == "UCH"
+    assert remote_gg00_rr0004 is not None
+    assert remote_gg00_rr0004.leaf == "device_firmware_version"
+    assert remote_gg00_rr0004.type_hint == "FW"
+    assert local_gg00_rr0006 is not None
+    assert local_gg00_rr0006.leaf == "manual_cooling_days"
+    assert local_gg00_rr0006.type_hint == "UCH"
+    assert local_gg00_rr0016 is not None
+    assert local_gg00_rr0016.leaf == "system_quick_mode_active"
+    assert local_gg00_rr0016.type_hint == "BOOL"
     assert local_gg00_rr0048 is not None
-    assert local_gg00_rr0048.leaf == "unknown_0048"
+    assert local_gg00_rr0048.leaf == "system_status_bitmask"
     assert local_gg00_rr0048.type_hint == "UIN"
+    assert local_gg00_rr0074 is not None
+    assert local_gg00_rr0074.leaf == "system_quick_mode_value"
+    assert local_gg00_rr0074.type_hint == "UCH"
     assert local_gg00_rr00da is not None
-    assert local_gg00_rr00da.leaf == "unknown_00da_date"
+    assert local_gg00_rr00da.leaf == "manual_cooling_date_start"
     assert local_gg00_rr00da.type_hint == "HDA:3"
     assert local_gg00_rr00db is not None
-    assert local_gg00_rr00db.leaf == "unknown_00db_date"
+    assert local_gg00_rr00db.leaf == "manual_cooling_date_end"
     assert local_gg00_rr00db.type_hint == "HDA:3"
 
 


### PR DESCRIPTION
- [x] Investigate CI failure in `test_namespace_owned_required_tuple_rows_are_resolvable`
- [x] Fix: add missing `*,*,0x0002..0x0004` wildcard fallback rows (`device_class_address`, `device_error_code`, `device_firmware_version`) to both `data/myvaillant_register_map.csv` and `src/helianthus_vrc_explorer/data/myvaillant_register_map.csv`
- [x] Verify both CSV files are in sync