### PR TITLE
fix: surface unknown ENH commands to callers (PR #248/#249 review)

### DIFF
--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -671,11 +671,12 @@ class EnhancedTcpTransport(TransportInterface):
         self._malformed_count = 0
         command = (first >> 2) & 0x0F
         data = ((first & 0x03) << 6) | (value & 0x3F)
-        # D3: Reject undefined ENH command nibbles at parse level
-        # (aligns with Go's stricter ErrInvalidPayload validation).
+        # D3: Log undefined ENH command nibbles at parse level.
+        # Still returned as ("frame", ...) so _read_message yields it to
+        # callers — prevents spin if adapter streams unknown frames, and
+        # lets deadline checks in _recv_bus_symbol/_start_arbitration fire.
         if command not in _ENH_VALID_RESPONSE_COMMANDS:
-            self._trace(f"Rejected undefined ENH command 0x{command:02X}")
-            return None
+            self._trace(f"Unknown ENH command 0x{command:02X} data=0x{data:02X}")
         return ("frame", command, data)
 
     def _init_transport(self, *, features: int) -> None:


### PR DESCRIPTION
Addresses review feedback on PRs #248 and #249.

**PR #249 P1**: Unknown ENH commands now returned as frames (not dropped) so callers can enforce deadlines.
**PR #248 P1**: Cumulative mismatch counter is correct — STARTED(wrong_addr) is abnormal. Documented in commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)