### PR TITLE
fix: reset mismatch counter on RECEIVED traffic (PR #246 follow-up)

### DIFF
--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -702,6 +702,7 @@ class EnhancedTcpTransport(TransportInterface):
                 # VE11: Bus traffic extends activity deadline — received
                 # frames should not consume arbitration budget.
                 deadline = time.monotonic() + self._config.timeout_s
+                mismatch_count = 0  # Reset: non-mismatch traffic seen
                 continue
             if command == _ENH_RES_STARTED and data == initiator:
                 self._trace(f"START_RESP started initiator=0x{data:02X}")


### PR DESCRIPTION
Review feedback on PR #246: mismatch_count reset on RECEIVED frames for truly consecutive counting.

1-line fix. All 34 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)