### PR TITLE
fix(R6): mismatch counter alignment + B555 half-sentinel (R6-VE-NEW-01, R6-Codex-Cross-03)

### DIFF
--- a/src/helianthus_vrc_explorer/protocol/b555.py
+++ b/src/helianthus_vrc_explorer/protocol/b555.py
@@ -134,13 +134,21 @@ def parse_b555_timer_read_response(payload: bytes) -> B555TimerRead:
     # VE17-R2: Validate time components.
     # Allow 0xFF sentinel ("no timer") and 24:00 ("end of day").
     for label, h, m in (("start", sh, sm), ("end", eh, em)):
-        if h == 0xFF:
-            continue
+        # R6-Codex-Cross-03: Sentinel must be symmetric — both hour AND
+        # minute must be 0xFF for a valid sentinel.  Half-sentinel values
+        # like (0xFF, 30) or (12, 0xFF) produce impossible times.
+        if h == 0xFF and m == 0xFF:
+            continue  # Valid sentinel: "no timer"
+        if h == 0xFF or m == 0xFF:
+            raise ValueError(
+                f"Invalid {label} half-sentinel: hour=0x{h:02X} minute=0x{m:02X} "
+                f"(both must be 0xFF for sentinel)"
+            )
         if h > 24:
             raise ValueError(f"Invalid {label} hour: {h}")
         if h == 24 and m != 0:
             raise ValueError(f"Invalid {label} time: 24:{m:02d} (only 24:00 is valid)")
-        if m != 0xFF and m > 59:
+        if m > 59:
             raise ValueError(f"Invalid {label} minute: {m}")
     return B555TimerRead(
         status=blob[0],

--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -702,7 +702,10 @@ class EnhancedTcpTransport(TransportInterface):
                 # VE11: Bus traffic extends activity deadline — received
                 # frames should not consume arbitration budget.
                 deadline = time.monotonic() + self._config.timeout_s
-                mismatch_count = 0  # Reset: non-mismatch traffic seen
+                # R6-VE-NEW-01: Do NOT reset mismatch_count on RECEIVED.
+                # Aligns with Go StartArbitration behavior — prevents
+                # adversarial STARTED(wrong)+RECEIVED alternation from
+                # bypassing the 3-mismatch abort guard.
                 continue
             if command == _ENH_RES_STARTED and data == initiator:
                 self._trace(f"START_RESP started initiator=0x{data:02X}")

--- a/tests/test_ve_protocol_ui.py
+++ b/tests/test_ve_protocol_ui.py
@@ -67,6 +67,21 @@ class TestVE17R2TimerValidation:
         with pytest.raises(ValueError, match="24:30"):
             parse_b555_timer_read_response(_timer_payload(0x00, 0, 0, 24, 30))
 
+    def test_half_sentinel_hour_0xff_minute_normal_rejected(self) -> None:
+        """R6-Codex-Cross-03: hour=0xFF + minute=30 is an invalid half-sentinel."""
+        with pytest.raises(ValueError, match="half-sentinel"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 0xFF, 30, 0, 0))
+
+    def test_half_sentinel_hour_normal_minute_0xff_rejected(self) -> None:
+        """R6-Codex-Cross-03: hour=12 + minute=0xFF is an invalid half-sentinel."""
+        with pytest.raises(ValueError, match="half-sentinel"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 12, 0xFF, 0, 0))
+
+    def test_half_sentinel_end_time_rejected(self) -> None:
+        """R6-Codex-Cross-03: end time with half-sentinel rejected too."""
+        with pytest.raises(ValueError, match="half-sentinel"):
+            parse_b555_timer_read_response(_timer_payload(0x00, 6, 0, 0xFF, 15))
+
 
 # ---------------------------------------------------------------------------
 # VE18-R3: _json_for_html must escape single quotes


### PR DESCRIPTION
## Summary

Addresses R6 audit feedback findings:

- **R6-VE-NEW-01 + D1**: Remove mismatch_count reset on RECEIVED — aligns with Go, prevents adversarial bypass of 3-mismatch abort
- **R6-Codex-Cross-03**: B555 timer sentinel must be symmetric (both hour+minute = 0xFF)

## Disposition of other R6 findings

- **R6-VE-NEW-02 (LOW)**: timeout_retries cumulative is design-intent (VE23). Documented.
- **R6-Codex-Cross-02**: Subsumed by R6-VE-NEW-01 fix (mismatch counter no longer resets at all)
- **D2**: Python raises on FAILED (better than Go silent drop). No change.
- **D3**: Skip-at-dispatch vs reject-at-parse — current behavior acceptable, no action.
- **D4**: INFO not needed in VRC Explorer. Documented gap.

## Test plan
- [x] 66 tests passing (3 new half-sentinel tests)
- [x] ruff check + format + terminology clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)