### PR TITLE
fix(VE-NEW-07): STARTED mismatch counter (cross-product EG14/EG39)

### DIFF
--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -693,6 +693,7 @@ class EnhancedTcpTransport(TransportInterface):
         # Activity deadline resets on each RECEIVED frame, but the
         # absolute cap (10× timeout) is never extended.
         absolute_cap = now + self._config.timeout_s * 10
+        mismatch_count = 0
         while time.monotonic() < min(deadline, absolute_cap):
             kind, command, data = self._read_message()
             if kind != "frame":
@@ -706,6 +707,22 @@ class EnhancedTcpTransport(TransportInterface):
                 self._trace(f"START_RESP started initiator=0x{data:02X}")
                 self._reset_parser()
                 return
+            if command == _ENH_RES_STARTED and data != initiator:
+                # VE-NEW-07 / EG14/EG39: Abort early on repeated
+                # STARTED with wrong address instead of waiting for
+                # the full absolute cap timeout.
+                mismatch_count += 1
+                self._trace(
+                    f"START_RESP mismatch want=0x{initiator:02X} "
+                    f"got=0x{data:02X} (n={mismatch_count})"
+                )
+                if mismatch_count >= 3:
+                    self._reset_parser()
+                    raise _EnhancedCollision(
+                        f"Arbitration mismatch: expected 0x{initiator:02X}, "
+                        f"got 0x{data:02X} ({mismatch_count}× consecutive)"
+                    )
+                continue
             if command == _ENH_RES_FAILED:
                 self._trace(f"START_RESP failed winner=0x{data:02X}")
                 self._reset_parser()

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -937,3 +937,37 @@ def test_adv_send_symbol_escape_byte_explicit() -> None:
         result = transport.send(dst, payload)
     assert result == response
     assert 0xA9 in symbols_sent
+
+
+def test_ve_new_07_started_mismatch_aborts_early() -> None:
+    """VE-NEW-07 / EG14/EG39: Abort after 3 STARTED with wrong address."""
+    import pytest
+
+    src = 0xF7
+    wrong_addr = 0x10
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        # Reply with wrong address 3 times
+        for _ in range(3):
+            _write_enh_frame(conn, _ENH_RES_STARTED, wrong_addr)
+
+        import time as _time
+
+        _time.sleep(1.0)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(
+                host=host,
+                port=port,
+                timeout_s=5.0,
+                src=src,
+                collision_max_retries=0,
+            )
+        )
+        with pytest.raises(TransportError, match="mismatch"):
+            transport.send_proto(0x15, 0x07, 0x04, b"")


### PR DESCRIPTION
## Summary

Cross-product fix parallel to ebusgo EG14/EG39 (fixed in ebusgo PR #131).

`_start_arbitration()` now counts consecutive STARTED frames with a mismatched initiator address and aborts after 3, raising `_EnhancedCollision` instead of waiting for the full absolute cap timeout (~50s → ~1s).

## Test plan
- [x] `test_ve_new_07_started_mismatch_aborts_early` — mock sends 3× STARTED(wrong_addr), transport aborts in ~1s
- [x] All 34 transport tests passing
- [x] Lint, format, terminology gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)