### PR TITLE
audit: remediate VE1-VE33 findings (32/33, VE3 refuted, VE13 N/A)

### DIFF
--- a/src/helianthus_vrc_explorer/cli.py
+++ b/src/helianthus_vrc_explorer/cli.py
@@ -382,7 +382,7 @@ def _build_transport(
             EnhancedTcpConfig(
                 host=settings.host,
                 port=settings.port,
-                src=settings.src if settings.src is not None else 0x31,
+                src=settings.src if settings.src is not None else 0xF7,
                 trace_path=trace_file,
             )
         )

--- a/src/helianthus_vrc_explorer/protocol/b555.py
+++ b/src/helianthus_vrc_explorer/protocol/b555.py
@@ -130,12 +130,24 @@ def parse_b555_timer_read_response(payload: bytes) -> B555TimerRead:
     blob = bytes(payload)
     if len(blob) != 7:
         raise ValueError(f"B555 A5 response must be 7 bytes, got {len(blob)}")
+    sh, sm, eh, em = blob[1], blob[2], blob[3], blob[4]
+    # VE17-R2: Validate time components.
+    # Allow 0xFF sentinel ("no timer") and 24:00 ("end of day").
+    for label, h, m in (("start", sh, sm), ("end", eh, em)):
+        if h == 0xFF:
+            continue
+        if h > 24:
+            raise ValueError(f"Invalid {label} hour: {h}")
+        if h == 24 and m != 0:
+            raise ValueError(f"Invalid {label} time: 24:{m:02d} (only 24:00 is valid)")
+        if m != 0xFF and m > 59:
+            raise ValueError(f"Invalid {label} minute: {m}")
     return B555TimerRead(
         status=blob[0],
-        start_hour=blob[1],
-        start_minute=blob[2],
-        end_hour=blob[3],
-        end_minute=blob[4],
+        start_hour=sh,
+        start_minute=sm,
+        end_hour=eh,
+        end_minute=em,
         temperature_raw_u16=int.from_bytes(blob[5:7], byteorder="little", signed=False),
     )
 

--- a/src/helianthus_vrc_explorer/scanner/b509.py
+++ b/src/helianthus_vrc_explorer/scanner/b509.py
@@ -84,6 +84,10 @@ def parse_b509_range(spec: str) -> tuple[int, int]:
         raise ValueError(f"range end out of bounds: {end_s!r}")
     if start > end:
         start, end = end, start
+    # VE16-R2: Cap maximum range to prevent accidental full-address-space scans.
+    span = end - start + 1
+    if span > 4096:
+        raise ValueError(f"B509 range too large: {span} addresses (max 4096)")
     return start, end
 
 
@@ -182,7 +186,7 @@ def scan_b509(
 
                 registers[_hex_u16(register)] = B509RegisterEntry(
                     addr=_hex_u16(register),
-                    op="0x0d",
+                    op="0x09",
                     reply_hex=reply_hex,
                     raw_hex=raw_hex,
                     type=value_type,

--- a/src/helianthus_vrc_explorer/scanner/b555.py
+++ b/src/helianthus_vrc_explorer/scanner/b555.py
@@ -199,6 +199,9 @@ def scan_b555(
     }
     programs = artifact["programs"]
 
+    # VE25-R2: discovered_slot_reads intentionally accumulates across programs.
+    # Each program contributes its own timer reads; the running total feeds
+    # the progress bar so the observer sees monotonically increasing progress.
     discovered_slot_reads = 0
     base_reads = len(DEFAULT_B555_PROGRAMS) * 2
 

--- a/src/helianthus_vrc_explorer/scanner/plan.py
+++ b/src/helianthus_vrc_explorer/scanner/plan.py
@@ -55,6 +55,21 @@ def parse_int_set(spec: str, *, min_value: int, max_value: int) -> list[int]:
         token = part.strip()
         if not token:
             continue
+        # VE23-R3: Support ".." as the primary range separator (unambiguous for hex).
+        # Fall back to "-" only when ".." is absent.
+        if ".." in token:
+            start_s, end_s = token.split("..", 1)
+            start = parse_int_token(start_s)
+            end = parse_int_token(end_s)
+            if start > end:
+                start, end = end, start
+            for value in range(start, end + 1):
+                if value < min_value or value > max_value:
+                    raise ValueError(
+                        f"Value out of range: {value} (allowed {min_value}-{max_value})"
+                    )
+                result.add(value)
+            continue
         if "-" in token:
             start_s, end_s = token.split("-", 1)
             start = parse_int_token(start_s)

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -749,18 +749,13 @@ def probe_instance_availability(
             and entry_reply_kind.endswith("_valid")
             and entry["value"] is True
         )
-        # VE13: Device explicitly reports as disconnected — skip further probes.
-        if (
-            not present
-            and entry["error"] is None
-            and entry.get("flags_access") != "absent"
-            and entry["value"] is False
-        ):
-            return InstanceAvailabilityProbe(
-                present=False,
-                contract=contract,
-                evidence=header_evidence,
-            )
+        # VE13 analysis: The audit recommended skipping RR=0x0002-0x0004
+        # when BOOL at RR=0x0001 returns False.  However, the secondary
+        # header evidence fallback is intentional: some remote devices
+        # report device_connected=False but still have valid header registers.
+        # Existing tests (test_is_instance_present_group_09_remote_accepts_
+        # secondary_header_evidence) validate this fallback behavior.
+        # VE13 finding is NOT applied — behavior is correct as-is.
         if not present:
             for register_id, type_hint in _REMOTE_HEADER_PROBE_REGISTERS[1:]:
                 header_entry = read_register(

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 _PRINTABLE_LATIN1: Final[set[int]] = set(range(0x20, 0x7F)) | set(range(0xA0, 0x100))
 _I32_INVALID_SENTINEL: Final[int] = 0x7FFFFFFF
 _I32_INVALID_SENTINEL_RAW_HEX: Final[str] = "ffffff7f"
+# VE24-R3: U32 sentinel — same raw pattern, different semantic type.
+_U32_INVALID_SENTINEL: Final[int] = 0xFFFFFFFF
+_U32_INVALID_SENTINEL_RAW_HEX: Final[str] = "ffffffff"
 _REMOTE_HEADER_PROBE_REGISTERS: Final[tuple[tuple[int, str], ...]] = (
     (0x0001, "BOOL"),
     (0x0002, "UCH"),
@@ -424,14 +427,22 @@ def _parse_inferred_value(value_bytes: bytes) -> tuple[str | None, object | None
 def _sentinel_value_display(
     *, value: object | None, raw_hex: str | None, value_type: str | None
 ) -> str | None:
-    if value_type != "I32":
-        return None
-    if raw_hex != _I32_INVALID_SENTINEL_RAW_HEX:
-        return None
     if isinstance(value, bool):
         return None
-    if isinstance(value, int) and value == _I32_INVALID_SENTINEL:
-        return "sentinel_invalid_i32 (0x7FFFFFFF)"
+    # I32 sentinel: 0x7FFFFFFF
+    if value_type == "I32":
+        if raw_hex != _I32_INVALID_SENTINEL_RAW_HEX:
+            return None
+        if isinstance(value, int) and value == _I32_INVALID_SENTINEL:
+            return "sentinel_invalid_i32 (0x7FFFFFFF)"
+        return None
+    # VE24-R3: U32 sentinel: 0xFFFFFFFF
+    if value_type == "U32":
+        if raw_hex != _U32_INVALID_SENTINEL_RAW_HEX:
+            return None
+        if isinstance(value, int) and value == _U32_INVALID_SENTINEL:
+            return "sentinel_invalid_u32 (0xFFFFFFFF)"
+        return None
     return None
 
 
@@ -510,7 +521,8 @@ def read_register(
             "raw_hex": None,
             "type": None,
             "value": None,
-            "error": f"transport_error: {exc}",
+            # VE18-R2: Sanitise — strip endpoint details from error text.
+            "error": f"transport_error: {type(exc).__name__}",
         }
 
     if len(response) == 0:
@@ -737,6 +749,18 @@ def probe_instance_availability(
             and entry_reply_kind.endswith("_valid")
             and entry["value"] is True
         )
+        # VE13: Device explicitly reports as disconnected — skip further probes.
+        if (
+            not present
+            and entry["error"] is None
+            and entry.get("flags_access") != "absent"
+            and entry["value"] is False
+        ):
+            return InstanceAvailabilityProbe(
+                present=False,
+                contract=contract,
+                evidence=header_evidence,
+            )
         if not present:
             for register_id, type_hint in _REMOTE_HEADER_PROBE_REGISTERS[1:]:
                 header_entry = read_register(

--- a/src/helianthus_vrc_explorer/scanner/register.py
+++ b/src/helianthus_vrc_explorer/scanner/register.py
@@ -62,9 +62,9 @@ class RegisterEntry(TypedDict):
     # Optional constraint dictionary annotation sourced from opcode 0x01 (01 GG RR).
     constraint_tt: NotRequired[str]
     constraint_type: NotRequired[str]
-    constraint_min: NotRequired[int | float | str]
-    constraint_max: NotRequired[int | float | str]
-    constraint_step: NotRequired[int | float]
+    constraint_min: NotRequired[int | float | str | None]
+    constraint_max: NotRequired[int | float | str | None]
+    constraint_step: NotRequired[int | float | None]
     constraint_source: NotRequired[str]
     constraint_scope: NotRequired[str]
     constraint_provenance: NotRequired[str]

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -682,9 +682,9 @@ class ConstraintEntry:
 
     tt: int
     kind: str
-    min_value: int | float | str
-    max_value: int | float | str
-    step_value: int | float
+    min_value: int | float | str | None
+    max_value: int | float | str | None
+    step_value: int | float | None
     raw_hex: str
     source: str = "opcode_0x01"
     scope: str = LIVE_PROBE_CONSTRAINT_SCOPE
@@ -701,8 +701,10 @@ def _decode_constraint_date(value: bytes) -> str:
         import datetime as _dt_mod
 
         _dt_mod.date(year, month, day)
-    except ValueError:
-        raise ValueError(f"Invalid date triplet: {value.hex()} ({year:04d}-{month:02d}-{day:02d})")
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid date triplet: {value.hex()} ({year:04d}-{month:02d}-{day:02d})"
+        ) from exc
     return f"{year:04d}-{month:02d}-{day:02d}"
 
 
@@ -1412,12 +1414,14 @@ def scan_b524(
                     if constraints:
                         constraint_map[group.group] = constraints
             except KeyboardInterrupt:
-                # VE32: Preserve partial constraint results on interrupt.
+                # VE32: Preserve partial constraint results, then re-raise
+                # so the outer handler sets meta.incomplete=true.
                 if observer is not None:
                     observer.log(
                         "Constraint probe interrupted — partial results preserved.",
                         level="warn",
                     )
+                raise
             if observer is not None:
                 observer.phase_finish("constraint_probe")
                 if not constraint_map:

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -697,8 +697,12 @@ def _decode_constraint_date(value: bytes) -> str:
     day = value[0]
     month = value[1]
     year = 2000 + value[2]
-    if not (1 <= month <= 12 and 1 <= day <= 31):
-        raise ValueError(f"Invalid date triplet: {value.hex()}")
+    try:
+        import datetime as _dt_mod
+
+        _dt_mod.date(year, month, day)
+    except ValueError:
+        raise ValueError(f"Invalid date triplet: {value.hex()} ({year:04d}-{month:02d}-{day:02d})")
     return f"{year:04d}-{month:02d}-{day:02d}"
 
 
@@ -727,7 +731,7 @@ def _parse_constraint_entry(
             kind="u8_range",
             min_value=min_u8,
             max_value=max_u8,
-            step_value=step_u8,
+            step_value=step_u8 if step_u8 != 0 else None,
             raw_hex=response.hex(),
         )
     if tt == 0x09:
@@ -741,7 +745,7 @@ def _parse_constraint_entry(
             kind="u16_range",
             min_value=min_u16,
             max_value=max_u16,
-            step_value=step_u16,
+            step_value=step_u16 if step_u16 != 0 else None,
             raw_hex=response.hex(),
         )
     if tt == 0x0F:
@@ -753,9 +757,9 @@ def _parse_constraint_entry(
         return ConstraintEntry(
             tt=tt,
             kind="f32_range",
-            min_value=min_f32,
-            max_value=max_f32,
-            step_value=step_f32,
+            min_value=min_f32 if math.isfinite(min_f32) else None,
+            max_value=max_f32 if math.isfinite(max_f32) else None,
+            step_value=step_f32 if math.isfinite(step_f32) else None,
             raw_hex=response.hex(),
         )
     if tt == 0x0C:

--- a/src/helianthus_vrc_explorer/scanner/scan.py
+++ b/src/helianthus_vrc_explorer/scanner/scan.py
@@ -1398,18 +1398,26 @@ def scan_b524(
                 )
                 observer.phase_start("constraint_probe", total=probe_total or 1)
 
-            for group in classified:
-                group_meta = metadata_map[group.group]
-                constraints = _probe_group_constraints(
-                    transport,
-                    dst=dst,
-                    group=group.group,
-                    rr_max=group_meta.rr_max,
-                    observer=observer,
-                    progress_phase="constraint_probe",
-                )
-                if constraints:
-                    constraint_map[group.group] = constraints
+            try:
+                for group in classified:
+                    group_meta = metadata_map[group.group]
+                    constraints = _probe_group_constraints(
+                        transport,
+                        dst=dst,
+                        group=group.group,
+                        rr_max=group_meta.rr_max,
+                        observer=observer,
+                        progress_phase="constraint_probe",
+                    )
+                    if constraints:
+                        constraint_map[group.group] = constraints
+            except KeyboardInterrupt:
+                # VE32: Preserve partial constraint results on interrupt.
+                if observer is not None:
+                    observer.log(
+                        "Constraint probe interrupted — partial results preserved.",
+                        level="warn",
+                    )
             if observer is not None:
                 observer.phase_finish("constraint_probe")
                 if not constraint_map:

--- a/src/helianthus_vrc_explorer/transport/base.py
+++ b/src/helianthus_vrc_explorer/transport/base.py
@@ -27,6 +27,21 @@ class TransportCommandNotEnabled(TransportError):
     """
 
 
+class TransportHostError(TransportError):
+    """Raised when the adapter reports a host-side error (invalid command/parameter).
+
+    Host errors are non-retryable — the request was malformed from the adapter's
+    perspective.  Retrying the identical request would produce the same error.
+    """
+
+
+class TransportDisconnected(TransportError):
+    """Raised when the TCP connection is cleanly closed by the peer (EOF).
+
+    Distinguished from TransportError to allow targeted reconnect handling.
+    """
+
+
 class TransportInterface(ABC):
     """Transport interface for sending B524 payloads and receiving raw responses."""
 

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -618,6 +618,7 @@ class EnhancedTcpTransport(TransportInterface):
     def _parse_enh_byte(self, value: int) -> tuple[str, int, int] | None:
         if self._enh_pending_first is None:
             if value & 0x80 == 0:
+                self._malformed_count = 0  # Valid data byte resets counter
                 return ("data", value, 0)
             if value & 0xC0 == 0x80:
                 self._malformed_count += 1

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -981,9 +981,10 @@ class EnhancedTcpTransport(TransportInterface):
                 # Local retry exhausted — raise non-retryable TransportNack
                 # so _send_with_policy does NOT re-arbitrate again.
                 raise TransportNack("nack received (local retry exhausted)")
-            if ack == _EBUS_SYN:
-                raise TransportTimeout("syn received while waiting for command ack")
             if ack != _EBUS_ACK:
+                # In ENH protocol, 0xAA (SYN) from _recv_bus_symbol is a data
+                # byte, not a bus-idle signal.  Treat any non-ACK/non-NACK as
+                # an unexpected symbol error (not a timeout).
                 raise TransportError(f"unexpected symbol 0x{ack:02X} while waiting for command ack")
 
             if _is_initiator_capable_address(dst):
@@ -995,20 +996,22 @@ class EnhancedTcpTransport(TransportInterface):
             response_deadline = time.monotonic() + self._config.timeout_s
 
             for response_attempt in range(2):
+                # In the ENH protocol, response bytes arrive via _ENH_RES_RECEIVED
+                # frames.  The adapter firmware handles wire-level SYN detection and
+                # reports bus loss via _ENH_RES_FAILED / _ENH_RES_ERROR_*, NOT by
+                # sending a RECEIVED frame with data=0xAA.  Therefore 0xAA from
+                # _recv_bus_symbol() is a legitimate data byte (the adapter decoded
+                # wire-escaped [0xA9, 0x01] back to logical 0xAA).  SYN guards are
+                # not needed here — _recv_bus_symbol() already raises appropriate
+                # exceptions for real bus errors and timeouts.
                 length = self._recv_bus_symbol(deadline=response_deadline)
-                if length == _EBUS_SYN:
-                    raise TransportTimeout("syn received while waiting for response length")
 
                 response = bytearray()
                 for _ in range(length):
                     value = self._recv_bus_symbol(deadline=response_deadline)
-                    if value == _EBUS_SYN:
-                        raise TransportTimeout("syn received while waiting for response data")
                     response.append(value)
 
                 crc_value = self._recv_bus_symbol(deadline=response_deadline)
-                if crc_value == _EBUS_SYN:
-                    raise TransportTimeout("syn received while waiting for response crc")
 
                 segment = bytes((length,)) + bytes(response)
                 if _crc(segment) != crc_value:

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -477,6 +477,18 @@ class EnhancedTcpTransport(TransportInterface):
         self._messages.clear()
         self._enh_pending_first = None
         self._malformed_count = 0
+        # VE12/VE19: Drain stale bytes from kernel TCP buffer.
+        session = self._session
+        if session is not None:
+            with contextlib.suppress(OSError):
+                session.sock.setblocking(False)
+                try:
+                    while session.sock.recv(4096):
+                        pass
+                except BlockingIOError:
+                    pass
+                finally:
+                    session.sock.settimeout(self._config.timeout_s)
 
     def close(self) -> None:
         with self._lock:
@@ -701,8 +713,9 @@ class EnhancedTcpTransport(TransportInterface):
         self._trace("START_RESP deadline expired")
         raise _EnhancedCollision("Arbitration deadline expired (bus data flooding)")
 
-    def _recv_bus_symbol(self) -> int:
-        deadline = time.monotonic() + self._config.timeout_s
+    def _recv_bus_symbol(self, *, deadline: float | None = None) -> int:
+        if deadline is None:
+            deadline = time.monotonic() + self._config.timeout_s
         while time.monotonic() < deadline:
             kind, command, data = self._read_message()
             if kind == "data":
@@ -963,19 +976,22 @@ class EnhancedTcpTransport(TransportInterface):
                 self._trace(f"#{seq} RECV_PROTO initiator_initiator=no_response")
                 return b""
 
+            # VE26-R2: Cumulative deadline for the entire response read.
+            response_deadline = time.monotonic() + self._config.timeout_s
+
             for response_attempt in range(2):
-                length = self._recv_bus_symbol()
+                length = self._recv_bus_symbol(deadline=response_deadline)
                 if length == _EBUS_SYN:
                     raise TransportTimeout("syn received while waiting for response length")
 
                 response = bytearray()
                 for _ in range(length):
-                    value = self._recv_bus_symbol()
+                    value = self._recv_bus_symbol(deadline=response_deadline)
                     if value == _EBUS_SYN:
                         raise TransportTimeout("syn received while waiting for response data")
                     response.append(value)
 
-                crc_value = self._recv_bus_symbol()
+                crc_value = self._recv_bus_symbol(deadline=response_deadline)
                 if crc_value == _EBUS_SYN:
                     raise TransportTimeout("syn received while waiting for response crc")
 

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -671,6 +671,7 @@ class EnhancedTcpTransport(TransportInterface):
                 self._trace(f"INIT_RESP host_error=0x{data:02X}")
                 raise TransportHostError(f"ENH init host error 0x{data:02X}")
         self._trace("INIT_RESP deadline expired (bus data flooding)")
+        raise TransportTimeout("ENH init deadline expired (bus data flooding)")
 
     def _start_arbitration(self, initiator: int) -> None:
         self._trace(f"START initiator=0x{initiator:02X}")

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -627,9 +627,7 @@ class EnhancedTcpTransport(TransportInterface):
                 if cnt >= 3:
                     self._malformed_count = 0
                     self.close()
-                    raise TransportError(
-                        f"Malformed ENH start 0x{value:02X} (3 consecutive)"
-                    )
+                    raise TransportError(f"Malformed ENH start 0x{value:02X} (3 consecutive)")
                 return None
             self._enh_pending_first = value
             return None
@@ -642,9 +640,7 @@ class EnhancedTcpTransport(TransportInterface):
             if cnt >= 3:
                 self._malformed_count = 0
                 self.close()
-                raise TransportError(
-                    f"Malformed ENH end 0x{value:02X} (3 consecutive)"
-                )
+                raise TransportError(f"Malformed ENH end 0x{value:02X} (3 consecutive)")
             return None
 
         first = self._enh_pending_first
@@ -889,9 +885,7 @@ class EnhancedTcpTransport(TransportInterface):
                 except (TransportError, TransportTimeout, OSError) as reconn_exc:
                     self._trace(f"#{seq} RECONNECT failed: {reconn_exc}")
                     if reconnect_retries >= self._config.reconnect_max_retries:
-                        raise TransportError(
-                            f"{exc} (reconnect failed: {reconn_exc})"
-                        ) from exc
+                        raise TransportError(f"{exc} (reconnect failed: {reconn_exc})") from exc
                     time.sleep(self._config.reconnect_delay_s)
                     continue
                 continue

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -483,8 +483,10 @@ class EnhancedTcpTransport(TransportInterface):
             with contextlib.suppress(OSError):
                 session.sock.setblocking(False)
                 try:
-                    while session.sock.recv(4096):
-                        pass
+                    # Cap at 64 KB to avoid spinning on a flooded bus.
+                    for _ in range(16):
+                        if not session.sock.recv(4096):
+                            break
                 except BlockingIOError:
                     pass
                 finally:
@@ -641,6 +643,12 @@ class EnhancedTcpTransport(TransportInterface):
                 self._malformed_count = 0
                 self.close()
                 raise TransportError(f"Malformed ENH end 0x{value:02X} (3 consecutive)")
+            # Resync: re-interpret the current byte instead of discarding.
+            if value & 0x80 == 0:
+                self._malformed_count = 0
+                return ("data", value, 0)
+            # Could be a new ENH frame start (0xC0..0xFF range).
+            self._enh_pending_first = value
             return None
 
         first = self._enh_pending_first
@@ -956,7 +964,9 @@ class EnhancedTcpTransport(TransportInterface):
 
         # VE4: Local NACK retry without re-arbitration (per eBUS spec 7.4).
         # After NACK the bus is still owned — retry the telegram directly.
-        for nack_attempt in range(2):  # original + 1 retry
+        # Honors nack_max_retries config (attempts = 1 + nack_max_retries).
+        max_nack_attempts = 1 + self._config.nack_max_retries
+        for nack_attempt in range(max_nack_attempts):
             if nack_attempt > 0:
                 self._trace(f"#{seq} LOCAL_NACK_RETRY attempt={nack_attempt}")
 
@@ -970,7 +980,7 @@ class EnhancedTcpTransport(TransportInterface):
 
             ack = self._recv_bus_symbol()
             if ack == _EBUS_NACK:
-                if nack_attempt == 0:
+                if nack_attempt < max_nack_attempts - 1:
                     continue  # retry without re-arbitration
                 # Local retry exhausted — raise non-retryable TransportNack
                 # so _send_with_policy does NOT re-arbitrate again.

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import random
 import socket
+import threading
 import time
 from collections import deque
 from collections.abc import Callable, Iterator
@@ -437,6 +438,7 @@ class EnhancedTcpTransport(TransportInterface):
         self._session: _EnhancedTcpSession | None = None
         self._messages = deque[tuple[str, int, int]]()
         self._enh_pending_first: int | None = None
+        self._lock = threading.RLock()
 
     def _trace(self, message: str) -> None:
         session = self._session
@@ -458,9 +460,10 @@ class EnhancedTcpTransport(TransportInterface):
         self._enh_pending_first = None
 
     def close(self) -> None:
-        session = self._session
-        self._session = None
-        self._reset_parser()
+        with self._lock:
+            session = self._session
+            self._session = None
+            self._reset_parser()
         if session is None:
             return
         if session.trace_handle is not None:
@@ -471,22 +474,21 @@ class EnhancedTcpTransport(TransportInterface):
 
     @contextlib.contextmanager
     def session(self) -> Iterator[EnhancedTcpTransport]:
-        self._session_depth += 1
-        if self._session_depth == 1:
-            try:
-                self._open_session()
-            except Exception:
-                self._session_depth -= 1
-                if self._session_depth < 0:
-                    self._session_depth = 0
-                raise
+        with self._lock:
+            self._session_depth += 1
+            if self._session_depth == 1:
+                try:
+                    self._open_session()
+                except Exception:
+                    self._session_depth = max(0, self._session_depth - 1)
+                    raise
         try:
             yield self
         finally:
-            self._session_depth -= 1
-            if self._session_depth <= 0:
-                self._session_depth = 0
-                self.close()
+            with self._lock:
+                self._session_depth = max(0, self._session_depth - 1)
+                if self._session_depth == 0:
+                    self.close()
 
     def _open_session(self) -> None:
         try:
@@ -728,20 +730,21 @@ class EnhancedTcpTransport(TransportInterface):
         if len(payload) > 0xFF:
             raise ValueError(f"payload too large for eBUS telegram: {len(payload)} bytes")
 
-        self._trace_seq += 1
-        seq = self._trace_seq
-        payload_bytes = bytes(payload)
-        return self._send_with_policy(
-            seq,
-            lambda: self._send_proto_once(
+        with self._lock:
+            self._trace_seq += 1
+            seq = self._trace_seq
+            payload_bytes = bytes(payload)
+            return self._send_with_policy(
                 seq,
-                dst=dst,
-                primary=primary,
-                secondary=secondary,
-                payload=payload_bytes,
-                expect_response=expect_response,
-            ),
-        )
+                lambda: self._send_proto_once(
+                    seq,
+                    dst=dst,
+                    primary=primary,
+                    secondary=secondary,
+                    payload=payload_bytes,
+                    expect_response=expect_response,
+                ),
+            )
 
     def _reconnect(self, seq: int, attempt: int) -> None:
         """Close the current session and re-establish a fresh TCP + INIT handshake."""

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import math
 import random
 import socket
 import threading
@@ -428,6 +429,11 @@ class EnhancedTcpTransport(TransportInterface):
 
     def __init__(self, config: EnhancedTcpConfig) -> None:
         _validate_u8("src", config.src)
+        if config.src in (0x00, _EBUS_ESCAPE, _EBUS_SYN, 0xFF):
+            raise ValueError(
+                f"src 0x{config.src:02X} is a reserved address "
+                f"(0x00, 0xA9/ESCAPE, 0xAA/SYN, 0xFF are not valid initiator addresses)"
+            )
         if config.timeout_max_retries < 0:
             raise ValueError("timeout_max_retries must be >= 0")
         if config.collision_max_retries < 0:
@@ -438,6 +444,10 @@ class EnhancedTcpTransport(TransportInterface):
             raise ValueError("collision backoff must be >= 0 ms")
         if config.collision_backoff_max_ms < config.collision_backoff_min_ms:
             raise ValueError("collision_backoff_max_ms must be >= collision_backoff_min_ms")
+        if config.timeout_s <= 0 or not math.isfinite(config.timeout_s):
+            raise ValueError(f"timeout_s must be positive and finite, got {config.timeout_s}")
+        if not (1 <= config.port <= 65535):
+            raise ValueError(f"port must be in range 1..65535, got {config.port}")
 
         self._config = config
         self._trace_seq = 0
@@ -658,6 +668,11 @@ class EnhancedTcpTransport(TransportInterface):
             kind, command, data = self._read_message()
             if kind != "frame":
                 continue
+            if command == _ENH_RES_RECEIVED:
+                # VE11: Bus traffic extends deadline — received frames are
+                # normal activity and should not consume arbitration budget.
+                deadline = time.monotonic() + self._config.timeout_s
+                continue
             if command == _ENH_RES_STARTED and data == initiator:
                 self._trace(f"START_RESP started initiator=0x{data:02X}")
                 self._reset_parser()
@@ -748,6 +763,11 @@ class EnhancedTcpTransport(TransportInterface):
         expect_response: bool = True,
     ) -> bytes:
         _validate_u8("dst", dst)
+        if dst in (0x00, _EBUS_ESCAPE, _EBUS_SYN):
+            raise ValueError(
+                f"dst 0x{dst:02X} is a reserved address "
+                f"(0x00, 0xA9/ESCAPE, 0xAA/SYN are not valid destination addresses)"
+            )
         _validate_u8("primary", primary)
         _validate_u8("secondary", secondary)
         if not isinstance(payload, (bytes, bytearray, memoryview)):
@@ -811,7 +831,14 @@ class EnhancedTcpTransport(TransportInterface):
                             ) from exc
                         time.sleep(self._config.reconnect_delay_s)
                         continue
-                    timeout_retries = 0
+                    # VE23: Do NOT reset timeout_retries — counter must be
+                    # cumulative across the entire _send_with_policy invocation
+                    # to prevent unbounded retry loops.
+                    # VE33: Reset collision/nack counters — reconnect establishes
+                    # a fresh bus context where old collision/nack state is
+                    # meaningless.
+                    collision_retries = 0
+                    nack_retries = 0
                     continue
                 # First timeout: reset parser and retry on the same session.
                 self._reset_parser()
@@ -907,58 +934,68 @@ class EnhancedTcpTransport(TransportInterface):
             f"primary=0x{primary:02X} secondary=0x{secondary:02X} payload={_short_hex(payload)}"
         )
 
-        for symbol in telegram[1:]:
-            self._send_symbol_with_echo(symbol)
+        # VE4: Local NACK retry without re-arbitration (per eBUS spec 7.4).
+        # After NACK the bus is still owned — retry the telegram directly.
+        for nack_attempt in range(2):  # original + 1 retry
+            if nack_attempt > 0:
+                self._trace(f"#{seq} LOCAL_NACK_RETRY attempt={nack_attempt}")
 
-        if dst == _ADDRESS_BROADCAST or not expect_response:
-            self._send_end_of_message()
-            self._trace(f"#{seq} RECV_PROTO broadcast_or_no_response")
-            return b""
+            for symbol in telegram[1:]:
+                self._send_symbol_with_echo(symbol)
 
-        ack = self._recv_bus_symbol()
-        if ack == _EBUS_NACK:
-            raise _EnhancedNack("nack received while waiting for command ack")
-        if ack == _EBUS_SYN:
-            raise TransportTimeout("syn received while waiting for command ack")
-        if ack != _EBUS_ACK:
-            raise TransportError(f"unexpected symbol 0x{ack:02X} while waiting for command ack")
-
-        if _is_initiator_capable_address(dst):
-            self._send_end_of_message()
-            self._trace(f"#{seq} RECV_PROTO initiator_initiator=no_response")
-            return b""
-
-        for response_attempt in range(2):
-            length = self._recv_bus_symbol()
-            if length == _EBUS_SYN:
-                raise TransportTimeout("syn received while waiting for response length")
-
-            response = bytearray()
-            for _ in range(length):
-                value = self._recv_bus_symbol()
-                if value == _EBUS_SYN:
-                    raise TransportTimeout("syn received while waiting for response data")
-                response.append(value)
-
-            crc_value = self._recv_bus_symbol()
-            if crc_value == _EBUS_SYN:
-                raise TransportTimeout("syn received while waiting for response crc")
-
-            segment = bytes((length,)) + bytes(response)
-            if _crc(segment) != crc_value:
-                self._send_symbol_with_echo(_EBUS_NACK)
-                if response_attempt == 0:
-                    continue
+            if dst == _ADDRESS_BROADCAST or not expect_response:
                 self._send_end_of_message()
-                raise _EnhancedCrcMismatch("response crc mismatch")
+                self._trace(f"#{seq} RECV_PROTO broadcast_or_no_response")
+                return b""
 
-            self._send_symbol_with_echo(_EBUS_ACK)
-            self._send_end_of_message()
-            parsed = bytes(response)
-            self._trace(f"#{seq} PARSED_PROTO len={len(parsed)} hex={_short_hex(parsed)}")
-            return parsed
+            ack = self._recv_bus_symbol()
+            if ack == _EBUS_NACK:
+                if nack_attempt == 0:
+                    continue  # retry without re-arbitration
+                raise _EnhancedNack("nack received (local retry exhausted)")
+            if ack == _EBUS_SYN:
+                raise TransportTimeout("syn received while waiting for command ack")
+            if ack != _EBUS_ACK:
+                raise TransportError(f"unexpected symbol 0x{ack:02X} while waiting for command ack")
 
-        raise TransportTimeout("unreachable enhanced response loop")
+            if _is_initiator_capable_address(dst):
+                self._send_end_of_message()
+                self._trace(f"#{seq} RECV_PROTO initiator_initiator=no_response")
+                return b""
+
+            for response_attempt in range(2):
+                length = self._recv_bus_symbol()
+                if length == _EBUS_SYN:
+                    raise TransportTimeout("syn received while waiting for response length")
+
+                response = bytearray()
+                for _ in range(length):
+                    value = self._recv_bus_symbol()
+                    if value == _EBUS_SYN:
+                        raise TransportTimeout("syn received while waiting for response data")
+                    response.append(value)
+
+                crc_value = self._recv_bus_symbol()
+                if crc_value == _EBUS_SYN:
+                    raise TransportTimeout("syn received while waiting for response crc")
+
+                segment = bytes((length,)) + bytes(response)
+                if _crc(segment) != crc_value:
+                    self._send_symbol_with_echo(_EBUS_NACK)
+                    if response_attempt == 0:
+                        continue
+                    self._send_end_of_message()
+                    raise _EnhancedCrcMismatch("response crc mismatch")
+
+                self._send_symbol_with_echo(_EBUS_ACK)
+                self._send_end_of_message()
+                parsed = bytes(response)
+                self._trace(f"#{seq} PARSED_PROTO len={len(parsed)} hex={_short_hex(parsed)}")
+                return parsed
+
+            raise TransportTimeout("unreachable enhanced response loop")
+
+        raise TransportTimeout("unreachable enhanced nack retry loop")
 
     def command_lines(self, command: str, *, read_all: bool = False) -> list[str]:
         _ = read_all

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -376,6 +376,19 @@ def _crc_update(crc: int, value: int) -> int:
 
 
 def _crc(data: bytes) -> int:
+    """Compute eBUS CRC-8 over logical frame bytes.
+
+    Per eBUS specification, the CRC is computed over the wire-expanded form
+    of the frame.  Logical bytes 0xA9 (ESCAPE) and 0xAA (SYN) are expanded
+    to their two-byte wire sequences [0xA9, 0x00] and [0xA9, 0x01] before
+    feeding into the CRC polynomial.  This function accepts logical bytes
+    and performs the expansion internally -- callers should NOT pre-expand.
+
+    The enhanced adapter firmware handles wire escape encoding/decoding
+    transparently: ENH SEND carries logical bytes; ENH RECEIVED returns
+    logical bytes.  CRC computation is the only place where escape expansion
+    matters to the client.
+    """
     value = 0
     for item in data:
         if item == _EBUS_ESCAPE:
@@ -672,6 +685,17 @@ class EnhancedTcpTransport(TransportInterface):
         raise TransportTimeout("Bus symbol read deadline expired")
 
     def _send_symbol_with_echo(self, symbol: int) -> None:
+        """Send a logical eBUS byte via ENH SEND and verify the echo.
+
+        The enhanced adapter firmware handles wire escape encoding
+        (0xA9->[0xA9,0x00], 0xAA->[0xA9,0x01]) transparently.  The ENH
+        protocol operates at the logical byte level -- no client-side
+        escape encoding is needed or desired.
+
+        Audit VE1/VE20: Verified correct -- adapter firmware handles wire
+        escape encoding.  Client-side escaping would cause double-encoding
+        corruption on the physical bus.
+        """
         self._send_enh_frame(_ENH_REQ_SEND, symbol)
         echo = self._recv_bus_symbol()
         if echo == _EBUS_SYN and symbol != _EBUS_SYN:

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -621,11 +621,14 @@ class EnhancedTcpTransport(TransportInterface):
                 return ("data", value, 0)
             if value & 0xC0 == 0x80:
                 self._malformed_count += 1
-                self._trace(f"Malformed ENH byte pair start 0x{value:02X} (count={self._malformed_count})")
-                if self._malformed_count >= 3:
+                cnt = self._malformed_count
+                self._trace(f"Malformed ENH start 0x{value:02X} (n={cnt})")
+                if cnt >= 3:
                     self._malformed_count = 0
                     self.close()
-                    raise TransportError(f"Malformed ENH byte pair start 0x{value:02X} (3 consecutive)")
+                    raise TransportError(
+                        f"Malformed ENH start 0x{value:02X} (3 consecutive)"
+                    )
                 return None
             self._enh_pending_first = value
             return None
@@ -633,11 +636,14 @@ class EnhancedTcpTransport(TransportInterface):
         if value & 0xC0 != 0x80:
             self._enh_pending_first = None
             self._malformed_count += 1
-            self._trace(f"Malformed ENH byte pair end 0x{value:02X} (count={self._malformed_count})")
-            if self._malformed_count >= 3:
+            cnt = self._malformed_count
+            self._trace(f"Malformed ENH end 0x{value:02X} (n={cnt})")
+            if cnt >= 3:
                 self._malformed_count = 0
                 self.close()
-                raise TransportError(f"Malformed ENH byte pair end 0x{value:02X} (3 consecutive)")
+                raise TransportError(
+                    f"Malformed ENH end 0x{value:02X} (3 consecutive)"
+                )
             return None
 
         first = self._enh_pending_first
@@ -676,14 +682,19 @@ class EnhancedTcpTransport(TransportInterface):
     def _start_arbitration(self, initiator: int) -> None:
         self._trace(f"START initiator=0x{initiator:02X}")
         self._send_enh_frame(_ENH_REQ_START, initiator)
-        deadline = time.monotonic() + self._config.timeout_s
-        while time.monotonic() < deadline:
+        now = time.monotonic()
+        deadline = now + self._config.timeout_s
+        # VE11: Absolute cap prevents infinite wait on a flooded bus.
+        # Activity deadline resets on each RECEIVED frame, but the
+        # absolute cap (10× timeout) is never extended.
+        absolute_cap = now + self._config.timeout_s * 10
+        while time.monotonic() < min(deadline, absolute_cap):
             kind, command, data = self._read_message()
             if kind != "frame":
                 continue
             if command == _ENH_RES_RECEIVED:
-                # VE11: Bus traffic extends deadline — received frames are
-                # normal activity and should not consume arbitration budget.
+                # VE11: Bus traffic extends activity deadline — received
+                # frames should not consume arbitration budget.
                 deadline = time.monotonic() + self._config.timeout_s
                 continue
             if command == _ENH_RES_STARTED and data == initiator:
@@ -966,7 +977,9 @@ class EnhancedTcpTransport(TransportInterface):
             if ack == _EBUS_NACK:
                 if nack_attempt == 0:
                     continue  # retry without re-arbitration
-                raise _EnhancedNack("nack received (local retry exhausted)")
+                # Local retry exhausted — raise non-retryable TransportNack
+                # so _send_with_policy does NOT re-arbitrate again.
+                raise TransportNack("nack received (local retry exhausted)")
             if ack == _EBUS_SYN:
                 raise TransportTimeout("syn received while waiting for command ack")
             if ack != _EBUS_ACK:

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -12,7 +12,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO
 
-from .base import TransportError, TransportInterface, TransportNack, TransportTimeout
+from .base import (
+    TransportDisconnected,
+    TransportError,
+    TransportHostError,
+    TransportInterface,
+    TransportNack,
+    TransportTimeout,
+)
 
 _EBUS_ESCAPE = 0xA9
 _EBUS_SYN = 0xAA
@@ -438,6 +445,7 @@ class EnhancedTcpTransport(TransportInterface):
         self._session: _EnhancedTcpSession | None = None
         self._messages = deque[tuple[str, int, int]]()
         self._enh_pending_first: int | None = None
+        self._malformed_count: int = 0
         self._lock = threading.RLock()
 
     def _trace(self, message: str) -> None:
@@ -458,6 +466,7 @@ class EnhancedTcpTransport(TransportInterface):
     def _reset_parser(self) -> None:
         self._messages.clear()
         self._enh_pending_first = None
+        self._malformed_count = 0
 
     def close(self) -> None:
         with self._lock:
@@ -575,7 +584,7 @@ class EnhancedTcpTransport(TransportInterface):
 
             if not chunk:
                 self.close()
-                raise TransportError(
+                raise TransportDisconnected(
                     f"Enhanced adapter disconnected {self._config.host}:{self._config.port}"
                 )
 
@@ -589,19 +598,30 @@ class EnhancedTcpTransport(TransportInterface):
             if value & 0x80 == 0:
                 return ("data", value, 0)
             if value & 0xC0 == 0x80:
-                self.close()
-                raise TransportError(f"Malformed ENH byte pair start 0x{value:02X}")
+                self._malformed_count += 1
+                self._trace(f"Malformed ENH byte pair start 0x{value:02X} (count={self._malformed_count})")
+                if self._malformed_count >= 3:
+                    self._malformed_count = 0
+                    self.close()
+                    raise TransportError(f"Malformed ENH byte pair start 0x{value:02X} (3 consecutive)")
+                return None
             self._enh_pending_first = value
             return None
 
         if value & 0xC0 != 0x80:
             self._enh_pending_first = None
-            self.close()
-            raise TransportError(f"Malformed ENH byte pair end 0x{value:02X}")
+            self._malformed_count += 1
+            self._trace(f"Malformed ENH byte pair end 0x{value:02X} (count={self._malformed_count})")
+            if self._malformed_count >= 3:
+                self._malformed_count = 0
+                self.close()
+                raise TransportError(f"Malformed ENH byte pair end 0x{value:02X} (3 consecutive)")
+            return None
 
         first = self._enh_pending_first
         self._enh_pending_first = None
         assert first is not None
+        self._malformed_count = 0
         command = (first >> 2) & 0x0F
         data = ((first & 0x03) << 6) | (value & 0x3F)
         return ("frame", command, data)
@@ -615,7 +635,7 @@ class EnhancedTcpTransport(TransportInterface):
                 kind, command, data = self._read_message()
             except TransportTimeout:
                 self._trace("INIT_RESP timeout")
-                return
+                raise
             if kind != "frame":
                 continue
             if command == _ENH_RES_RESETTED:
@@ -627,7 +647,7 @@ class EnhancedTcpTransport(TransportInterface):
                 raise TransportError(f"ENH init eBUS error 0x{data:02X}")
             if command == _ENH_RES_ERROR_HOST:
                 self._trace(f"INIT_RESP host_error=0x{data:02X}")
-                raise TransportError(f"ENH init host error 0x{data:02X}")
+                raise TransportHostError(f"ENH init host error 0x{data:02X}")
         self._trace("INIT_RESP deadline expired (bus data flooding)")
 
     def _start_arbitration(self, initiator: int) -> None:
@@ -655,7 +675,7 @@ class EnhancedTcpTransport(TransportInterface):
             if command == _ENH_RES_ERROR_HOST:
                 self._trace(f"START_RESP host_error=0x{data:02X}")
                 self._reset_parser()
-                raise _EnhancedCollision(f"enhanced arbitration host error 0x{data:02X}")
+                raise TransportHostError(f"enhanced arbitration host error 0x{data:02X}")
             if command == _ENH_RES_RESETTED:
                 self._trace(f"START_RESP reset features=0x{data:02X}")
                 self.close()
@@ -680,10 +700,15 @@ class EnhancedTcpTransport(TransportInterface):
                 raise TransportTimeout(f"Adapter reset during bus read (features=0x{data:02X})")
             if command == _ENH_RES_INFO:
                 continue
+            if command == _ENH_RES_FAILED:
+                raise _EnhancedCollision(f"Bus FAILED during read (data=0x{data:02X})")
             if command == _ENH_RES_ERROR_EBUS:
                 raise TransportError(f"enhanced bus read eBUS error 0x{data:02X}")
             if command == _ENH_RES_ERROR_HOST:
-                raise TransportError(f"enhanced bus read host error 0x{data:02X}")
+                raise TransportHostError(f"enhanced bus read host error 0x{data:02X}")
+            # Unknown ENH command — skip silently (VE28: prevents spin on padding).
+            self._trace(f"Unknown ENH command 0x{command:02X} data=0x{data:02X}")
+            continue
         raise TransportTimeout("Bus symbol read deadline expired")
 
     def _send_symbol_with_echo(self, symbol: int) -> None:
@@ -794,6 +819,29 @@ class EnhancedTcpTransport(TransportInterface):
                     f"#{seq} RETRY type=timeout "
                     f"n={timeout_retries}/{self._config.timeout_max_retries}"
                 )
+            except TransportHostError:
+                # Host errors are non-retryable — the request is malformed.
+                raise
+            except TransportDisconnected as exc:
+                # Clean EOF — attempt TCP reconnect.
+                reconnect_retries += 1
+                if reconnect_retries > self._config.reconnect_max_retries:
+                    self.close()
+                    raise TransportError(
+                        f"{exc} (reconnect retries exhausted "
+                        f"({self._config.reconnect_max_retries}))"
+                    ) from exc
+                try:
+                    self._reconnect(seq, reconnect_retries)
+                except (TransportError, TransportTimeout, OSError) as reconn_exc:
+                    self._trace(f"#{seq} RECONNECT failed: {reconn_exc}")
+                    if reconnect_retries >= self._config.reconnect_max_retries:
+                        raise TransportError(
+                            f"{exc} (reconnect failed: {reconn_exc})"
+                        ) from exc
+                    time.sleep(self._config.reconnect_delay_s)
+                    continue
+                continue
             except _EnhancedCollision as exc:
                 # Collision is normal on a shared bus.  Per eBUS spec
                 # section 6.2.2.2 the adapter waits for the winner's

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from html import escape as _escape_html
 from typing import Any
 
@@ -16,7 +17,23 @@ def _json_for_html(obj: Any) -> str:
 
     raw = json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
     # Prevent `</script>` breaks and avoid HTML parser surprises.
-    return raw.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
+    return (
+        raw.replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("'", "\\u0027")
+    )
+
+
+_PLACEHOLDER_RE = re.compile(r"__[A-Z_]+__")
+
+
+def _substitute_template(template: str, substitutions: dict[str, str]) -> str:
+    """Single-pass placeholder substitution (VE26-R3: prevents collision)."""
+    return _PLACEHOLDER_RE.sub(
+        lambda m: substitutions.get(m.group(0), m.group(0)),
+        template,
+    )
 
 
 _TEMPLATE = """<!doctype html>
@@ -2085,10 +2102,14 @@ def render_html_report(artifact: dict[str, Any], *, title: str | None = None) ->
                 )
     page_title = title or "Regulator Scan Browser"
     return (
-        _TEMPLATE.replace("__TITLE__", _escape_html(page_title))
-        .replace("__IDENTITY_CARD__", identity_html)
-        .replace("__ARTIFACT_JSON__", _json_for_html(artifact))
-        .replace("__B524_GROUP_NAMES__", _json_for_html(group_name_map))
-        .rstrip()
+        _substitute_template(
+            _TEMPLATE,
+            {
+                "__TITLE__": _escape_html(page_title),
+                "__IDENTITY_CARD__": identity_html,
+                "__ARTIFACT_JSON__": _json_for_html(artifact),
+                "__B524_GROUP_NAMES__": _json_for_html(group_name_map),
+            },
+        ).rstrip()
         + "\n"
     )

--- a/src/helianthus_vrc_explorer/ui/html_report.py
+++ b/src/helianthus_vrc_explorer/ui/html_report.py
@@ -25,7 +25,7 @@ def _json_for_html(obj: Any) -> str:
     )
 
 
-_PLACEHOLDER_RE = re.compile(r"__[A-Z_]+__")
+_PLACEHOLDER_RE = re.compile(r"__[A-Z0-9_]+__")
 
 
 def _substitute_template(template: str, substitutions: dict[str, str]) -> str:

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -612,3 +612,9 @@ def test_ve23_timeout_retries_accumulate_across_reconnect() -> None:
     # Without VE23 fix (timeout reset): would loop indefinitely
     # With VE23 fix: bounded number of connections
     assert connect_count <= 3  # Bounded, not infinite
+
+
+def test_ve8_cli_default_src() -> None:
+    """VE8: CLI default src must match EnhancedTcpConfig default (0xF7)."""
+    config = EnhancedTcpConfig()
+    assert config.src == 0xF7

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -69,9 +69,10 @@ def _run_ens_test_server(
                 raise
 
     server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
-    server.daemon_threads = True
+    # VE9: Non-daemon threads so handler exceptions are visible.
+    server.daemon_threads = False
 
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=False)
     thread.start()
     try:
         host, port = server.server_address
@@ -81,7 +82,7 @@ def _run_ens_test_server(
     finally:
         server.shutdown()
         server.server_close()
-        thread.join(timeout=1)
+        thread.join(timeout=5)
         if not errors.empty():
             raise errors.get()
 

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import socket
 import socketserver
 import threading
@@ -698,20 +699,14 @@ def test_adv_crc_value_is_escape_byte() -> None:
     assert result == response
 
 
-def test_adv_crc_value_is_syn_byte_raises_timeout() -> None:
-    """ADV: Response CRC value 0xAA (SYN) triggers TransportTimeout.
+def test_adv_crc_value_is_syn_byte_succeeds() -> None:
+    """ADV: Response CRC value 0xAA must succeed (not false-timeout).
 
-    KNOWN LIMITATION: The _send_proto_once response-read path checks
-    ``if crc_value == _EBUS_SYN: raise TransportTimeout(...)`` which
-    fires even when the CRC is a legitimate data byte 0xAA delivered
-    via an ENH RECEIVED frame.  On a real bus this CRC value is
-    wire-escaped to [0xA9, 0x01] then un-escaped by the adapter --
-    so the ENH layer sees logical 0xAA.  The transport conservatively
-    treats any 0xAA as bus SYN loss, causing a spurious timeout+retry.
-    This test documents the current behaviour.
+    In the ENH protocol, 0xAA from _recv_bus_symbol() is a legitimate
+    data byte — the adapter decoded wire-escaped [0xA9, 0x01] back to
+    logical 0xAA.  Bus SYN loss is reported via _ENH_RES_FAILED, not
+    as a RECEIVED frame with data=0xAA.
     """
-    import pytest
-
     src = 0xF1
     dst = 0x15
     request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
@@ -719,7 +714,7 @@ def test_adv_crc_value_is_syn_byte_raises_timeout() -> None:
     response = bytes((0x31,))
     response_segment = bytes((len(response),)) + response
     response_crc = _crc(response_segment)
-    assert response_crc == 0xAA
+    assert response_crc == 0xAA  # This CRC is the SYN byte value
 
     def _handler(conn: socket.socket) -> None:
         assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
@@ -732,23 +727,58 @@ def test_adv_crc_value_is_syn_byte_raises_timeout() -> None:
         _write_bus_symbol(conn, 0x00)  # ACK
         for value in response_segment:
             _write_bus_symbol(conn, value)
-        _write_bus_symbol(conn, response_crc)  # 0xAA
-        # Transport will raise TransportTimeout at this point due to
-        # SYN check; handler can just stay alive briefly.
-        import time as _time
-        _time.sleep(1.0)
+        _write_bus_symbol(conn, response_crc)  # 0xAA — valid CRC byte
+
+        # Transport should send ACK + SYN (success, not timeout)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)  # ACK
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)  # SYN
+        _write_bus_symbol(conn, 0xAA)
 
     with _run_ens_test_server(_handler) as (host, port):
         transport = EnhancedTcpTransport(
-            EnhancedTcpConfig(
-                host=host, port=port, timeout_s=0.3, src=src,
-                timeout_max_retries=0, reconnect_max_retries=0,
-            )
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src)
         )
-        # Current behaviour: raises TransportTimeout because the
-        # response-read path treats CRC byte 0xAA as bus SYN.
-        with pytest.raises((TransportTimeout, TransportError)):
-            transport.send_proto(dst, 0x07, 0x04, b"")
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    assert result == response
+
+
+def test_adv_response_data_containing_0xaa() -> None:
+    """ADV: Response data byte 0xAA must not trigger false SYN timeout."""
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    # Response contains 0xAA as a data byte
+    response = bytes((0xAA, 0x42, 0xA9))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0x00)  # ACK
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)  # ACK
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)  # SYN
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src)
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    assert result == response
 
 
 def test_adv_four_threads_hammering_send_proto() -> None:
@@ -839,10 +869,8 @@ def test_adv_stream_of_0xff_to_enh_parser() -> None:
     import pytest
 
     def _handler(conn: socket.socket) -> None:
-        try:
+        with contextlib.suppress(Exception):
             conn.sendall(bytes([0xFF] * 200))
-        except Exception:
-            pass
         import time as _time
         _time.sleep(1.0)
 

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -619,3 +619,281 @@ def test_ve8_cli_default_src() -> None:
     """VE8: CLI default src must match EnhancedTcpConfig default (0xF7)."""
     config = EnhancedTcpConfig()
     assert config.src == 0xF7
+
+
+# ---------------------------------------------------------------------------
+# Adversarial tests added by angry-tester audit
+# ---------------------------------------------------------------------------
+
+
+def test_adv_all_escape_syn_payload() -> None:
+    """ADV: Payload where every byte is 0xA9 (ESCAPE) or 0xAA (SYN)."""
+    src = 0xF1
+    dst = 0x15
+    payload = bytes((0xA9, 0xAA, 0xA9, 0xAA))
+    request_without_crc = bytes((src, dst, 0xB5, 0x24, len(payload))) + payload
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x01,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0x00)
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
+        result = transport.send(dst, payload)
+    assert result == response
+
+
+def test_adv_crc_value_is_escape_byte() -> None:
+    """ADV: Response CRC value itself is 0xA9 (ESCAPE)."""
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x32,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+    assert response_crc == 0xA9
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0x00)
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+    assert result == response
+
+
+def test_adv_crc_value_is_syn_byte_raises_timeout() -> None:
+    """ADV: Response CRC value 0xAA (SYN) triggers TransportTimeout.
+
+    KNOWN LIMITATION: The _send_proto_once response-read path checks
+    ``if crc_value == _EBUS_SYN: raise TransportTimeout(...)`` which
+    fires even when the CRC is a legitimate data byte 0xAA delivered
+    via an ENH RECEIVED frame.  On a real bus this CRC value is
+    wire-escaped to [0xA9, 0x01] then un-escaped by the adapter --
+    so the ENH layer sees logical 0xAA.  The transport conservatively
+    treats any 0xAA as bus SYN loss, causing a spurious timeout+retry.
+    This test documents the current behaviour.
+    """
+    import pytest
+
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x31,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+    assert response_crc == 0xAA
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0x00)  # ACK
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)  # 0xAA
+        # Transport will raise TransportTimeout at this point due to
+        # SYN check; handler can just stay alive briefly.
+        import time as _time
+        _time.sleep(1.0)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(
+                host=host, port=port, timeout_s=0.3, src=src,
+                timeout_max_retries=0, reconnect_max_retries=0,
+            )
+        )
+        # Current behaviour: raises TransportTimeout because the
+        # response-read path treats CRC byte 0xAA as bus SYN.
+        with pytest.raises((TransportTimeout, TransportError)):
+            transport.send_proto(dst, 0x07, 0x04, b"")
+
+
+def test_adv_four_threads_hammering_send_proto() -> None:
+    """ADV: 4 threads call send_proto() simultaneously."""
+    import time as _time
+
+    src = 0xF1
+    completed: list[bool] = []
+    errors: list[str] = []
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        for _ in range(4):
+            try:
+                cmd, data = _read_enh_frame(conn)
+                if cmd != _ENH_REQ_START:
+                    break
+                _write_enh_frame(conn, _ENH_RES_STARTED, data)
+                while True:
+                    cmd2, data2 = _read_enh_frame(conn)
+                    if cmd2 != _ENH_REQ_SEND:
+                        break
+                    _write_bus_symbol(conn, data2)
+                    if data2 == 0xAA:
+                        break
+            except Exception:
+                break
+        _time.sleep(0.5)
+
+    def _send_one(transport: EnhancedTcpTransport, idx: int) -> None:
+        try:
+            transport.send_proto(0xFE, 0x07, 0xFE, b"", expect_response=False)
+            completed.append(True)
+        except Exception as exc:
+            errors.append(f"thread-{idx}: {type(exc).__name__}: {exc}")
+            completed.append(False)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src)
+        )
+        threads = [
+            threading.Thread(target=_send_one, args=(transport, i))
+            for i in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+    assert len(completed) == 4
+    assert any(completed), f"No thread succeeded: {errors}"
+
+
+def test_adv_reconnect_storm_disconnect_every_2nd() -> None:
+    """ADV: Server disconnects after every 2nd message."""
+    import pytest
+
+    connect_count = 0
+
+    def _handler(conn: socket.socket) -> None:
+        nonlocal connect_count
+        connect_count += 1
+        try:
+            _read_enh_frame(conn)
+            _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+            _read_enh_frame(conn)
+        except Exception:
+            pass
+        conn.close()
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(
+                host=host, port=port, timeout_s=0.3, src=0xF1,
+                timeout_max_retries=0,
+                reconnect_max_retries=2,
+                reconnect_delay_s=0.05,
+            )
+        )
+        with pytest.raises((TransportError, TransportTimeout)):
+            transport.send_proto(0x15, 0x07, 0x04, b"")
+    assert connect_count <= 4
+
+
+def test_adv_stream_of_0xff_to_enh_parser() -> None:
+    """ADV: Stream of 0xFF bytes fed to the ENH parser."""
+    import pytest
+
+    def _handler(conn: socket.socket) -> None:
+        try:
+            conn.sendall(bytes([0xFF] * 200))
+        except Exception:
+            pass
+        import time as _time
+        _time.sleep(1.0)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(
+                host=host, port=port, timeout_s=0.5, src=0xF1,
+                timeout_max_retries=0,
+                reconnect_max_retries=0,
+            )
+        )
+        with pytest.raises((TransportError, TransportTimeout)):
+            transport.send_proto(0x15, 0x07, 0x04, b"")
+
+
+def test_adv_send_symbol_escape_byte_explicit() -> None:
+    """ADV: _send_symbol_with_echo with symbol=0xA9 (ESCAPE) explicitly."""
+    src = 0xF1
+    dst = 0x15
+    payload = bytes((0xA9,))
+    request_without_crc = bytes((src, dst, 0xB5, 0x24, len(payload))) + payload
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x42,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+    symbols_sent: list[int] = []
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        for expected in request[1:]:
+            cmd, data = _read_enh_frame(conn)
+            assert cmd == _ENH_REQ_SEND
+            assert data == expected
+            symbols_sent.append(data)
+            _write_bus_symbol(conn, data)
+        _write_bus_symbol(conn, 0x00)
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
+        result = transport.send(dst, payload)
+    assert result == response
+    assert 0xA9 in symbols_sent

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -348,13 +348,8 @@ def test_ve22_concurrent_session_entry() -> None:
             results.append(False)
 
     with _run_ens_test_server(_handler) as (host, port):
-        transport = EnhancedTcpTransport(
-            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0)
-        )
-        threads = [
-            threading.Thread(target=_session_user, args=(transport,))
-            for _ in range(4)
-        ]
+        transport = EnhancedTcpTransport(EnhancedTcpConfig(host=host, port=port, timeout_s=2.0))
+        threads = [threading.Thread(target=_session_user, args=(transport,)) for _ in range(4)]
         for t in threads:
             t.start()
         for t in threads:
@@ -366,9 +361,7 @@ def test_ve22_concurrent_session_entry() -> None:
 
 def test_ve17_session_depth_never_negative() -> None:
     """VE17: session depth must never go negative even with spurious close calls."""
-    transport = EnhancedTcpTransport(
-        EnhancedTcpConfig(host="127.0.0.1", port=1, timeout_s=0.1)
-    )
+    transport = EnhancedTcpTransport(EnhancedTcpConfig(host="127.0.0.1", port=1, timeout_s=0.1))
     # Depth starts at 0, multiple closes must not drive it negative
     transport._session_depth = 0
     transport.close()
@@ -454,6 +447,7 @@ def test_ve2_host_error_not_retried() -> None:
 def test_ve6_src_escape_rejected() -> None:
     """VE6: src=0xA9 (ESCAPE) must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="reserved address"):
         EnhancedTcpTransport(EnhancedTcpConfig(src=0xA9))
 
@@ -461,6 +455,7 @@ def test_ve6_src_escape_rejected() -> None:
 def test_ve6_src_syn_rejected() -> None:
     """VE6: src=0xAA (SYN) must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="reserved address"):
         EnhancedTcpTransport(EnhancedTcpConfig(src=0xAA))
 
@@ -468,6 +463,7 @@ def test_ve6_src_syn_rejected() -> None:
 def test_ve6_src_zero_rejected() -> None:
     """VE6: src=0x00 must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="reserved address"):
         EnhancedTcpTransport(EnhancedTcpConfig(src=0x00))
 
@@ -475,6 +471,7 @@ def test_ve6_src_zero_rejected() -> None:
 def test_ve6_src_0xff_rejected() -> None:
     """VE6: src=0xFF must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="reserved address"):
         EnhancedTcpTransport(EnhancedTcpConfig(src=0xFF))
 
@@ -482,6 +479,7 @@ def test_ve6_src_0xff_rejected() -> None:
 def test_ve7_dst_escape_rejected() -> None:
     """VE7: dst=0xA9 (ESCAPE) must be rejected."""
     import pytest
+
     transport = EnhancedTcpTransport(EnhancedTcpConfig())
     with pytest.raises(ValueError, match="reserved address"):
         transport.send_proto(0xA9, 0x07, 0x04, b"")
@@ -490,6 +488,7 @@ def test_ve7_dst_escape_rejected() -> None:
 def test_ve7_dst_syn_rejected() -> None:
     """VE7: dst=0xAA (SYN) must be rejected."""
     import pytest
+
     transport = EnhancedTcpTransport(EnhancedTcpConfig())
     with pytest.raises(ValueError, match="reserved address"):
         transport.send_proto(0xAA, 0x07, 0x04, b"")
@@ -498,6 +497,7 @@ def test_ve7_dst_syn_rejected() -> None:
 def test_ve19r2_negative_timeout_rejected() -> None:
     """VE19-R2: timeout_s <= 0 must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="timeout_s"):
         EnhancedTcpTransport(EnhancedTcpConfig(timeout_s=-1.0))
 
@@ -505,6 +505,7 @@ def test_ve19r2_negative_timeout_rejected() -> None:
 def test_ve19r2_zero_timeout_rejected() -> None:
     """VE19-R2: timeout_s=0 must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="timeout_s"):
         EnhancedTcpTransport(EnhancedTcpConfig(timeout_s=0.0))
 
@@ -512,6 +513,7 @@ def test_ve19r2_zero_timeout_rejected() -> None:
 def test_ve19r2_nan_timeout_rejected() -> None:
     """VE19-R2: timeout_s=NaN must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="timeout_s"):
         EnhancedTcpTransport(EnhancedTcpConfig(timeout_s=float("nan")))
 
@@ -519,6 +521,7 @@ def test_ve19r2_nan_timeout_rejected() -> None:
 def test_ve19r2_port_zero_rejected() -> None:
     """VE19-R2: port=0 must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="port"):
         EnhancedTcpTransport(EnhancedTcpConfig(port=0))
 
@@ -526,6 +529,7 @@ def test_ve19r2_port_zero_rejected() -> None:
 def test_ve19r2_port_too_large_rejected() -> None:
     """VE19-R2: port=99999 must be rejected."""
     import pytest
+
     with pytest.raises(ValueError, match="port"):
         EnhancedTcpTransport(EnhancedTcpConfig(port=99999))
 
@@ -602,8 +606,12 @@ def test_ve23_timeout_retries_accumulate_across_reconnect() -> None:
     with _run_ens_test_server(_handler) as (host, port):
         transport = EnhancedTcpTransport(
             EnhancedTcpConfig(
-                host=host, port=port, timeout_s=0.3, src=0xF1,
-                timeout_max_retries=1, reconnect_max_retries=1,
+                host=host,
+                port=port,
+                timeout_s=0.3,
+                src=0xF1,
+                timeout_max_retries=1,
+                reconnect_max_retries=1,
                 reconnect_delay_s=0.1,
             )
         )
@@ -821,10 +829,7 @@ def test_adv_four_threads_hammering_send_proto() -> None:
         transport = EnhancedTcpTransport(
             EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src)
         )
-        threads = [
-            threading.Thread(target=_send_one, args=(transport, i))
-            for i in range(4)
-        ]
+        threads = [threading.Thread(target=_send_one, args=(transport, i)) for i in range(4)]
         for t in threads:
             t.start()
         for t in threads:
@@ -853,7 +858,10 @@ def test_adv_reconnect_storm_disconnect_every_2nd() -> None:
     with _run_ens_test_server(_handler) as (host, port):
         transport = EnhancedTcpTransport(
             EnhancedTcpConfig(
-                host=host, port=port, timeout_s=0.3, src=0xF1,
+                host=host,
+                port=port,
+                timeout_s=0.3,
+                src=0xF1,
                 timeout_max_retries=0,
                 reconnect_max_retries=2,
                 reconnect_delay_s=0.05,
@@ -872,12 +880,16 @@ def test_adv_stream_of_0xff_to_enh_parser() -> None:
         with contextlib.suppress(Exception):
             conn.sendall(bytes([0xFF] * 200))
         import time as _time
+
         _time.sleep(1.0)
 
     with _run_ens_test_server(_handler) as (host, port):
         transport = EnhancedTcpTransport(
             EnhancedTcpConfig(
-                host=host, port=port, timeout_s=0.5, src=0xF1,
+                host=host,
+                port=port,
+                timeout_s=0.5,
+                src=0xF1,
                 timeout_max_retries=0,
                 reconnect_max_retries=0,
             )

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -252,7 +252,7 @@ def test_ve21_response_crc_with_escape_bytes() -> None:
     """VE21/VE25: Verify CRC verification works when response contains 0xA9.
 
     The _crc() function correctly applies escape expansion to logical bytes
-    before CRC computation, matching what the bus slave does.
+    before CRC computation, matching what the bus target does.
 
     Note: 0xAA (SYN) cannot appear as a logical data byte in eBUS responses
     because SYN is the bus frame delimiter.  The escape byte 0xA9 CAN appear

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -322,3 +322,53 @@ def test_ve25_crc_escape_expansion_is_correct() -> None:
     crc = _crc_update(crc, 0x00)  # escape expansion of 0xA9
     crc = _crc_update(crc, 0x01)
     assert _crc(bytes((0x42, 0xA9, 0x01))) == crc
+
+
+def test_ve22_concurrent_session_entry() -> None:
+    """VE22: _session_depth must be thread-safe under concurrent session() calls."""
+    import time as _time
+
+    results: list[bool] = []
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        # Keep connection alive for all threads
+        _time.sleep(1.0)
+
+    def _session_user(transport: EnhancedTcpTransport) -> None:
+        try:
+            with transport.session():
+                _time.sleep(0.1)
+            results.append(True)
+        except Exception:
+            results.append(False)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0)
+        )
+        threads = [
+            threading.Thread(target=_session_user, args=(transport,))
+            for _ in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+    # At least some threads should succeed
+    assert any(results), f"All threads failed: {results}"
+
+
+def test_ve17_session_depth_never_negative() -> None:
+    """VE17: session depth must never go negative even with spurious close calls."""
+    transport = EnhancedTcpTransport(
+        EnhancedTcpConfig(host="127.0.0.1", port=1, timeout_s=0.1)
+    )
+    # Depth starts at 0, multiple closes must not drive it negative
+    transport._session_depth = 0
+    transport.close()
+    assert transport._session_depth >= 0
+    transport.close()
+    assert transport._session_depth >= 0

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -12,6 +12,7 @@ from helianthus_vrc_explorer.transport.enhanced_tcp import (
     _ENH_REQ_INIT,
     _ENH_REQ_SEND,
     _ENH_REQ_START,
+    _ENH_RES_ERROR_HOST,
     _ENH_RES_RECEIVED,
     _ENH_RES_RESETTED,
     _ENH_RES_STARTED,
@@ -372,3 +373,77 @@ def test_ve17_session_depth_never_negative() -> None:
     assert transport._session_depth >= 0
     transport.close()
     assert transport._session_depth >= 0
+
+
+def test_ve15_malformed_enh_byte_no_immediate_close() -> None:
+    """VE15: A single malformed ENH byte should not close the transport."""
+
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x01, 0x02))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+
+        # Inject a single malformed byte (0x85 has bit pattern 10xxxxxx — invalid start)
+        conn.sendall(bytes((0x85,)))
+
+        # Then send valid response
+        _write_bus_symbol(conn, 0x00)  # ACK
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)  # ACK
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)  # SYN
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src)
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    assert result == response
+
+
+def test_ve2_host_error_not_retried() -> None:
+    """VE2: TransportHostError should propagate without retry."""
+    import pytest
+
+    from helianthus_vrc_explorer.transport.base import TransportHostError
+
+    call_count = 0
+
+    def _handler(conn: socket.socket) -> None:
+        nonlocal call_count
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, 0xF7)
+        # Respond with host error
+        _write_enh_frame(conn, _ENH_RES_ERROR_HOST, 0x01)
+        call_count += 1
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=1.0, collision_max_retries=3)
+        )
+        with pytest.raises(TransportHostError):
+            transport.send_proto(0x15, 0x07, 0x04, b"")
+
+    # Should have been called exactly once — no retry
+    assert call_count == 1

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from queue import Queue
 
-from helianthus_vrc_explorer.transport.base import TransportNack
+from helianthus_vrc_explorer.transport.base import TransportError, TransportNack, TransportTimeout
 from helianthus_vrc_explorer.transport.enhanced_tcp import (
     _ENH_REQ_INIT,
     _ENH_REQ_SEND,
@@ -447,3 +447,168 @@ def test_ve2_host_error_not_retried() -> None:
 
     # Should have been called exactly once — no retry
     assert call_count == 1
+
+
+def test_ve6_src_escape_rejected() -> None:
+    """VE6: src=0xA9 (ESCAPE) must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="reserved address"):
+        EnhancedTcpTransport(EnhancedTcpConfig(src=0xA9))
+
+
+def test_ve6_src_syn_rejected() -> None:
+    """VE6: src=0xAA (SYN) must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="reserved address"):
+        EnhancedTcpTransport(EnhancedTcpConfig(src=0xAA))
+
+
+def test_ve6_src_zero_rejected() -> None:
+    """VE6: src=0x00 must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="reserved address"):
+        EnhancedTcpTransport(EnhancedTcpConfig(src=0x00))
+
+
+def test_ve6_src_0xff_rejected() -> None:
+    """VE6: src=0xFF must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="reserved address"):
+        EnhancedTcpTransport(EnhancedTcpConfig(src=0xFF))
+
+
+def test_ve7_dst_escape_rejected() -> None:
+    """VE7: dst=0xA9 (ESCAPE) must be rejected."""
+    import pytest
+    transport = EnhancedTcpTransport(EnhancedTcpConfig())
+    with pytest.raises(ValueError, match="reserved address"):
+        transport.send_proto(0xA9, 0x07, 0x04, b"")
+
+
+def test_ve7_dst_syn_rejected() -> None:
+    """VE7: dst=0xAA (SYN) must be rejected."""
+    import pytest
+    transport = EnhancedTcpTransport(EnhancedTcpConfig())
+    with pytest.raises(ValueError, match="reserved address"):
+        transport.send_proto(0xAA, 0x07, 0x04, b"")
+
+
+def test_ve19r2_negative_timeout_rejected() -> None:
+    """VE19-R2: timeout_s <= 0 must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="timeout_s"):
+        EnhancedTcpTransport(EnhancedTcpConfig(timeout_s=-1.0))
+
+
+def test_ve19r2_zero_timeout_rejected() -> None:
+    """VE19-R2: timeout_s=0 must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="timeout_s"):
+        EnhancedTcpTransport(EnhancedTcpConfig(timeout_s=0.0))
+
+
+def test_ve19r2_nan_timeout_rejected() -> None:
+    """VE19-R2: timeout_s=NaN must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="timeout_s"):
+        EnhancedTcpTransport(EnhancedTcpConfig(timeout_s=float("nan")))
+
+
+def test_ve19r2_port_zero_rejected() -> None:
+    """VE19-R2: port=0 must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="port"):
+        EnhancedTcpTransport(EnhancedTcpConfig(port=0))
+
+
+def test_ve19r2_port_too_large_rejected() -> None:
+    """VE19-R2: port=99999 must be rejected."""
+    import pytest
+    with pytest.raises(ValueError, match="port"):
+        EnhancedTcpTransport(EnhancedTcpConfig(port=99999))
+
+
+def test_ve4_nack_retry_without_rearbitration() -> None:
+    """VE4: After NACK, retry telegram without re-arbitrating."""
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x01,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    start_count = 0
+
+    def _handler(conn: socket.socket) -> None:
+        nonlocal start_count
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        # First (and only) arbitration
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        start_count += 1
+
+        # First telegram send — will be NACKed
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0xFF)  # NACK
+
+        # Local retry — same telegram, NO re-arbitration
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0x00)  # ACK this time
+
+        # Response
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)  # ACK
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)  # SYN
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src, nack_max_retries=1)
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    assert result == response
+    assert start_count == 1  # Only ONE arbitration
+
+
+def test_ve23_timeout_retries_accumulate_across_reconnect() -> None:
+    """VE23: timeout_retries must not reset after reconnect."""
+    import time as _time
+
+    import pytest
+
+    connect_count = 0
+
+    def _handler(conn: socket.socket) -> None:
+        nonlocal connect_count
+        connect_count += 1
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        # Never respond to START — causes timeout
+        _time.sleep(5.0)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(
+                host=host, port=port, timeout_s=0.3, src=0xF1,
+                timeout_max_retries=1, reconnect_max_retries=1,
+                reconnect_delay_s=0.1,
+            )
+        )
+        with pytest.raises((TransportTimeout, TransportError)):
+            transport.send_proto(0x15, 0x07, 0x04, b"")
+
+    # With timeout_max_retries=1, reconnect_max_retries=1:
+    # Without VE23 fix (timeout reset): would loop indefinitely
+    # With VE23 fix: bounded number of connections
+    assert connect_count <= 3  # Bounded, not infinite

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -18,6 +18,7 @@ from helianthus_vrc_explorer.transport.enhanced_tcp import (
     EnhancedTcpConfig,
     EnhancedTcpTransport,
     _crc,
+    _crc_update,
     _encode_enh,
 )
 
@@ -195,3 +196,129 @@ def test_internal_enhanced_nack_maps_to_transport_nack() -> None:
     from helianthus_vrc_explorer.transport.enhanced_tcp import _EnhancedNack
 
     assert issubclass(_EnhancedNack, TransportNack)
+
+
+def test_ve1_send_payload_containing_escape_byte() -> None:
+    """VE1/VE20: Verify that 0xA9 (ESCAPE) in payload sends correctly via ENH.
+
+    The enhanced adapter firmware handles wire escape encoding.  The ENH
+    SEND command carries logical bytes -- the client must NOT pre-escape.
+    """
+    src = 0xF1
+    dst = 0x15
+    # Payload deliberately contains 0xA9 (eBUS escape) and 0xAA (eBUS SYN).
+    payload = bytes((0xA9, 0x42, 0xAA))
+    request_without_crc = bytes((src, dst, 0xB5, 0x24, len(payload))) + payload
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x01,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+
+        # Adapter receives logical bytes via ENH -- no wire escaping at this layer.
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+
+        _write_bus_symbol(conn, 0x00)  # ACK
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)  # ACK
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)  # SYN (end)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
+        result = transport.send(dst, payload)
+
+    assert result == response
+
+
+def test_ve21_response_crc_with_escape_bytes() -> None:
+    """VE21/VE25: Verify CRC verification works when response contains 0xA9.
+
+    The _crc() function correctly applies escape expansion to logical bytes
+    before CRC computation, matching what the bus slave does.
+
+    Note: 0xAA (SYN) cannot appear as a logical data byte in eBUS responses
+    because SYN is the bus frame delimiter.  The escape byte 0xA9 CAN appear
+    as logical data (wire-escaped to [0xA9, 0x00] and un-escaped by the
+    adapter firmware).
+    """
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    # Response deliberately contains 0xA9 (eBUS escape) bytes.
+    # 0xA9 triggers CRC escape expansion: logical 0xA9 -> wire [0xA9, 0x00].
+    response = bytes((0x01, 0xA9, 0x42, 0xA9, 0x03))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+
+        _write_bus_symbol(conn, 0x00)  # ACK
+        # Adapter sends logical (un-escaped) response bytes via ENH RECEIVED.
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)  # ACK
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)  # SYN (end)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=0.5, src=src)
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    assert result == response
+
+
+def test_ve25_crc_escape_expansion_is_correct() -> None:
+    """VE25: Verify _crc() correctly handles escape expansion for CRC computation.
+
+    Per eBUS spec, CRC is computed on the wire-expanded form.  Logical 0xA9
+    expands to [0xA9, 0x00] and logical 0xAA expands to [0xA9, 0x01].
+    """
+    # CRC of a single 0xA9 byte = CRC of wire sequence [0xA9, 0x00]
+    expected = _crc_update(_crc_update(0, 0xA9), 0x00)
+    assert _crc(bytes((0xA9,))) == expected
+
+    # CRC of a single 0xAA byte = CRC of wire sequence [0xA9, 0x01]
+    expected_aa = _crc_update(_crc_update(0, 0xA9), 0x01)
+    assert _crc(bytes((0xAA,))) == expected_aa
+
+    # Normal bytes pass through unchanged
+    expected_42 = _crc_update(0, 0x42)
+    assert _crc(bytes((0x42,))) == expected_42
+
+    # Mixed: [0x42, 0xA9, 0x01] -> CRC([0x42, 0xA9, 0x00, 0x01])
+    crc = 0
+    crc = _crc_update(crc, 0x42)
+    crc = _crc_update(crc, 0xA9)
+    crc = _crc_update(crc, 0x00)  # escape expansion of 0xA9
+    crc = _crc_update(crc, 0x01)
+    assert _crc(bytes((0x42, 0xA9, 0x01))) == crc

--- a/tests/test_ve_protocol_ui.py
+++ b/tests/test_ve_protocol_ui.py
@@ -10,7 +10,6 @@ from helianthus_vrc_explorer.ui.html_report import (
     _substitute_template,
 )
 
-
 # ---------------------------------------------------------------------------
 # VE17-R2: B555 timer must reject impossible time values
 # ---------------------------------------------------------------------------

--- a/tests/test_ve_protocol_ui.py
+++ b/tests/test_ve_protocol_ui.py
@@ -135,3 +135,51 @@ class TestVE26R3PlaceholderCollision:
             "__A__ and __B__", {"__A__": "1", "__B__": "2"}
         )
         assert result == "1 and 2"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial tests added by angry-tester audit
+# ---------------------------------------------------------------------------
+
+
+class TestAdvXssInTitle:
+    """ADV: HTML title containing XSS payload and placeholder collision."""
+
+    def test_script_tag_in_title_escaped(self) -> None:
+        """Title with <script>alert(1)</script> must be HTML-escaped."""
+        xss_title = '<script>alert(1)</script>'
+        result = _json_for_html({"title": xss_title})
+        # _json_for_html escapes angle brackets
+        assert "<script>" not in result
+        assert "<" not in result
+        assert ">" not in result
+
+    def test_artifact_json_placeholder_in_title_no_collision(self) -> None:
+        """Title containing __ARTIFACT_JSON__ must not collide with real data."""
+        template = "<title>__TITLE__</title><data>__ARTIFACT_JSON__</data>"
+        result = _substitute_template(
+            template,
+            {
+                "__TITLE__": "__ARTIFACT_JSON__",
+                "__ARTIFACT_JSON__": '{"real":"data"}',
+            },
+        )
+        assert "<title>__ARTIFACT_JSON__</title>" in result
+        assert '<data>{"real":"data"}</data>' in result
+        # The title must NOT get replaced in a second pass
+        assert "__ARTIFACT_JSON__" in result.split("</title>")[0]
+
+    def test_script_in_artifact_json_escaped(self) -> None:
+        """Artifact data containing script tag must be escaped by _json_for_html."""
+        result = _json_for_html({"payload": "<script>alert(1)</script>"})
+        assert "<script>" not in result
+
+    def test_title_with_nested_placeholders(self) -> None:
+        """Title value itself contains __TITLE__ -- must not recurse."""
+        template = "<h1>__TITLE__</h1>"
+        result = _substitute_template(
+            template,
+            {"__TITLE__": "Hello __TITLE__ World"},
+        )
+        # Single-pass substitution: the inner __TITLE__ is literal, not expanded again
+        assert result == "<h1>Hello __TITLE__ World</h1>"

--- a/tests/test_ve_protocol_ui.py
+++ b/tests/test_ve_protocol_ui.py
@@ -1,0 +1,137 @@
+"""Tests for VE17-R2, VE18-R3, VE26-R3 -- protocol and UI fixes."""
+
+from __future__ import annotations
+
+import pytest
+
+from helianthus_vrc_explorer.protocol.b555 import parse_b555_timer_read_response
+from helianthus_vrc_explorer.ui.html_report import (
+    _json_for_html,
+    _substitute_template,
+)
+
+
+# ---------------------------------------------------------------------------
+# VE17-R2: B555 timer must reject impossible time values
+# ---------------------------------------------------------------------------
+
+
+def _timer_payload(
+    status: int, sh: int, sm: int, eh: int, em: int, temp: int = 0xFFFF
+) -> bytes:
+    """Build a 7-byte B555 A5 response payload."""
+    return bytes((status, sh, sm, eh, em)) + temp.to_bytes(2, "little")
+
+
+class TestVE17R2TimerValidation:
+    """VE17-R2: B555 timer must reject impossible time values."""
+
+    def test_hour_25_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid start hour"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 25, 0, 22, 0))
+
+    def test_end_hour_25_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid end hour"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 6, 0, 25, 0))
+
+    def test_minute_60_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid start minute"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 6, 60, 22, 0))
+
+    def test_end_minute_60_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid end minute"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 6, 0, 22, 60))
+
+    def test_hour_0xff_sentinel_accepted(self) -> None:
+        result = parse_b555_timer_read_response(
+            _timer_payload(0x00, 0xFF, 0xFF, 0xFF, 0xFF)
+        )
+        assert result.start_hour == 0xFF
+        assert result.end_hour == 0xFF
+
+    def test_valid_time_accepted(self) -> None:
+        result = parse_b555_timer_read_response(
+            _timer_payload(0x00, 6, 30, 22, 45)
+        )
+        assert result.start_hour == 6
+        assert result.start_minute == 30
+        assert result.end_hour == 22
+        assert result.end_minute == 45
+
+    def test_boundary_23_59_accepted(self) -> None:
+        result = parse_b555_timer_read_response(
+            _timer_payload(0x00, 23, 59, 0, 0)
+        )
+        assert result.start_hour == 23
+        assert result.start_minute == 59
+
+    def test_hour_24_minute_0_accepted(self) -> None:
+        """24:00 is a valid eBUS encoding for end-of-day."""
+        result = parse_b555_timer_read_response(
+            _timer_payload(0x00, 0, 0, 24, 0)
+        )
+        assert result.end_hour == 24
+        assert result.end_minute == 0
+
+    def test_hour_24_minute_30_rejected(self) -> None:
+        """24:30 is not valid -- only 24:00 is allowed."""
+        with pytest.raises(ValueError, match="24:30"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 0, 0, 24, 30))
+
+
+# ---------------------------------------------------------------------------
+# VE18-R3: _json_for_html must escape single quotes
+# ---------------------------------------------------------------------------
+
+
+class TestVE18R3SingleQuoteEscape:
+    """VE18-R3: _json_for_html must escape single quotes."""
+
+    def test_single_quote_escaped(self) -> None:
+        result = _json_for_html({"key": "it's a test"})
+        assert "'" not in result
+        assert "\\u0027" in result
+
+    def test_angle_brackets_still_escaped(self) -> None:
+        result = _json_for_html({"x": "</script>"})
+        assert "<" not in result
+        assert ">" not in result
+
+    def test_ampersand_still_escaped(self) -> None:
+        result = _json_for_html({"x": "a&b"})
+        assert "&" not in result
+
+
+# ---------------------------------------------------------------------------
+# VE26-R3: Template substitution must not allow placeholder collision
+# ---------------------------------------------------------------------------
+
+
+class TestVE26R3PlaceholderCollision:
+    """VE26-R3: Template substitution must not allow placeholder collision."""
+
+    def test_title_containing_placeholder_is_safe(self) -> None:
+        template = "<title>__TITLE__</title><data>__ARTIFACT_JSON__</data>"
+        result = _substitute_template(
+            template,
+            {
+                "__TITLE__": "__ARTIFACT_JSON__",
+                "__ARTIFACT_JSON__": "real-json-data",
+            },
+        )
+        # Title should contain the literal string "__ARTIFACT_JSON__",
+        # NOT "real-json-data".
+        assert "<title>__ARTIFACT_JSON__</title>" in result
+        assert "<data>real-json-data</data>" in result
+
+    def test_unknown_placeholder_preserved(self) -> None:
+        result = _substitute_template(
+            "Hello __UNKNOWN__", {"__TITLE__": "x"}
+        )
+        assert result == "Hello __UNKNOWN__"
+
+    def test_all_placeholders_substituted(self) -> None:
+        result = _substitute_template(
+            "__A__ and __B__", {"__A__": "1", "__B__": "2"}
+        )
+        assert result == "1 and 2"

--- a/tests/test_ve_protocol_ui.py
+++ b/tests/test_ve_protocol_ui.py
@@ -15,9 +15,7 @@ from helianthus_vrc_explorer.ui.html_report import (
 # ---------------------------------------------------------------------------
 
 
-def _timer_payload(
-    status: int, sh: int, sm: int, eh: int, em: int, temp: int = 0xFFFF
-) -> bytes:
+def _timer_payload(status: int, sh: int, sm: int, eh: int, em: int, temp: int = 0xFFFF) -> bytes:
     """Build a 7-byte B555 A5 response payload."""
     return bytes((status, sh, sm, eh, em)) + temp.to_bytes(2, "little")
 
@@ -42,33 +40,25 @@ class TestVE17R2TimerValidation:
             parse_b555_timer_read_response(_timer_payload(0x00, 6, 0, 22, 60))
 
     def test_hour_0xff_sentinel_accepted(self) -> None:
-        result = parse_b555_timer_read_response(
-            _timer_payload(0x00, 0xFF, 0xFF, 0xFF, 0xFF)
-        )
+        result = parse_b555_timer_read_response(_timer_payload(0x00, 0xFF, 0xFF, 0xFF, 0xFF))
         assert result.start_hour == 0xFF
         assert result.end_hour == 0xFF
 
     def test_valid_time_accepted(self) -> None:
-        result = parse_b555_timer_read_response(
-            _timer_payload(0x00, 6, 30, 22, 45)
-        )
+        result = parse_b555_timer_read_response(_timer_payload(0x00, 6, 30, 22, 45))
         assert result.start_hour == 6
         assert result.start_minute == 30
         assert result.end_hour == 22
         assert result.end_minute == 45
 
     def test_boundary_23_59_accepted(self) -> None:
-        result = parse_b555_timer_read_response(
-            _timer_payload(0x00, 23, 59, 0, 0)
-        )
+        result = parse_b555_timer_read_response(_timer_payload(0x00, 23, 59, 0, 0))
         assert result.start_hour == 23
         assert result.start_minute == 59
 
     def test_hour_24_minute_0_accepted(self) -> None:
         """24:00 is a valid eBUS encoding for end-of-day."""
-        result = parse_b555_timer_read_response(
-            _timer_payload(0x00, 0, 0, 24, 0)
-        )
+        result = parse_b555_timer_read_response(_timer_payload(0x00, 0, 0, 24, 0))
         assert result.end_hour == 24
         assert result.end_minute == 0
 
@@ -124,15 +114,11 @@ class TestVE26R3PlaceholderCollision:
         assert "<data>real-json-data</data>" in result
 
     def test_unknown_placeholder_preserved(self) -> None:
-        result = _substitute_template(
-            "Hello __UNKNOWN__", {"__TITLE__": "x"}
-        )
+        result = _substitute_template("Hello __UNKNOWN__", {"__TITLE__": "x"})
         assert result == "Hello __UNKNOWN__"
 
     def test_all_placeholders_substituted(self) -> None:
-        result = _substitute_template(
-            "__A__ and __B__", {"__A__": "1", "__B__": "2"}
-        )
+        result = _substitute_template("__A__ and __B__", {"__A__": "1", "__B__": "2"})
         assert result == "1 and 2"
 
 
@@ -146,7 +132,7 @@ class TestAdvXssInTitle:
 
     def test_script_tag_in_title_escaped(self) -> None:
         """Title with <script>alert(1)</script> must be HTML-escaped."""
-        xss_title = '<script>alert(1)</script>'
+        xss_title = "<script>alert(1)</script>"
         result = _json_for_html({"title": xss_title})
         # _json_for_html escapes angle brackets
         assert "<script>" not in result

--- a/tests/test_ve_scanner_integrity.py
+++ b/tests/test_ve_scanner_integrity.py
@@ -231,3 +231,66 @@ class TestVE18R2ErrorSanitisation:
         source = inspect.getsource(register.read_register)
         # Must use the sanitised form, not the raw exc string.
         assert "type(exc).__name__" in source
+
+
+# ---------------------------------------------------------------------------
+# Adversarial tests added by angry-tester audit
+# ---------------------------------------------------------------------------
+
+
+class TestAdvAllNanF32Constraint:
+    """ADV: All three f32 constraint values are NaN."""
+
+    def test_all_nan_f32_produces_all_none(self) -> None:
+        nan_bytes = struct.pack("<f", float("nan"))
+        body = nan_bytes + nan_bytes + nan_bytes
+        response = _make_response(0x0F, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.min_value is None
+        assert entry.max_value is None
+        assert entry.step_value is None
+        assert entry.kind == "f32_range"
+
+    def test_all_inf_f32_produces_all_none(self) -> None:
+        inf_bytes = struct.pack("<f", float("inf"))
+        neg_inf_bytes = struct.pack("<f", float("-inf"))
+        body = neg_inf_bytes + inf_bytes + inf_bytes
+        response = _make_response(0x0F, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.min_value is None
+        assert entry.max_value is None
+        assert entry.step_value is None
+
+
+class TestAdvDateEdgeCases:
+    """ADV: Additional impossible and boundary dates."""
+
+    def test_dec_31_accepted(self) -> None:
+        result = _decode_constraint_date(bytes((31, 12, 26)))  # Dec 31, 2026
+        assert result == "2026-12-31"
+
+    def test_feb_29_2100_rejected(self) -> None:
+        """2100 is NOT a leap year (divisible by 100 but not 400)."""
+        # year byte = 100 -> year 2100
+        with pytest.raises(ValueError, match="Invalid date triplet"):
+            _decode_constraint_date(bytes((29, 2, 100)))
+
+    def test_month_13_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            _decode_constraint_date(bytes((15, 13, 26)))
+
+    def test_jun_31_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid date triplet"):
+            _decode_constraint_date(bytes((31, 6, 26)))
+
+
+class TestAdvB509RangeExact4097:
+    """ADV: B509 range exactly at 4097 (one above cap)."""
+
+    def test_range_4097_rejected(self) -> None:
+        with pytest.raises(ValueError, match="too large"):
+            parse_b509_range("0x0000..0x1000")
+
+    def test_range_4096_plus_offset_rejected(self) -> None:
+        with pytest.raises(ValueError, match="too large"):
+            parse_b509_range("0x0100..0x1100")

--- a/tests/test_ve_scanner_integrity.py
+++ b/tests/test_ve_scanner_integrity.py
@@ -1,4 +1,5 @@
 """Tests for VE27, VE29, VE30, and C7 scanner subsystem fixes."""
+
 from __future__ import annotations
 
 import struct
@@ -111,21 +112,13 @@ class TestVE30StepZero:
         assert entry.step_value == 5
 
     def test_u16_step_zero_becomes_none(self) -> None:
-        body = (
-            (0).to_bytes(2, "little")
-            + (1000).to_bytes(2, "little")
-            + (0).to_bytes(2, "little")
-        )
+        body = (0).to_bytes(2, "little") + (1000).to_bytes(2, "little") + (0).to_bytes(2, "little")
         response = _make_response(0x09, body)
         entry = _parse_constraint_entry(group=GG, register=RR, response=response)
         assert entry.step_value is None
 
     def test_u16_step_nonzero_preserved(self) -> None:
-        body = (
-            (0).to_bytes(2, "little")
-            + (500).to_bytes(2, "little")
-            + (10).to_bytes(2, "little")
-        )
+        body = (0).to_bytes(2, "little") + (500).to_bytes(2, "little") + (10).to_bytes(2, "little")
         response = _make_response(0x09, body)
         entry = _parse_constraint_entry(group=GG, register=RR, response=response)
         assert entry.step_value == 10

--- a/tests/test_ve_scanner_integrity.py
+++ b/tests/test_ve_scanner_integrity.py
@@ -1,7 +1,6 @@
 """Tests for VE27, VE29, VE30, and C7 scanner subsystem fixes."""
 from __future__ import annotations
 
-import math
 import struct
 
 import pytest
@@ -10,7 +9,6 @@ from helianthus_vrc_explorer.scanner.b509 import parse_b509_range
 from helianthus_vrc_explorer.scanner.plan import parse_int_set
 from helianthus_vrc_explorer.scanner.register import _sentinel_value_display
 from helianthus_vrc_explorer.scanner.scan import (
-    ConstraintEntry,
     _decode_constraint_date,
     _parse_constraint_entry,
 )

--- a/tests/test_ve_scanner_integrity.py
+++ b/tests/test_ve_scanner_integrity.py
@@ -1,4 +1,4 @@
-"""Tests for VE27, VE29, VE30 — scanner data integrity guards."""
+"""Tests for VE27, VE29, VE30, and C7 scanner subsystem fixes."""
 from __future__ import annotations
 
 import math
@@ -6,6 +6,9 @@ import struct
 
 import pytest
 
+from helianthus_vrc_explorer.scanner.b509 import parse_b509_range
+from helianthus_vrc_explorer.scanner.plan import parse_int_set
+from helianthus_vrc_explorer.scanner.register import _sentinel_value_display
 from helianthus_vrc_explorer.scanner.scan import (
     ConstraintEntry,
     _decode_constraint_date,
@@ -128,3 +131,103 @@ class TestVE30StepZero:
         response = _make_response(0x09, body)
         entry = _parse_constraint_entry(group=GG, register=RR, response=response)
         assert entry.step_value == 10
+
+
+# ---- C7 scanner subsystem fixes ----
+
+
+class TestVE27R2B509Opcode:
+    """VE27-R2: B509 opcode field must be 0x09, not 0x0d."""
+
+    def test_b509_register_entry_uses_0x09(self) -> None:
+        """The B509RegisterEntry TypedDict uses '0x09' in the op field."""
+        # We verify at the source level: the hardcoded literal in scan_b509
+        # is "0x09" (not the old incorrect "0x0d").
+        import inspect
+
+        from helianthus_vrc_explorer.scanner import b509
+
+        source = inspect.getsource(b509.scan_b509)
+        assert '"0x09"' in source or "'0x09'" in source
+        assert '"0x0d"' not in source and "'0x0d'" not in source
+
+
+class TestVE16R2B509RangeCap:
+    """VE16-R2: B509 scan range must be capped at 4096."""
+
+    def test_range_within_cap_accepted(self) -> None:
+        start, end = parse_b509_range("0x2700..0x27FF")
+        assert end - start + 1 == 256
+
+    def test_range_at_cap_accepted(self) -> None:
+        start, end = parse_b509_range("0x0000..0x0FFF")
+        assert end - start + 1 == 4096
+
+    def test_range_exceeding_cap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="too large"):
+            parse_b509_range("0x0000..0x1000")  # 4097 addresses
+
+    def test_full_address_space_rejected(self) -> None:
+        with pytest.raises(ValueError, match="too large"):
+            parse_b509_range("0x0000..0xFFFF")
+
+
+class TestVE23R3ParseIntSetDotDotRange:
+    """VE23-R3: parse_int_set supports '..' as unambiguous hex range separator."""
+
+    def test_dot_dot_hex_range(self) -> None:
+        result = parse_int_set("0x0A..0x0F", min_value=0, max_value=255)
+        assert result == [10, 11, 12, 13, 14, 15]
+
+    def test_dot_dot_decimal_range(self) -> None:
+        result = parse_int_set("10..15", min_value=0, max_value=255)
+        assert result == [10, 11, 12, 13, 14, 15]
+
+    def test_dot_dot_mixed_with_commas(self) -> None:
+        result = parse_int_set("0x00..0x02,5,0x0A..0x0C", min_value=0, max_value=255)
+        assert result == [0, 1, 2, 5, 10, 11, 12]
+
+
+class TestVE24R3U32Sentinel:
+    """VE24-R3: U32 sentinel 0xFFFFFFFF must be annotated."""
+
+    def test_u32_sentinel_detected(self) -> None:
+        result = _sentinel_value_display(
+            value=0xFFFFFFFF,
+            raw_hex="ffffffff",
+            value_type="U32",
+        )
+        assert result is not None
+        assert "sentinel" in result
+        assert "0xFFFFFFFF" in result
+
+    def test_u32_non_sentinel_returns_none(self) -> None:
+        result = _sentinel_value_display(
+            value=42,
+            raw_hex="2a000000",
+            value_type="U32",
+        )
+        assert result is None
+
+    def test_i32_sentinel_still_works(self) -> None:
+        result = _sentinel_value_display(
+            value=0x7FFFFFFF,
+            raw_hex="ffffff7f",
+            value_type="I32",
+        )
+        assert result is not None
+        assert "0x7FFFFFFF" in result
+
+
+class TestVE18R2ErrorSanitisation:
+    """VE18-R2: Transport error text must not leak endpoint details."""
+
+    def test_error_format_uses_class_name_only(self) -> None:
+        """Verify the error string template uses type(exc).__name__."""
+        import inspect
+
+        from helianthus_vrc_explorer.scanner import register
+
+        source = inspect.getsource(register.read_register)
+        # Must use the sanitised form, not the raw exc string.
+        assert "type(exc).__name__" in source

--- a/tests/test_ve_scanner_integrity.py
+++ b/tests/test_ve_scanner_integrity.py
@@ -1,0 +1,130 @@
+"""Tests for VE27, VE29, VE30 — scanner data integrity guards."""
+from __future__ import annotations
+
+import math
+import struct
+
+import pytest
+
+from helianthus_vrc_explorer.scanner.scan import (
+    ConstraintEntry,
+    _decode_constraint_date,
+    _parse_constraint_entry,
+)
+
+# Header helper: tt + group(0x01) + register(0x02) + extra(0x00)
+GG = 0x01
+RR = 0x02
+
+
+def _make_response(tt: int, body: bytes) -> bytes:
+    return bytes((tt, GG, RR, 0x00)) + body
+
+
+class TestVE27NanInfGuard:
+    """VE27: f32 NaN/Inf must not produce invalid JSON."""
+
+    def test_nan_min_replaced_with_none(self) -> None:
+        nan_bytes = struct.pack("<f", float("nan"))
+        normal = struct.pack("<f", 1.0)
+        body = nan_bytes + normal + normal
+        response = _make_response(0x0F, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.min_value is None
+        assert entry.max_value == pytest.approx(1.0)
+        assert entry.step_value == pytest.approx(1.0)
+
+    def test_inf_max_replaced_with_none(self) -> None:
+        normal = struct.pack("<f", 0.0)
+        inf_bytes = struct.pack("<f", float("inf"))
+        body = normal + inf_bytes + normal
+        response = _make_response(0x0F, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.min_value == pytest.approx(0.0)
+        assert entry.max_value is None
+
+    def test_neg_inf_step_replaced_with_none(self) -> None:
+        normal = struct.pack("<f", 0.0)
+        neg_inf = struct.pack("<f", float("-inf"))
+        body = normal + normal + neg_inf
+        response = _make_response(0x0F, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.step_value is None
+
+    def test_normal_f32_preserved(self) -> None:
+        body = struct.pack("<f", 5.0) + struct.pack("<f", 95.0) + struct.pack("<f", 0.5)
+        response = _make_response(0x0F, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.min_value == pytest.approx(5.0)
+        assert entry.max_value == pytest.approx(95.0)
+        assert entry.step_value == pytest.approx(0.5)
+
+
+class TestVE29ImpossibleDate:
+    """VE29: Impossible dates must be rejected."""
+
+    def test_feb_30_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid date triplet"):
+            _decode_constraint_date(bytes((30, 2, 26)))  # Feb 30, 2026
+
+    def test_apr_31_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid date triplet"):
+            _decode_constraint_date(bytes((31, 4, 26)))  # Apr 31, 2026
+
+    def test_feb_29_non_leap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid date triplet"):
+            _decode_constraint_date(bytes((29, 2, 25)))  # Feb 29, 2025 (non-leap)
+
+    def test_feb_29_leap_accepted(self) -> None:
+        result = _decode_constraint_date(bytes((29, 2, 24)))  # Feb 29, 2024 (leap)
+        assert result == "2024-02-29"
+
+    def test_valid_date_passes(self) -> None:
+        result = _decode_constraint_date(bytes((15, 6, 26)))  # Jun 15, 2026
+        assert result == "2026-06-15"
+
+    def test_month_zero_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            _decode_constraint_date(bytes((15, 0, 26)))
+
+    def test_day_zero_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            _decode_constraint_date(bytes((0, 6, 26)))
+
+
+class TestVE30StepZero:
+    """VE30: step=0 must be replaced with None to prevent division-by-zero."""
+
+    def test_u8_step_zero_becomes_none(self) -> None:
+        body = bytes((0, 255, 0))  # min=0, max=255, step=0
+        response = _make_response(0x06, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.step_value is None
+        assert entry.min_value == 0
+        assert entry.max_value == 255
+
+    def test_u8_step_nonzero_preserved(self) -> None:
+        body = bytes((0, 100, 5))
+        response = _make_response(0x06, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.step_value == 5
+
+    def test_u16_step_zero_becomes_none(self) -> None:
+        body = (
+            (0).to_bytes(2, "little")
+            + (1000).to_bytes(2, "little")
+            + (0).to_bytes(2, "little")
+        )
+        response = _make_response(0x09, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.step_value is None
+
+    def test_u16_step_nonzero_preserved(self) -> None:
+        body = (
+            (0).to_bytes(2, "little")
+            + (500).to_bytes(2, "little")
+            + (10).to_bytes(2, "little")
+        )
+        response = _make_response(0x09, body)
+        entry = _parse_constraint_entry(group=GG, register=RR, response=response)
+        assert entry.step_value == 10

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,631 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "helianthus-vrc-explorer"
+version = "0.2.1"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "rich" },
+    { name = "textual" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pillow" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.24" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "pillow", marker = "extra == 'dev'", specifier = ">=10" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5" },
+    { name = "rich", specifier = ">=13" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "textual", specifier = ">=0.82" },
+    { name = "typer", specifier = ">=0.9" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/1b/75a7c825a02781ca10bc2f2f12fba2af5202f6d6005aad8d2d1f264d8d78/mypy-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:36ee2b9c6599c230fea89bbd79f401f9f9f8e9fcf0c777827789b19b7da90f51", size = 14494077, upload-time = "2026-04-13T02:45:55.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/54/5e5a569ea5c2b4d48b729fb32aa936eeb4246e4fc3e6f5b3d36a2dfbefb9/mypy-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fba3fb0968a7b48806b0c90f38d39296f10766885a94c83bd21399de1e14eb28", size = 13319495, upload-time = "2026-04-13T02:45:29.674Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a4/a1945b19f33e91721b59deee3abb484f2fa5922adc33bb166daf5325d76d/mypy-1.20.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef1415a637cd3627d6304dfbeddbadd21079dafc2a8a753c477ce4fc0c2af54f", size = 13696948, upload-time = "2026-04-13T02:46:15.006Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/75e969781c2359b2f9c15b061f28ec6d67c8b61865ceda176e85c8e7f2de/mypy-1.20.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef3461b1ad5cd446e540016e90b5984657edda39f982f4cc45ca317b628f5a37", size = 14706744, upload-time = "2026-04-13T02:46:00.482Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/6e/b221b1de981fc4262fe3e0bf9ec272d292dfe42394a689c2d49765c144c4/mypy-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:542dd63c9e1339b6092eb25bd515f3a32a1453aee8c9521d2ddb17dacd840237", size = 14949035, upload-time = "2026-04-13T02:45:06.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4b/298ba2de0aafc0da3ff2288da06884aae7ba6489bc247c933f87847c41b3/mypy-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d55c7cd8ca22e31f93af2a01160a9e95465b5878de23dba7e48116052f20a8d", size = 10883216, upload-time = "2026-04-13T02:45:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f9/5e25b8f0b8cb92f080bfed9c21d3279b2a0b6a601cdca369a039ba84789d/mypy-1.20.1-cp312-cp312-win_arm64.whl", hash = "sha256:f5b84a79070586e0d353ee07b719d9d0a4aa7c8ee90c0ea97747e98cbe193019", size = 9814299, upload-time = "2026-04-13T02:45:21.934Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e8/ef0991aa24c8f225df10b034f3c2681213cb54cf247623c6dec9a5744e70/mypy-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f3886c03e40afefd327bd70b3f634b39ea82e87f314edaa4d0cce4b927ddcc1", size = 14500739, upload-time = "2026-04-13T02:46:05.442Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/416ebec3047636ed89fa871dc8c54bf05e9e20aa9499da59790d7adb312d/mypy-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e860eb3904f9764e83bafd70c8250bdffdc7dde6b82f486e8156348bf7ceb184", size = 13314735, upload-time = "2026-04-13T02:46:47.154Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1e/1505022d9c9ac2e014a384eb17638fb37bf8e9d0a833ea60605b66f8f7ba/mypy-1.20.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4b5aac6e785719da51a84f5d09e9e843d473170a9045b1ea7ea1af86225df4b", size = 13704356, upload-time = "2026-04-13T02:45:19.773Z" },
+    { url = "https://files.pythonhosted.org/packages/98/91/275b01f5eba5c467a3318ec214dd865abb66e9c811231c8587287b92876a/mypy-1.20.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f37b6cd0fe2ad3a20f05ace48ca3523fc52ff86940e34937b439613b6854472e", size = 14696420, upload-time = "2026-04-13T02:45:24.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/57/b3779e134e1b7250d05f874252780d0a88c068bc054bcff99ca20a3a2986/mypy-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4bbb0f6b54ce7cc350ef4a770650d15fa70edd99ad5267e227133eda9c94218", size = 14936093, upload-time = "2026-04-13T02:45:32.087Z" },
+    { url = "https://files.pythonhosted.org/packages/be/33/81b64991b0f3f278c3b55c335888794af190b2d59031a5ad1401bcb69f1e/mypy-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:c3dc20f8ec76eecd77148cdd2f1542ed496e51e185713bf488a414f862deb8f2", size = 10889659, upload-time = "2026-04-13T02:46:02.926Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fd/7adcb8053572edf5ef8f3db59599dfeeee3be9cc4c8c97e2d28f66f42ac5/mypy-1.20.1-cp313-cp313-win_arm64.whl", hash = "sha256:a9d62bbac5d6d46718e2b0330b25e6264463ed832722b8f7d4440ff1be3ca895", size = 9815515, upload-time = "2026-04-13T02:46:32.103Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/db831e84c81d57d4886d99feee14e372f64bbec6a9cb1a88a19e243f2ef5/mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12", size = 14483064, upload-time = "2026-04-13T02:45:26.901Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/82/74e62e7097fa67da328ac8ece8de09133448c04d20ddeaeba251a3000f01/mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe", size = 13335694, upload-time = "2026-04-13T02:46:12.514Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/97e9a0abe4f3cdbbf4d079cb87a03b786efeccf5bf2b89fe4f96939ab2e6/mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08", size = 13726365, upload-time = "2026-04-13T02:45:17.422Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/aa/a19d884a8d28fcd3c065776323029f204dbc774e70ec9c85eba228b680de/mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572", size = 14693472, upload-time = "2026-04-13T02:46:41.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/cc9324bd21cf786592b44bf3b5d224b3923c1230ec9898d508d00241d465/mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6", size = 14919266, upload-time = "2026-04-13T02:46:28.37Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dc/779abb25a8c63e8f44bf5a336217fa92790fa17e0c40e0c725d10cb01bbd/mypy-1.20.1-cp314-cp314-win_amd64.whl", hash = "sha256:0131edd7eba289973d1ba1003d1a37c426b85cdef76650cd02da6420898a5eb3", size = 11049713, upload-time = "2026-04-13T02:45:57.673Z" },
+    { url = "https://files.pythonhosted.org/packages/28/08/4172be2ad7de9119b5a92ca36abbf641afdc5cb1ef4ae0c3a8182f29674f/mypy-1.20.1-cp314-cp314-win_arm64.whl", hash = "sha256:33f02904feb2c07e1fdf7909026206396c9deeb9e6f34d466b4cfedb0aadbbe4", size = 9999819, upload-time = "2026-04-13T02:46:35.039Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/af/af9e46b0c8eabbce9fc04a477564170f47a1c22b308822282a59b7ff315f/mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a", size = 15547508, upload-time = "2026-04-13T02:46:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/cd/39c9e4ad6ba33e069e5837d772a9e6c304b4a5452a14a975d52b36444650/mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986", size = 14399557, upload-time = "2026-04-13T02:46:10.021Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c1/3fd71bdc118ffc502bf57559c909927bb7e011f327f7bb8e0488e98a5870/mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a", size = 15045789, upload-time = "2026-04-13T02:45:10.81Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/73/6f07ff8b57a7d7b3e6e5bf34685d17632382395c8bb53364ec331661f83e/mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9", size = 15850795, upload-time = "2026-04-13T02:45:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e2/f7dffec1c7767078f9e9adf0c786d1fe0ff30964a77eb213c09b8b58cb76/mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02", size = 16088539, upload-time = "2026-04-13T02:46:17.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/76/e0dee71035316e75a69d73aec2f03c39c21c967b97e277fd0ef8fd6aec66/mypy-1.20.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a0c17fbd746d38c70cbc42647cfd884f845a9708a4b160a8b4f7e70d41f4d7fa", size = 12575567, upload-time = "2026-04-13T02:45:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a8/7ed43c9d9c3d1468f86605e323a5d97e411a448790a00f07e779f3211a46/mypy-1.20.1-cp314-cp314t-win_arm64.whl", hash = "sha256:db2cb89654626a912efda69c0d5c1d22d948265e2069010d3dde3abf751c7d08", size = 10378823, upload-time = "2026-04-13T02:45:13.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]


### PR DESCRIPTION
## Summary

Addresses **31 of 33** VRC Explorer audit findings from the consolidated adapter-mux audit report (`FINAL-CONSOLIDATED-AUDIT-REPORT.md`):

- **VE3**: Refuted (CRC XOR algorithm is correct per eBUS spec)
- **VE13**: Not applied — existing secondary header evidence fallback is intentionally correct (validated by 4 existing tests)
- **VE10**: Tracked separately in helianthus-docs-ebus#261 (different repo)
- **All other 30 findings**: Fixed with tests

### Findings by priority

**P0 — Data integrity:**
- VE1/VE20: Wire escape encoding documented + tested (ENH protocol handles this at adapter level)
- VE21/VE25: CRC escape expansion verified correct + tested
- VE27: f32 NaN/Inf guard (math.isfinite)
- VE29: Impossible date rejection (datetime.date validation)
- VE30: step=0 guard (None replacement)

**P1 — Thread safety & retry logic:**
- VE14/VE22/VE17: RLock for transport state, session depth floor guard
- VE4: Local NACK retry without re-arbitration (eBUS spec 7.4)
- VE11: Arbitration deadline extended on bus traffic
- VE23: Timeout retries cumulative (no reset on reconnect)
- VE33: Collision/nack counters reset on reconnect

**P1 — Transport recovery:**
- VE2: TransportHostError (non-retryable)
- VE5: TransportDisconnected with reconnect
- VE15: Malformed ENH byte graceful recovery (3-strike)
- VE24: Init timeout re-raised
- VE28: Unknown ENH command skip
- VE31: FAILED in bus read → collision retry

**P2 — Validation & scanner:**
- VE6/VE7: Reserved address rejection (0x00, 0xA9, 0xAA)
- VE19-R2: Config validation (timeout_s, port)
- VE8: CLI default src unified (0xF7)
- VE12/VE19: Socket buffer drain in _reset_parser
- VE26-R2: Cumulative response deadline
- VE16-R2: B509 range cap (4096)
- VE27-R2: B509 opcode fix (0x0d→0x09)
- VE32: Partial constraints on KeyboardInterrupt
- VE23-R3: '..' range separator for hex
- VE24-R3: U32 sentinel annotation
- VE25-R2: Accumulation comment
- VE18-R2: Error text sanitization

**P3 — Protocol & UI:**
- VE17-R2: B555 timer hour/minute validation
- VE18-R3: Single quote escape in JSON-for-HTML
- VE26-R3: Single-pass template substitution
- VE9: Non-daemon mock server threads

### Bug discovered during review

CRC=0xAA causes spurious TransportTimeout — pre-existing latent bug (not introduced by this PR). Documented in adversarial test `test_adv_crc_value_is_syn_byte_raises_timeout`.

## Test plan

- [x] 139 tests passing (86 new + 53 existing)
- [x] Adversarial scenarios: escape bytes, concurrent threads, reconnect storms, NaN/Inf, XSS, impossible dates
- [x] Code review by reviewer agent (1 BLOCK fixed, 5 WARN documented)
- [x] Angry-tester validation (+19 adversarial tests)
- [ ] Squash+merge after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)