### PR TITLE
fix(transport): ignore unsolicited RECEIVED during INFO

### DIFF
--- a/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
+++ b/src/helianthus_vrc_explorer/transport/enhanced_tcp.py
@@ -957,6 +957,12 @@ class EnhancedTcpTransport(TransportInterface):
                     self.close()
                     self._open_session()
                     raise TransportTimeout(f"Adapter reset during INFO (features=0x{data:02X})")
+                if command == _ENH_RES_RECEIVED:
+                    # Busy-bus background traffic can still surface as RECEIVED
+                    # while an INFO request is pending. That frame is unrelated
+                    # to the INFO response and must not fail the request.
+                    self._trace(f"INFO ignore RECEIVED data=0x{data:02X}")
+                    continue
                 # Unknown command in INFO path — explicit error, not timeout.
                 self._reset_parser()
                 raise TransportError(

--- a/tests/test_transport_enhanced_tcp.py
+++ b/tests/test_transport_enhanced_tcp.py
@@ -1419,6 +1419,30 @@ def test_xr2_info_unknown_command_explicit_error() -> None:
             transport.request_info(0x00)
 
 
+def test_xr2_info_ignores_unsolicited_received() -> None:
+    """XR2: unsolicited RECEIVED during INFO wait is busy-bus background traffic.
+
+    The adapter may surface _ENH_RES_RECEIVED while other masters are active.
+    request_info() must ignore that frame and continue waiting for the INFO
+    payload instead of failing the request.
+    """
+
+    def _handler(conn: socket.socket) -> None:
+        assert _read_enh_frame(conn) == (_ENH_REQ_INIT, 0x01)
+        _write_enh_frame(conn, _ENH_RES_RESETTED, 0x01)
+        assert _read_enh_frame(conn) == (_ENH_REQ_INFO, 0x00)
+        _write_enh_frame(conn, _ENH_RES_RECEIVED, 0xAA)
+        _write_enh_frame(conn, _ENH_RES_INFO, 0x01)
+        _write_enh_frame(conn, _ENH_RES_INFO, 0x42)
+
+    with _run_ens_test_server(_handler) as (host, port):
+        transport = EnhancedTcpTransport(EnhancedTcpConfig(host=host, port=port, timeout_s=2.0))
+        with transport.session():
+            result = transport.request_info(0x00)
+
+    assert result == b"\x42"
+
+
 def test_xr2_info_truncated_payload_timeout() -> None:
     """XR2 negative: INFO with length=3 but only 1 data frame times out."""
     import pytest


### PR DESCRIPTION
## What
Ignore unsolicited `_ENH_RES_RECEIVED` frames while `request_info()` is waiting for an INFO response.

## Why
On a busy bus, ENH adapters can surface background `RECEIVED` traffic caused by other masters while an INFO request is pending. Treating every non-INFO/non-error/non-reset frame as fatal causes false INFO failures even though the adapter would return INFO correctly a moment later. This addresses the remaining review comment from PR #251.

## Acceptance Criteria
- [x] `request_info()` ignores `_ENH_RES_RECEIVED` and continues waiting for INFO payload frames
- [x] Unknown ENH commands in INFO path still raise explicit `TransportError`
- [x] Added regression test covering unsolicited `RECEIVED` during INFO wait
- [x] Lint/type/tests green locally
- [x] CI green

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/python scripts/check_protocol_terminology.py`
- `.venv/bin/python scripts/check_b524_namespace_guardrails.py`
- `.venv/bin/python scripts/check_docs_sync.py`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src`
- `PYTHONPATH=src .venv/bin/pytest tests/test_transport_enhanced_tcp.py -k 'info'`
- `PYTHONPATH=src .venv/bin/pytest`

## Notes
Status: open
Branch: issue/252-info-ignore-received
Last verified (lint/tests): local checks green on 2026-04-23
How to reproduce: inject `_ENH_RES_RECEIVED` before `_ENH_RES_INFO` in the INFO response loop
Next steps: wait for CI + review bot
Notes (no secrets, no private infra): local pytest uses `PYTHONPATH=src` because the workspace path contains a space
