### PR TITLE
fix: suppress post-grant idle SYN before first echo (XR-SYN-GUARD, cross-product)

### DIFF
--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -470,6 +470,10 @@ class EnhancedTcpTransport(TransportInterface):
         self._messages = deque[tuple[str, int, int]]()
         self._enh_pending_first: int | None = None
         self._malformed_count: int = 0
+        # XR-SYN-GUARD: Suppress idle SYN bytes between arbitration grant and
+        # first real echo.  Same pattern as adaptermux AM-NEW-42, ebusgo
+        # postGrantPreEcho, proxy requestBytesSeen==0 guard.
+        self._post_grant_pre_echo: bool = False
         self._lock = threading.RLock()
 
     def _trace(self, message: str) -> None:
@@ -491,6 +495,9 @@ class EnhancedTcpTransport(TransportInterface):
         self._messages.clear()
         self._enh_pending_first = None
         self._malformed_count = 0
+        # XR-SYN-GUARD: Clear post-grant flag on reset — arbitration was
+        # torn down, so any subsequent echo will come from a fresh grant.
+        self._post_grant_pre_echo = False
         # VE12/VE19: Drain stale bytes from kernel TCP buffer.
         session = self._session
         if session is not None:
@@ -730,6 +737,11 @@ class EnhancedTcpTransport(TransportInterface):
             if command == _ENH_RES_STARTED and data == initiator:
                 self._trace(f"START_RESP started initiator=0x{data:02X}")
                 self._reset_parser()
+                # XR-SYN-GUARD: Arm post-grant SYN suppression.
+                # Idle SYN bytes arriving between STARTED and first send-echo
+                # must be discarded, not returned to the echo check.
+                # Set AFTER _reset_parser (which clears the flag).
+                self._post_grant_pre_echo = True
                 return
             if command == _ENH_RES_STARTED and data != initiator:
                 # VE-NEW-07 / EG14/EG39: Abort early on repeated
@@ -777,8 +789,18 @@ class EnhancedTcpTransport(TransportInterface):
         while time.monotonic() < deadline:
             kind, command, data = self._read_message()
             if kind == "data":
+                # XR-SYN-GUARD: Suppress idle SYN between grant and first echo.
+                if self._post_grant_pre_echo and command == _EBUS_SYN:
+                    self._trace(f"POST_GRANT_SYN suppressed data=0x{command:02X}")
+                    continue
+                self._post_grant_pre_echo = False
                 return command
             if command == _ENH_RES_RECEIVED:
+                # XR-SYN-GUARD: Suppress idle SYN between grant and first echo.
+                if self._post_grant_pre_echo and data == _EBUS_SYN:
+                    self._trace(f"POST_GRANT_SYN suppressed data=0x{data:02X}")
+                    continue
+                self._post_grant_pre_echo = False
                 return data
             if command == _ENH_RES_RESETTED:
                 self.close()
@@ -789,16 +811,21 @@ class EnhancedTcpTransport(TransportInterface):
             if command == _ENH_RES_FAILED:
                 # D2: Explicitly trace FAILED during response read (Go silently
                 # drops these — Python raises, which is stricter and correct).
+                self._post_grant_pre_echo = False
                 self._trace(f"BUS_READ_FAILED data=0x{data:02X}")
                 raise _EnhancedCollision(f"Bus FAILED during read (data=0x{data:02X})")
             if command == _ENH_RES_ERROR_EBUS:
+                self._post_grant_pre_echo = False
                 raise TransportError(f"enhanced bus read eBUS error 0x{data:02X}")
             if command == _ENH_RES_ERROR_HOST:
+                self._post_grant_pre_echo = False
                 raise TransportHostError(f"enhanced bus read host error 0x{data:02X}")
             # D3: Unreachable after parse-level rejection in _parse_enh_byte.
             # Kept as defense-in-depth safety net.
             self._trace(f"Unexpected ENH command 0x{command:02X} data=0x{data:02X}")
             continue
+        # XR-SYN-GUARD: Clear post-grant flag on timeout — no echo arrived.
+        self._post_grant_pre_echo = False
         raise TransportTimeout("Bus symbol read deadline expired")
 
     def _send_symbol_with_echo(self, symbol: int) -> None:

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -971,3 +971,106 @@ def test_ve_new_07_started_mismatch_aborts_early() -> None:
         )
         with pytest.raises(TransportError, match="mismatch"):
             transport.send_proto(0x15, 0x07, 0x04, b"")
+
+
+def test_send_symbol_with_echo_suppresses_post_grant_syn() -> None:
+    """XR-SYN-GUARD: Idle SYN bytes between STARTED and first echo are suppressed.
+
+    Same bug family as adaptermux AM-NEW-42, ebusgo postGrantPreEcho,
+    proxy requestBytesSeen==0 guard.
+
+    Race: adapter emits RECEIVED(0xAA) idle SYN between STARTED and
+    our first SEND.  Without suppression, _recv_bus_symbol returns
+    0xAA as the echo, which mismatches the real DST byte and raises
+    _EnhancedCollision.  With suppression, the SYN is silently
+    consumed and the real echo is returned.
+    """
+    src = 0xF1
+    dst = 0x15
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response = bytes((0x01,))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+
+        # Emit 2 idle SYN RECEIVED frames BEFORE the client sends its first byte.
+        _write_bus_symbol(conn, 0xAA)
+        _write_bus_symbol(conn, 0xAA)
+
+        # Client sends first telegram byte (dst).  Should get real echo,
+        # not the suppressed SYN.
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+
+        _write_bus_symbol(conn, 0x00)  # ACK
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(
+                host=host,
+                port=port,
+                timeout_s=2.0,
+                src=src,
+                collision_max_retries=0,
+            )
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    assert result == response
+
+
+def test_post_grant_syn_guard_clears_on_first_non_syn() -> None:
+    """XR-SYN-GUARD: Flag clears on first non-SYN byte, so SYN after echo
+    is treated as a real bus symbol (not suppressed)."""
+    src = 0xF1
+    dst = 0x15
+    # Response containing 0xAA as a legitimate data byte AFTER the first echo.
+    response = bytes((0xAA, 0x42))
+    request_without_crc = bytes((src, dst, 0x07, 0x04, 0x00))
+    request = request_without_crc + bytes((_crc(request_without_crc),))
+    response_segment = bytes((len(response),)) + response
+    response_crc = _crc(response_segment)
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_START, src)
+        _write_enh_frame(conn, _ENH_RES_STARTED, src)
+        # No idle SYN before first send — normal path.
+        for expected in request[1:]:
+            assert _read_enh_frame(conn) == (_ENH_REQ_SEND, expected)
+            _write_bus_symbol(conn, expected)
+        _write_bus_symbol(conn, 0x00)  # ACK
+        # Response contains 0xAA as data — must NOT be suppressed because
+        # the flag was cleared on the first echo.
+        for value in response_segment:
+            _write_bus_symbol(conn, value)
+        _write_bus_symbol(conn, response_crc)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0x00)
+        _write_bus_symbol(conn, 0x00)
+        assert _read_enh_frame(conn) == (_ENH_REQ_SEND, 0xAA)
+        _write_bus_symbol(conn, 0xAA)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(
+            EnhancedTcpConfig(host=host, port=port, timeout_s=2.0, src=src)
+        )
+        result = transport.send_proto(dst, 0x07, 0x04, b"")
+
+    # 0xAA in response must be preserved, not suppressed.
+    assert result == response


### PR DESCRIPTION
## Summary

Cross-product fix parallel to adaptermux **AM-NEW-42**, ebusgo **postGrantPreEcho**, proxy **requestBytesSeen==0 guard**.

Root-cause confirmed by Codex GPT-5.4 xhigh (2026-04-18).

### Race

1. `_start_arbitration()` receives STARTED, calls `_reset_parser()`, returns
2. Between `_reset_parser()` and first `_send_symbol_with_echo()`, adapter may emit `RECEIVED(0xAA)` (idle SYN)
3. First `_recv_bus_symbol()` reads the stale SYN → echo mismatch → `_EnhancedCollision`

### Fix (Option B)

- `_post_grant_pre_echo` flag, initialized `False`
- Set `True` in `_start_arbitration` after STARTED (post `_reset_parser`)
- `_recv_bus_symbol`: if flag set and byte is `0xAA`, skip; clear flag on first non-SYN, on any error, on timeout

### Test plan
- [x] `test_send_symbol_with_echo_suppresses_post_grant_syn`: 2× idle SYN → real echo
- [x] `test_post_grant_syn_guard_clears_on_first_non_syn`: response data 0xAA preserved
- [x] 36 transport tests passing
- [x] ruff + format + terminology clean

## Invariant

> Suppress idle SYN between arbitration grant and first real echo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)